### PR TITLE
Remove auto sort for run page

### DIFF
--- a/libs/bublik/features/run/src/lib/run-table/hooks/index.ts
+++ b/libs/bublik/features/run/src/lib/run-table/hooks/index.ts
@@ -9,7 +9,6 @@ import {
 	getExpandedUnexpectedState,
 	getRowValues,
 	getUnexpectedGlobalFilter,
-	globalFilterToSort,
 	toggleSubtree,
 	getRootRowId,
 	getPackageIdsWithUnexpected,
@@ -29,7 +28,6 @@ export const useExpandUnexpected = (config: UseExpandUnexpectedConfig) => {
 
 	const rootRowValues = getRowValues(rowModel.rowsById[rootRowId]);
 	const globalFilter = getUnexpectedGlobalFilter(rootRowValues, rootRowId);
-	const sortingState = globalFilter.map(globalFilterToSort);
 	const { expandAllUnexpected, resetRowState } = useRunTableRowState();
 
 	const expandUnexpected = useCallback(() => {
@@ -54,9 +52,8 @@ export const useExpandUnexpected = (config: UseExpandUnexpectedConfig) => {
 		table.setGlobalFilter(globalFilter);
 		table.setExpanded(toggleSubtree(true, packageIdsWithUnexpected));
 		table.setExpanded(toggleSubtree(false, allTestIds));
-		table.setSorting(sortingState);
 		resetRowState();
-	}, [globalFilter, resetRowState, sortingState, table]);
+	}, [globalFilter, resetRowState, table]);
 
 	const reset = useCallback(() => {
 		table.setGlobalFilter([]);


### PR DESCRIPTION
Remove auto sort when going to `/run/<run_id>` page when navigating from runs or dashboard page before we sorted in descending order as well as when clicking on "Preview NOK"