### PR TITLE
fix(auth): prevent app crash when showing toast message

### DIFF
--- a/apps/bublik/src/pages/auth/email-activation.page.tsx
+++ b/apps/bublik/src/pages/auth/email-activation.page.tsx
@@ -16,8 +16,8 @@ export const EmailActivationPage = () => {
 		try {
 			const inputs = VerifyEmailSchemaInputs.parse(params);
 
-			const message = await verifyEmail(inputs).unwrap();
-			toast.success(message);
+			await verifyEmail(inputs).unwrap();
+			toast.success('The email is verified. You are registered.');
 			navigate('/auth/login');
 		} catch (e) {
 			toast.error('Failed to verify email!');

--- a/libs/bublik/features/auth/src/lib/reset-password/reset-password.container.tsx
+++ b/libs/bublik/features/auth/src/lib/reset-password/reset-password.container.tsx
@@ -29,12 +29,9 @@ export const ResetPasswordFormContainer = () => {
 		try {
 			const parsedParams = ResetPasswordParamsSchema.parse(params);
 
-			const message = await resetPassword({
-				...parsedParams,
-				...form
-			}).unwrap();
+			await resetPassword({ ...parsedParams, ...form }).unwrap();
 
-			toast.success(message);
+			toast.success('A verification link has been sent to your email address');
 			navigate('/auth/login');
 		} catch (error: unknown) {
 			setErrorsOnForm(error, {

--- a/libs/services/bublik-api/src/lib/endpoints/auth-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/auth-endpoints.ts
@@ -65,7 +65,7 @@ export const authEndpoints = {
 			})
 		}),
 		resetPassword: build.mutation<
-			string,
+			{ message: string },
 			ResetPasswordParamsInputs & ResetUserPasswordFormInputs
 		>({
 			query: (form) => ({
@@ -84,7 +84,7 @@ export const authEndpoints = {
 				body: form
 			})
 		}),
-		activateEmail: build.mutation<string, VerifyEmailInputs>({
+		activateEmail: build.mutation<{ message: string }, VerifyEmailInputs>({
 			query: ({ userId, token }) => ({
 				url: `/auth/register/activate/${userId}/${token}/`,
 				method: 'GET'


### PR DESCRIPTION
Due to changes in API app crashed on some actions:
- Showing toast message for email verification
- Showing toast message for sent email to reset password Toast messages should no longer depend on API response to prevent this from happening since those message should rarely change