### PR TITLE
fix(history): [linear] resetting filters on "Preview" button click

### DIFF
--- a/libs/bublik/features/history/src/lib/history-linear/column-components/links/links.tsx
+++ b/libs/bublik/features/history/src/lib/history-linear/column-components/links/links.tsx
@@ -99,18 +99,12 @@ export const Links = ({ row }: LinksProps) => {
 				measurementId={row.has_measurements ? Number(row.result_id) : undefined}
 			>
 				<ButtonTw
-					asChild
 					size="xss"
 					variant="secondary"
 					className="justify-start w-fit"
 				>
-					<Link
-						className="justify-start w-fit"
-						to={{ pathname: '/history', search: shortcuts.historyQuery }}
-					>
-						<Icon name="ExpandSelection" className="mr-1.5" size={20} />
-						Preview
-					</Link>
+					<Icon name="ExpandSelection" className="mr-1.5" size={20} />
+					<span>Preview</span>
 				</ButtonTw>
 			</LogPreviewContainer>
 		</div>


### PR DESCRIPTION
Incorrectly using link instead of just button for preview log on the history linear page. This caused search filters to be incorrectly applied instead of just opening log preview