### PR TITLE
style(import): fix import table overflowing horizontally

### DIFF
--- a/apps/bublik/src/pages/import-page/import-page.tsx
+++ b/apps/bublik/src/pages/import-page/import-page.tsx
@@ -10,8 +10,8 @@ export const ImportPage = () => {
 	useDocumentTitle('Import - Bublik');
 
 	return (
-		<div className="p-2">
-			<div className="flex flex-col h-full gap-1">
+		<div className="p-2 overflow-hidden h-full">
+			<div className="flex flex-col gap-1 h-full">
 				<ImportEventsTableContainer>
 					<ImportRunFormContainer />
 				</ImportEventsTableContainer>

--- a/libs/bublik/features/run-import/src/lib/import-events-table/__snapshots__/import-event-table.component.spec.tsx.snap
+++ b/libs/bublik/features/run-import/src/lib/import-events-table/__snapshots__/import-event-table.component.spec.tsx.snap
@@ -174,7 +174,7 @@ exports[`ImportEventTableComponent > should render successfully 1`] = `
       class="border-separate border-spacing-y-1 w-full"
     >
       <thead
-        class="bg-white"
+        class="bg-white sticky top-0 z-10"
       >
         <tr
           class="h-8.5"

--- a/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.component.tsx
+++ b/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.component.tsx
@@ -1,16 +1,16 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
 import {
-	useReactTable,
-	getCoreRowModel,
 	flexRender,
+	getCoreRowModel,
+	getFilteredRowModel,
 	getPaginationRowModel,
-	getFilteredRowModel
+	useReactTable
 } from '@tanstack/react-table';
 
 import { LogEvent } from '@/shared/types';
 import { getErrorMessage } from '@/services/bublik-api';
-import { Icon, Pagination, Skeleton, cn } from '@/shared/tailwind-ui';
+import { cn, Icon, Pagination, Skeleton } from '@/shared/tailwind-ui';
 
 import { columns } from './import-event-table.columns';
 
@@ -90,7 +90,7 @@ export const ImportEventTable = (props: ImportEventTableProps) => {
 	return (
 		<div>
 			<table className="border-separate border-spacing-y-1 w-full">
-				<thead className={cn('bg-white')}>
+				<thead className={cn('bg-white sticky top-0 z-10')}>
 					{table.getHeaderGroups().map((headerGroup) => (
 						<tr key={headerGroup.id} className="h-8.5">
 							{headerGroup.headers.map((header) => (

--- a/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.container.tsx
+++ b/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.container.tsx
@@ -75,7 +75,10 @@ export const ImportEventsTableContainer = (props: PropsWithChildren) => {
 				</div>
 			</div>
 			<div
-				className={cn('flex flex-col', isFetching && 'opacity-40 select-none')}
+				className={cn(
+					'flex flex-col overflow-auto flex-grow',
+					isFetching && 'opacity-40 select-none'
+				)}
 			>
 				{isLoading ? (
 					<ImportEventTableLoading />


### PR DESCRIPTION
Improve overflowing behaviour for import log event table so it's not overflowing main document incorrectly