### PR TITLE
fix(run,log): fix text overflow in new bug preview modal

### DIFF
--- a/libs/shared/tailwind-ui/src/lib/new-bug/new-bug.component.tsx
+++ b/libs/shared/tailwind-ui/src/lib/new-bug/new-bug.component.tsx
@@ -193,7 +193,7 @@ function NewBugButton(props: NewBugButtonProps) {
 			<DialogOverlay className={dialogOverlayStyles()} />
 			<DialogContent
 				className={cn(
-					'p-4 bg-white rounded-xl shadow-popover min-w-[40vw] overflow-auto',
+					'p-4 bg-white rounded-xl shadow-popover min-w-[40vw] overflow-auto max-w-[80vw]',
 					dialogContentStyles()
 				)}
 			>
@@ -203,7 +203,7 @@ function NewBugButton(props: NewBugButtonProps) {
 					</h2>
 					<pre
 						className={cn(
-							'transition-all border border-border-primary rounded-md hover:border-primary',
+							'transition-all border border-border-primary rounded-md hover:border-primary whitespace-break-spaces overflow-wrap-anywhere',
 							'text-xs p-2'
 						)}
 					>


### PR DESCRIPTION
Some links are too long to fit inside modal. 
Example `Name: [dpdk-ethdev-ts](http://localhost:4200/prefix/v2/runs/1?expanded=%7B%220%22%3Atrue%2C%220.0%22%3Atrue%2C%220.3%22%3Atrue%2C%220.2%22%3Atrue%2C%220.1%22%3Atrue%7D)`

This will allow text to wrap