### PR TITLE
feat(measurements): add stacked chart mode

### DIFF
--- a/libs/bublik/features/log/src/lib/containers/link-to-measurements/link-to-measurements.tsx
+++ b/libs/bublik/features/log/src/lib/containers/link-to-measurements/link-to-measurements.tsx
@@ -9,6 +9,8 @@ import {
 	usePrefetchMeasurementsPage
 } from '@/services/bublik-api';
 import { ButtonTw, Icon } from '@/shared/tailwind-ui';
+import { routes } from '@/router';
+import { MeasurementsMode } from '@/shared/types';
 
 export interface LinkToMeasurementsProps {
 	focusId?: string | number | null;
@@ -27,7 +29,7 @@ export const LinkToMeasurementsContainer: FC<LinkToMeasurementsProps> = ({
 
 	usePrefetchMeasurementsPage({ resultId });
 
-	const to = `/runs/${runId}/results/${resultId}/measurements`;
+	if (!resultId || !runId) return;
 
 	return (
 		<ButtonTw
@@ -42,7 +44,13 @@ export const LinkToMeasurementsContainer: FC<LinkToMeasurementsProps> = ({
 					: 'default'
 			}
 		>
-			<Link to={to}>
+			<Link
+				to={routes.measurements({
+					resultId,
+					runId,
+					mode: MeasurementsMode.Default
+				})}
+			>
 				{isFetching ? (
 					<Icon name="ProgressIndicator" className="mr-1.5 animate-spin" />
 				) : (

--- a/libs/bublik/features/measurements/src/lib/components/mode-picker/index.tsx
+++ b/libs/bublik/features/measurements/src/lib/components/mode-picker/index.tsx
@@ -6,6 +6,7 @@ import { ModeDefault } from './mode-default';
 import { ModeCharts } from './mode-charts';
 import { ModeTables } from './mode-tables';
 import { ModeSplit } from './mode-split';
+import { ModeOverlay } from './mode-overlay';
 
 export interface ModePickerProps {
 	mode?: MeasurementsMode;
@@ -19,6 +20,8 @@ export const ModePicker = ({ mode }: ModePickerProps) => {
 			return <ModeSplit />;
 		case MeasurementsMode.Tables:
 			return <ModeTables />;
+		case MeasurementsMode.Overlay:
+			return <ModeOverlay />;
 		case MeasurementsMode.Default:
 			return <ModeDefault />;
 		default:

--- a/libs/bublik/features/measurements/src/lib/components/mode-picker/mode-overlay.tsx
+++ b/libs/bublik/features/measurements/src/lib/components/mode-picker/mode-overlay.tsx
@@ -1,0 +1,57 @@
+import { useParams } from 'react-router-dom';
+
+import { useGetSingleMeasurementQuery } from '@/services/bublik-api';
+import { MeasurementsRouterParams } from '@/shared/types';
+import { Chart } from '@/shared/charts';
+import { CardHeader, Skeleton } from '@/shared/tailwind-ui';
+
+import { MeasurementStatisticsContainer } from '../../containers';
+
+export function ModeOverlay() {
+	const { runId, resultId } = useParams<MeasurementsRouterParams>();
+
+	if (!runId || !resultId) return null;
+
+	return (
+		<div className="p-2 h-full">
+			<div className="flex flex-col gap-1 h-full">
+				<MeasurementStatisticsContainer />
+				<div className="relative transition-all bg-white rounded-md h-[120vh]">
+					<CardHeader label="Charts" />
+					<div className="h-full p-4">
+						<OverlayContainer resultId={resultId} />
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+interface OverlayContainerProps {
+	resultId: string;
+}
+
+function OverlayContainer({ resultId }: OverlayContainerProps) {
+	const { data, isLoading, error } = useGetSingleMeasurementQuery(resultId);
+
+	if (error) return <div>Error...</div>;
+
+	if (isLoading) {
+		return (
+			<div className="p-2 h-full">
+				<Skeleton className="h-full rounded-md" />
+			</div>
+		);
+	}
+
+	if (!data) return <div>No Data!</div>;
+
+	return (
+		<Chart
+			id="Combined"
+			plots={data}
+			style={{ height: '95%' }}
+			disableFullScreenToggle
+		/>
+	);
+}

--- a/libs/bublik/features/sidebar/src/lib/main-nav/main-nav.tsx
+++ b/libs/bublik/features/sidebar/src/lib/main-nav/main-nav.tsx
@@ -89,12 +89,12 @@ const mainMenu: SidebarItem[] = [
 		},
 		subitems: [
 			{
-				label: 'Charts',
+				label: 'Charts + Tables',
 				icon: <Icon name="LineChart" />,
 				to: '/runs',
 				pattern: {
 					path: '/runs/:runId/results/:resultId/measurements',
-					search: { mode: MeasurementsMode.Charts }
+					search: { mode: MeasurementsMode.Default }
 				}
 			},
 			{
@@ -104,6 +104,24 @@ const mainMenu: SidebarItem[] = [
 				pattern: {
 					path: '/runs/:runId/results/:resultId/measurements',
 					search: { mode: MeasurementsMode.Split }
+				}
+			},
+			{
+				label: 'Tables',
+				icon: <Icon name="PaperListText" />,
+				to: '/runs',
+				pattern: {
+					path: '/runs/:runId/results/:resultId/measurements',
+					search: { mode: MeasurementsMode.Tables }
+				}
+			},
+			{
+				label: 'Stacked',
+				icon: <Icon name="LineChartMultiple" />,
+				to: '/runs',
+				pattern: {
+					path: '/runs/:runId/results/:resultId/measurements',
+					search: { mode: MeasurementsMode.Overlay }
 				}
 			}
 		]

--- a/libs/bublik/router/src/lib/router.ts
+++ b/libs/bublik/router/src/lib/router.ts
@@ -43,7 +43,8 @@ export const routes = {
 	}),
 	measurements: buildRoute<MeasurementsConfig>({
 		getPathname: ({ runId, resultId }) =>
-			`/runs/${runId}/results/${resultId}/measurements`
+			`/runs/${runId}/results/${resultId}/measurements`,
+		getSearch: () => 'mode=default'
 	}),
 	runs: buildRoute<never>('/runs'),
 	flower: buildRoute('/flower'),

--- a/libs/shared/types/src/lib/measurements.ts
+++ b/libs/shared/types/src/lib/measurements.ts
@@ -10,7 +10,8 @@ export const enum MeasurementsMode {
 	Default = 'default',
 	Charts = 'charts',
 	Tables = 'tables',
-	Split = 'split'
+	Split = 'split',
+	Overlay = 'overlay'
 }
 
 export type MeasurementsRouterParams = {


### PR DESCRIPTION
Added stacked chart mode (the same as in history)
All links to measurements should now include mode
to properly display selected mode in sidebar