### PR TITLE
Add scroll to top when changing page or page size

### DIFF
--- a/libs/bublik/features/runs/src/lib/hooks.ts
+++ b/libs/bublik/features/runs/src/lib/hooks.ts
@@ -64,6 +64,10 @@ export const useRunsPagination = () => {
 
 				setSearchParams(newSearchParams);
 			}
+
+			document
+				.getElementById('page-container')
+				?.scrollTo({ top: 0, behavior: 'smooth' });
 		},
 		[pagination, searchParams, setSearchParams]
 	);


### PR DESCRIPTION
Scroll to top of the page when user goes to new page or selects new page size just like on the history page