### PR TITLE
Report axis labels

### DIFF
--- a/libs/bublik/features/run-report/src/lib/run-report-chart/run-report-chart.component.tsx
+++ b/libs/bublik/features/run-report/src/lib/run-report-chart/run-report-chart.component.tsx
@@ -37,7 +37,7 @@ function RunReportChart(props: RunReportChartProps) {
 	);
 
 	return (
-		<div className="w-full">
+		<div className="w-full flex flex-col gap-2">
 			<Plot
 				options={{
 					legend: enableLegend ? {} : undefined,
@@ -58,6 +58,16 @@ function RunReportChart(props: RunReportChartProps) {
 					series: series
 				}}
 			/>
+			<div className="flex items-center justify-center gap-2">
+				<div className="flex items-start flex-col gap-2">
+					<span className="text-text-secondary text-sm font-semibold">
+						Axis X: {xAxisLabel}
+					</span>
+					<span className="text-text-secondary text-sm font-semibold">
+						Axis Y: {yAxisLabel}
+					</span>
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/libs/bublik/features/run-report/src/lib/run-report-test/run-report-test.component.tsx
+++ b/libs/bublik/features/run-report/src/lib/run-report-test/run-report-test.component.tsx
@@ -193,7 +193,7 @@ function MeasurementBlock(props: RunReportEntityBlockProps) {
 
 	return (
 		<div className="flex flex-col pl-1">
-			<div className="flex flex-col max-h-96" id={encodeURIComponent(id)}>
+			<div className="flex flex-col max-h-[412px]" id={encodeURIComponent(id)}>
 				{/* LEVEL 4 */}
 				{multiple_sequences ? (
 					<CardHeader

--- a/libs/bublik/features/run-report/src/lib/run-report-test/run-report-test.component.tsx
+++ b/libs/bublik/features/run-report/src/lib/run-report-test/run-report-test.component.tsx
@@ -20,7 +20,6 @@ import {
 import { RunReportChart } from '../run-report-chart';
 import { RunReportTable } from '../run-report-table';
 import { RunReportArgs } from '../run-report.component';
-import { useIsSticky } from '@/shared/hooks';
 
 interface RunReportTestBlockProps {
 	enableChartView: boolean;


### PR DESCRIPTION
This pull request introduces improvements to the report page.

Key changes:
- Added a new section to display X and Y axis labels below the chart
- Increased the max height of the measurement block from 384px to 412px for better content display

![labels](https://github.com/user-attachments/assets/981a3d1e-a501-4ee1-b30e-e80aa74b960d)
