### PR TITLE
ci(types): added check that code is buildable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,20 @@ jobs:
         run: pnpm install
       - name: Check code formatting
         run: pnpm run format:check
+  check-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Check code is buildable
+        run: pnpm run build


### PR DESCRIPTION
This will just try to build frontend in process checking types It's a bit hard to add typecheck command since NX doesn't have built in one