### PR TITLE
Disable hoverable content for tooltips

### DIFF
--- a/libs/shared/tailwind-ui/src/lib/providers/providers.tsx
+++ b/libs/shared/tailwind-ui/src/lib/providers/providers.tsx
@@ -9,7 +9,7 @@ import { TooltipProvider } from '../tooltip';
 
 export const Providers = ({ children }: PropsWithChildren) => {
 	return (
-		<TooltipProvider>
+		<TooltipProvider disableHoverableContent={true}>
 			<ConnectionStatusProvider />
 			<SonnerToaster />
 			{children}


### PR DESCRIPTION
When hovering over button/action and quickly moving mouse to another button/action tooltip content interferes with mouse selecting and blocks clicking on button/actions. This will disable hover by default on all tooltips