### PR TITLE
fix(history): not displaying dates in legend

### DIFF
--- a/libs/bublik/features/history/src/lib/history-filter-legend/history-filter-legend.container.utils.ts
+++ b/libs/bublik/features/history/src/lib/history-filter-legend/history-filter-legend.container.utils.ts
@@ -8,9 +8,10 @@ import { queryToHistorySearchState } from '../slice/history-slice.utils';
 
 export const getLegendItems = (search: HistoryAPIQuery): LegendItem[] => {
 	const state = queryToHistorySearchState(search);
+
 	const formattedDate = `${formatTimeToDot(
-		search.startDate
-	)} — ${formatTimeToDot(search.finishDate)}`;
+		state.startDate.toISOString()
+	)} — ${formatTimeToDot(state.finishDate.toISOString())}`;
 
 	return [
 		{


### PR DESCRIPTION
This will fix dates failing to display in history legend This was due to missing search params for dates
Now we get it from redux store.
If no search params found default one will be used