### PR TITLE
fix(build): add `.nx` folder to `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,5 @@ docker-compose*
 README.md
 LICENSE
 .vscode
+.nx
+dist


### PR DESCRIPTION
We should ignore `.nx` folder to prevent it copying to image 
`.nx` mainly contains cache files that we don't need inside image