### PR TITLE
fix(log): don't use custom redirect for JSON logs in development

### DIFF
--- a/libs/services/bublik-api/src/lib/endpoints/log-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/log-endpoints.ts
@@ -10,7 +10,6 @@ import {
 	RootBlock,
 	TreeDataAPIResponse
 } from '@/shared/types';
-import { config } from '@/bublik/config';
 
 import { transformLogTree } from '../transform';
 import { BUBLIK_TAG } from '../types';
@@ -66,9 +65,7 @@ export const logEndpoints = {
 
 					const options: RequestInit = { credentials: 'include' };
 
-					const response = config.isDev
-						? await fetch(`${config.rootUrl}/external?url=${externalUrl}`)
-						: await fetch(externalUrl, options);
+					const response = await fetch(externalUrl, options);
 
 					if (!response.ok) throw getBublikFromStatusCode(response);
 


### PR DESCRIPTION
We should always use whatever location backend returns When developing locally and trying to fetch JSON logs Backend should proxy request to JSON so we don't hit CORS errors due do different domains