### PR TITLE
refactor(history): update search parameters

### DIFF
--- a/libs/bublik/features/history/src/lib/hooks/use-history-query.ts
+++ b/libs/bublik/features/history/src/lib/hooks/use-history-query.ts
@@ -2,21 +2,19 @@
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
 import { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { camelizeKeys } from 'humps';
 
-import { HistoryAPIQuery } from '@/shared/types';
+import { HistoryAPIBackendQuery, HistoryAPIQuery } from '@/shared/types';
+import { searchQueryToBackendQuery } from '../slice/history-slice.utils';
 
 export const useHistoryQuery = () => {
 	const [searchParams] = useSearchParams();
 
-	const query = useMemo(() => {
-		const rawQuery = camelizeKeys(
-			Object.fromEntries(searchParams.entries())
+	const query = useMemo<HistoryAPIBackendQuery>(() => {
+		const rawQuery = Object.fromEntries(
+			searchParams.entries()
 		) as HistoryAPIQuery;
 
-		rawQuery.verdict = decodeURIComponent(rawQuery.verdict || '');
-
-		return rawQuery;
+		return searchQueryToBackendQuery(rawQuery);
 	}, [searchParams]);
 
 	return { query };

--- a/libs/bublik/features/history/src/lib/slice/history-slice.utils.ts
+++ b/libs/bublik/features/history/src/lib/slice/history-slice.utils.ts
@@ -7,7 +7,11 @@ import {
 	DEFAULT_HISTORY_END_DATE,
 	DEFAULT_HISTORY_START_DATE
 } from '@/bublik/config';
-import { HistoryAPIQuery, VERDICT_TYPE } from '@/shared/types';
+import {
+	HistoryAPIBackendQuery,
+	HistoryAPIQuery,
+	VERDICT_TYPE
+} from '@/shared/types';
 import { BadgeItem } from '@/shared/tailwind-ui';
 import { formatTimeToAPI } from '@/shared/utils';
 
@@ -109,6 +113,37 @@ export const historySearchStateToForm = (
 		verdict: arrayToBadgeItem(state.verdict)
 	};
 };
+
+export function searchQueryToBackendQuery(
+	query: HistoryAPIQuery
+): HistoryAPIBackendQuery {
+	return {
+		testName: query.testName,
+		hash: query.hash,
+		testArgs: query.parameters,
+		revisions: query.revisions,
+		branches: query.branches,
+		/* Run section */
+		tags: query.runData,
+		tagExpr: query.tagExpr,
+		branchExpr: query.branchExpr,
+		labelExpr: query.labelExpr,
+		testArgExpr: query.testArgExpr,
+		revExpr: query.revisionExpr,
+		verdictExpr: query.verdictExpr,
+		fromDate: query.startDate,
+		toDate: query.finishDate,
+		/* Result section */
+		resultTypes: query.resultProperties,
+		runProperties: query.runProperties,
+		resultStatuses: query.results,
+		/* Verdict section */
+		verdictLookup: query.verdictLookup,
+		verdict: query.verdict,
+		page: query.page,
+		pageSize: query.pageSize
+	};
+}
 
 export const historySearchStateToQuery = (
 	state: HistorySearchFormState

--- a/libs/services/bublik-api/src/lib/endpoints/history-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/history-endpoints.ts
@@ -3,7 +3,7 @@
 import { EndpointBuilder } from '@reduxjs/toolkit/dist/query/endpointDefinitions';
 
 import {
-	HistoryAPIQuery,
+	HistoryAPIBackendQuery,
 	HistoryDataAggregationAPIResponse,
 	HistoryLinearAPIResponse
 } from '@/shared/types';
@@ -17,7 +17,10 @@ export const historyEndpoints = {
 	endpoints: (
 		build: EndpointBuilder<BublikBaseQueryFn, BUBLIK_TAG, API_REDUCER_PATH>
 	) => ({
-		getHistoryLinear: build.query<HistoryLinearAPIResponse, HistoryAPIQuery>({
+		getHistoryLinear: build.query<
+			HistoryLinearAPIResponse,
+			HistoryAPIBackendQuery
+		>({
 			query: (query) => {
 				return { url: withApiV2('/history'), params: prepareForSend(query) };
 			},
@@ -25,7 +28,7 @@ export const historyEndpoints = {
 		}),
 		getHistoryAggregation: build.query<
 			HistoryDataAggregationAPIResponse,
-			HistoryAPIQuery
+			HistoryAPIBackendQuery
 		>({
 			query: (query) => {
 				return {

--- a/libs/shared/types/src/lib/history.ts
+++ b/libs/shared/types/src/lib/history.ts
@@ -12,6 +12,35 @@ import { Pagination } from './utils';
 /** History page mode */
 export type HistoryMode = 'linear' | 'aggregation' | 'measurements';
 
+export type HistoryAPIBackendQuery = {
+	testName?: string;
+	hash?: string;
+	testArgs?: string;
+	revisions?: string;
+	branches?: string;
+
+	fromDate?: string;
+	toDate?: string;
+	tags?: string;
+	tagExpr?: string;
+
+	labelExpr?: string;
+	revExpr?: string;
+	branchExpr?: string;
+	verdictExpr?: string;
+	testArgExpr?: string;
+
+	runProperties?: string;
+	resultTypes?: string;
+	resultStatuses?: string;
+
+	verdictLookup?: VERDICT_TYPE;
+	verdict?: string;
+
+	page?: string;
+	pageSize?: string;
+};
+
 export type HistoryAPIQuery = {
 	page?: string;
 	pageSize?: string;


### PR DESCRIPTION
Backend renamed search parameters for some fields. This will adjust frontend code to convert search params to
 backend search params for compatibility since we want to
 preserve old links working