### PR TITLE
Remove run selection limit for viewing merged runs

### DIFF
--- a/libs/bublik/features/runs/src/lib/runs-table/runs-table.component.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-table/runs-table.component.tsx
@@ -85,7 +85,7 @@ const getRowProps: (
 	removeSelection: RunsTableProps['removeSelection']
 ) => TwTableProps<RunsData>['getRowProps'] =
 	(selection, addSelection, removeSelection) => (table, row) => {
-		const MAX_SELECTION_NUMBER = 5;
+		const MAX_SELECTION_NUMBER = 9999;
 		const className = row.getIsSelected()
 			? 'bg-primary-wash border-primary'
 			: '';

--- a/libs/bublik/features/runs/src/lib/selection-popover/selection-popover.component.tsx
+++ b/libs/bublik/features/runs/src/lib/selection-popover/selection-popover.component.tsx
@@ -40,10 +40,10 @@ export const SelectionPopover: FC<SelectionPopoverComponentProps> = (props) => {
 					animate="visible"
 					exit="exit"
 					transition={transition}
-					className="fixed bottom-4 right-4 bg-white rounded-lg shadow-popover min-w-[360px]"
+					className="fixed bottom-4 right-4 bg-white rounded-lg shadow-popover min-w-[360px] max-h-[90vh] flex flex-col"
 					layout="size"
 				>
-					<div className="flex flex-col gap-2 px-4 pt-2">
+					<div className="flex flex-col gap-2 px-4 pt-2 flex-1 overflow-auto">
 						<SelectedResultList
 							label="Selection"
 							ids={compareIds}


### PR DESCRIPTION
When selecting runs on the runs page for viewing merged run stats we have limit of 5.
Now users can select more than 5 with no up limit at all