### PR TITLE
style(log): fix horizontal page overflow

### DIFF
--- a/libs/bublik/features/log/src/lib/log-feature.tsx
+++ b/libs/bublik/features/log/src/lib/log-feature.tsx
@@ -73,7 +73,7 @@ export const LogFeature: FC<LogFeatureProps> = ({
 					<TreeContainer runId={runId} />
 				</Resizable>
 			)}
-			<div className="flex flex-col flex-grow h-full gap-1">
+			<div className="flex flex-col flex-grow h-full gap-1 overflow-hidden">
 				{children}
 				<main className="flex-grow bg-white rounded-md overflow-hidden">
 					<CardHeader label="Log">


### PR DESCRIPTION
Log container and run details sometime will overflow page horizontally this will prevent this from happening and will allow log frame to be contained by window width