### PR TITLE
fix(ci): ignore `.pnpm-store` while checking formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,4 @@ pnpm-lock.yaml
 *.mdx
 .idea
 .vscode
+.pnpm-store


### PR DESCRIPTION
This prevents false errors when testing workflows locally with `act` tool