### PR TITLE
Enable sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"release": "release-it",
 		"nx": "nx",
 		"start": "nx serve",
-		"build": "nx build",
+		"build": "nx build --sourcemap=true",
 		"docker:build": "docker build -f apps/bublik/Dockerfile.dev . -t bublik-ui",
 		"docker:start": "docker run -it --rm -p 4200:4200 -v $(pwd):/app -v /app/node_modules --env-file apps/bublik/.env.local bublik-ui",
 		"bublik:build-all": "nx run bublik:build-all",


### PR DESCRIPTION
Add sourcemaps flag so builds include js maps
for js files to ease debuggin in deployed application