### PR TITLE
fix(history): skipping fetching data on direct navigation

### DIFF
--- a/libs/bublik/features/history/src/lib/history-aggregation/history-aggregation.container.tsx
+++ b/libs/bublik/features/history/src/lib/history-aggregation/history-aggregation.container.tsx
@@ -13,17 +13,19 @@ import { useAggregationGlobalFilter } from './history-aggregation.hooks';
 import { HistoryEmpty } from '../history-empty';
 import { useHistoryActions } from '../slice';
 import { HistoryError } from '../history-error';
+import { useLocation } from 'react-router-dom';
 
 export const HistoryAggregationContainer = () => {
 	const actions = useHistoryActions();
 	const { pagination, handlePaginationChange } = useHistoryPagination();
 	const { globalFilter, handleGlobalFilterChange } =
 		useAggregationGlobalFilter();
+	const state = useLocation().state as { fromRun?: boolean };
 	const { query } = useHistoryQuery();
 
 	const { data, isLoading, isFetching, error } = useGetHistoryAggregationQuery(
 		query,
-		{ skip: !query.testName }
+		{ skip: state?.fromRun || !query.testName }
 	);
 
 	const handleOpenFormClick = useCallback(


### PR DESCRIPTION
Since user can now select default history mode
in user preferences we should treat aggregation mode like linear mode. We disable fetching until user submitted form just like in linear mode so behaviour is consistent between different modes