### PR TITLE
Release 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 
 
+### [1.0.3](https://github.com/ts-factory/bublik-ui/compare/v1.0.2...v1.0.3) (2025-01-12)
+
+
+### 🐛 Bug Fix
+
+* **log:** don't use custom redirect for JSON logs in development ([7dc8e58](https://github.com/ts-factory/bublik-ui/commit/7dc8e58d755d9e493eae4883d79a926da83df838))
+
 ### [1.0.2](https://github.com/ts-factory/bublik-ui/compare/v1.0.1...v1.0.2) (2024-12-24)
 
 

--- a/libs/bublik/features/deploy-info/src/lib/changelog.mdx
+++ b/libs/bublik/features/deploy-info/src/lib/changelog.mdx
@@ -1,5 +1,12 @@
 # Changelog
 
+### [1.0.3](https://github.com/ts-factory/bublik-ui/compare/v1.0.2...v1.0.3) (2025-01-12)
+
+
+### 🐛 Bug Fix
+
+* **log:** don't use custom redirect for JSON logs in development ([7dc8e58](https://github.com/ts-factory/bublik-ui/commit/7dc8e58d755d9e493eae4883d79a926da83df838))
+
 ### [1.0.2](https://github.com/ts-factory/bublik-ui/compare/v1.0.1...v1.0.2) (2024-12-24)
 
 

--- a/libs/bublik/features/deploy-info/src/lib/git-info.json
+++ b/libs/bublik/features/deploy-info/src/lib/git-info.json
@@ -1,7 +1,7 @@
 {
-	"date": "2024.12.24",
-	"summary": "fix(config): replace `.toSorted` with `.sort` for broader browser compatibility",
-	"revision": "eb969b71",
-	"branch": "release-v1.0.2",
-	"latestTag": "v1.0.2"
+	"date": "2025.01.13",
+	"summary": "fix(log): don't use custom redirect for JSON logs in development",
+	"revision": "7dc8e58d",
+	"branch": "release-1.0.3",
+	"latestTag": "v1.0.3"
 }

--- a/libs/services/bublik-api/src/lib/endpoints/log-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/log-endpoints.ts
@@ -10,7 +10,6 @@ import {
 	RootBlock,
 	TreeDataAPIResponse
 } from '@/shared/types';
-import { config } from '@/bublik/config';
 
 import { transformLogTree } from '../transform';
 import { BUBLIK_TAG } from '../types';
@@ -66,9 +65,7 @@ export const logEndpoints = {
 
 					const options: RequestInit = { credentials: 'include' };
 
-					const response = config.isDev
-						? await fetch(`${config.rootUrl}/external?url=${externalUrl}`)
-						: await fetch(externalUrl, options);
+					const response = await fetch(externalUrl, options);
 
 					if (!response.ok) throw getBublikFromStatusCode(response);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bublik-ui",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"license": "Apache-2.0",
 	"scripts": {
 		"preinstall": "npx only-allow pnpm",


### PR DESCRIPTION
Small incremental release with changes for development mode:
We should not use vite dev server as a proxy for JSON logs. 
We should let backend handle it so it unifies all of the configuration related to development and production

This doesn't change anything for production usage. Just delegates logic to backend:
1. In development backend should act as a proxy for JSON logs so we don't hit CORS issues
2. In production it should just return raw url for JSON logs