### PR TITLE
Add selection popover for charts on result(measurement) page

### DIFF
--- a/libs/bublik/features/history/src/lib/history-measurements/plot-list.component.tsx
+++ b/libs/bublik/features/history/src/lib/history-measurements/plot-list.component.tsx
@@ -1,31 +1,28 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { useMemo, useState } from 'react';
-import { Link, To, useSearchParams } from 'react-router-dom';
-import { AnimatePresence, motion, Transition, Variants } from 'framer-motion';
+import { useState } from 'react';
 
 import { Point } from '@/shared/types';
 import {
-	ButtonTw,
 	CardHeader,
 	cn,
 	Icon,
 	Skeleton,
 	ToolbarButton,
-	Tooltip,
 	useSidebar
 } from '@/shared/tailwind-ui';
 import {
 	ExportChart,
-	getChartName,
 	getColorByIdx,
-	MeasurementChart
+	isDisabledForCombined,
+	MeasurementChart,
+	SelectedChartsPopover
 } from '@/shared/charts';
 import { SingleMeasurementChart } from '@/services/bublik-api';
 import { LogPreviewContainer } from '@/bublik/features/log-preview-drawer';
 
 import { useCombinedView } from './plot-list.hooks';
-import { isDisabledForCombined, resolvePoint } from './plot-list.utils';
+import { resolvePoint } from './plot-list.utils';
 
 interface PlotListItemProps {
 	idx: number;
@@ -116,7 +113,8 @@ export function PlotList({ plots, isFetching }: PlotListProps) {
 		handleAddChartClick,
 		handleRemoveClick,
 		handleResetButtonClick,
-		selectedCharts
+		selectedCharts,
+		handleOpenButtonClick
 	} = useCombinedView();
 
 	return (
@@ -166,109 +164,14 @@ export function PlotList({ plots, isFetching }: PlotListProps) {
 					);
 				})}
 			</ul>
-			<PlotStackedForm
+			<SelectedChartsPopover
 				open={!!selectedCharts.length}
 				label="Combined"
 				plots={selectedCharts}
 				onResetButtonClick={handleResetButtonClick}
 				onRemoveClick={handleRemoveClick}
+				onOpenButtonClick={handleOpenButtonClick}
 			/>
 		</div>
 	);
 }
-
-const variants: Variants = {
-	visible: { opacity: 1, y: '0%' },
-	hidden: { opacity: 0, y: '100%' },
-	exit: { opacity: 0, y: '100%' }
-};
-
-const transition: Transition = { bounce: 0.1 };
-
-export interface PlotStackedFormProps {
-	label: string;
-	open: boolean;
-	plots: { plot: SingleMeasurementChart; color: string }[];
-	onResetButtonClick?: () => void;
-	onRemoveClick?: (plot: SingleMeasurementChart) => void;
-}
-
-const PlotStackedForm = (props: PlotStackedFormProps) => {
-	const [searchParams] = useSearchParams();
-
-	const linkToCombined = useMemo<To>(() => {
-		const params = new URLSearchParams(searchParams);
-
-		params.set('mode', 'measurements-combined');
-		params.set('combinedPlots', props.plots.map((p) => p.plot.id).join(';'));
-
-		return { pathname: '/history', search: params.toString() };
-	}, [props.plots, searchParams]);
-
-	return (
-		<AnimatePresence>
-			{props.open ? (
-				<motion.div
-					variants={variants}
-					initial="hidden"
-					animate="visible"
-					exit="exit"
-					transition={transition}
-					className="fixed bottom-4 right-4 bg-white rounded-lg shadow-popover min-w-[360px] px-4 py-2"
-				>
-					<h1 className="text-[0.875rem] leading-[1.125rem] font-semibold mb-2">
-						{props.label}
-					</h1>
-					<ul className="flex flex-col gap-2 mb-4">
-						{props.plots.map(({ plot }) => {
-							return (
-								<li
-									key={plot.id}
-									className="flex items-center justify-between p-2 border rounded border-border-primary hover:bg-gray-50"
-								>
-									<div>
-										<span className="text-[0.6875rem] font-medium leading-[0.875rem]">
-											{getChartName(plot)}
-										</span>
-									</div>
-									<Tooltip
-										content="Remove from combined chart"
-										disableHoverableContent
-									>
-										<button
-											aria-label="Remove from compare"
-											className="grid transition-colors rounded place-items-center text-text-unexpected hover:bg-red-100"
-											onClick={() => props.onRemoveClick?.(plot)}
-										>
-											<Icon name="CrossSimple" />
-										</button>
-									</Tooltip>
-								</li>
-							);
-						})}
-					</ul>
-					<div className="flex items-center gap-2">
-						<ButtonTw
-							variant="primary"
-							size="md"
-							rounded="lg"
-							className="flex-1"
-							asChild
-						>
-							<Link to={linkToCombined}>Open</Link>
-						</ButtonTw>
-						<ButtonTw
-							variant="outline"
-							size="md"
-							rounded="lg"
-							className="flex-1"
-							onClick={props.onResetButtonClick}
-						>
-							Reset
-						</ButtonTw>
-					</div>
-				</motion.div>
-			) : null}
-		</AnimatePresence>
-	);
-};

--- a/libs/bublik/features/history/src/lib/history-measurements/plot-list.hooks.ts
+++ b/libs/bublik/features/history/src/lib/history-measurements/plot-list.hooks.ts
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { To, useNavigate, useSearchParams } from 'react-router-dom';
 import { skipToken } from '@reduxjs/toolkit/query';
 
 import {
@@ -50,9 +51,11 @@ export const useGetHistoryMeasurements = () => {
 };
 
 export const useCombinedView = () => {
+	const [searchParams] = useSearchParams();
 	const [selectedCharts, setSelectedCharts] = useState<
 		{ plot: SingleMeasurementChart; color: string }[]
 	>([]);
+	const navigate = useNavigate();
 
 	const handleAddChartClick = (args: {
 		plot: SingleMeasurementChart;
@@ -77,11 +80,25 @@ export const useCombinedView = () => {
 		setSelectedCharts(selectedCharts.filter(({ plot: p }) => p.id !== plot.id));
 	};
 
+	const linkToCombined = useMemo<To>(() => {
+		const params = new URLSearchParams(searchParams);
+
+		params.set('mode', 'measurements-combined');
+		params.set('combinedPlots', selectedCharts.map((p) => p.plot.id).join(';'));
+
+		return { pathname: '/history', search: params.toString() };
+	}, [selectedCharts, searchParams]);
+
+	const handleOpenButtonClick = () => {
+		navigate(linkToCombined);
+	};
+
 	return {
 		handleAddChartClick,
 		handleRemoveClick,
 		handleResetButtonClick,
-		selectedCharts
+		selectedCharts,
+		handleOpenButtonClick
 	};
 };
 

--- a/libs/bublik/features/history/src/lib/history-measurements/plot-list.utils.ts
+++ b/libs/bublik/features/history/src/lib/history-measurements/plot-list.utils.ts
@@ -4,30 +4,6 @@ import { SingleMeasurementChart } from '@/services/bublik-api';
 import { PointSchema } from '@/shared/types';
 import { Point } from '@/shared/types';
 
-function isDisabledForCombined(
-	plot: SingleMeasurementChart,
-	selectedPlots: SingleMeasurementChart[]
-): boolean {
-	if (!selectedPlots.length) return false;
-
-	// Get x-axis values from dataset for current plot
-	const axisX = plot.dataset.slice(1).map((row) => {
-		const xIndex = plot.dataset[0].indexOf(plot.axis_x.key);
-		return row[xIndex];
-	});
-
-	// Get x-axis values from dataset for first selected plot
-	const selectedAxisX = selectedPlots[0].dataset.slice(1).map((row) => {
-		const xIndex = selectedPlots[0].dataset[0].indexOf(
-			selectedPlots[0].axis_x.key
-		);
-		return row[xIndex];
-	});
-
-	// Compare x-axis values to ensure they match
-	return !axisX.every((v, idx) => selectedAxisX[idx] === v);
-}
-
 function resolvePoint(
 	plot: SingleMeasurementChart,
 	dataIndex: number
@@ -52,4 +28,4 @@ function resolvePoint(
 	return result.data;
 }
 
-export { isDisabledForCombined, resolvePoint };
+export { resolvePoint };

--- a/libs/bublik/features/measurements/src/lib/components/mode-picker/index.tsx
+++ b/libs/bublik/features/measurements/src/lib/components/mode-picker/index.tsx
@@ -1,30 +1,66 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { MeasurementsMode } from '@/shared/types';
+import { MeasurementsMode, MeasurementsRouterParams } from '@/shared/types';
 
 import { ModeDefault } from './mode-default';
 import { ModeCharts } from './mode-charts';
 import { ModeTables } from './mode-tables';
 import { ModeSplit } from './mode-split';
 import { ModeOverlay } from './mode-overlay';
+import { useResultSelectCharts } from '../../hooks';
+import {
+	SingleMeasurementChart,
+	useGetSingleMeasurementQuery
+} from '@/services/bublik-api';
+import { getColorByIdx, SelectedChartsPopover } from '@/shared/charts';
+import { useNavigate, useParams } from 'react-router';
+import { skipToken } from '@reduxjs/toolkit/query';
+import { useSearchParams } from 'react-router-dom';
+
+const modeMap = {
+	[MeasurementsMode.Charts]: ModeCharts,
+	[MeasurementsMode.Split]: ModeSplit,
+	[MeasurementsMode.Tables]: ModeTables,
+	[MeasurementsMode.Overlay]: ModeOverlay,
+	[MeasurementsMode.Default]: ModeDefault
+};
 
 export interface ModePickerProps {
 	mode?: MeasurementsMode;
 }
 
 export const ModePicker = ({ mode }: ModePickerProps) => {
-	switch (mode) {
-		case MeasurementsMode.Charts:
-			return <ModeCharts />;
-		case MeasurementsMode.Split:
-			return <ModeSplit />;
-		case MeasurementsMode.Tables:
-			return <ModeTables />;
-		case MeasurementsMode.Overlay:
-			return <ModeOverlay />;
-		case MeasurementsMode.Default:
-			return <ModeDefault />;
-		default:
-			return <ModeDefault />;
-	}
+	const Component = modeMap[mode ?? MeasurementsMode.Default];
+
+	return (
+		<>
+			<Component />
+			<SelectedChartsContainer />
+		</>
+	);
 };
+
+function SelectedChartsContainer() {
+	const { resultId } = useParams<MeasurementsRouterParams>();
+	const { selectedCharts, resetCharts, removeChart, handleOpenButtonClick } =
+		useResultSelectCharts();
+	const { data } = useGetSingleMeasurementQuery(resultId ?? skipToken);
+
+	return (
+		<SelectedChartsPopover
+			open={!!selectedCharts.length}
+			label="Combined"
+			plots={
+				data?.charts
+					?.filter((chart) => selectedCharts.includes(chart.id))
+					?.map((chart, idx) => ({
+						plot: chart,
+						color: getColorByIdx(idx)
+					})) ?? []
+			}
+			onResetButtonClick={resetCharts}
+			onRemoveClick={(plot) => removeChart(plot.id)}
+			onOpenButtonClick={handleOpenButtonClick}
+		/>
+	);
+}

--- a/libs/bublik/features/measurements/src/lib/components/mode-picker/mode-overlay.tsx
+++ b/libs/bublik/features/measurements/src/lib/components/mode-picker/mode-overlay.tsx
@@ -6,6 +6,8 @@ import { CardHeader, Skeleton } from '@/shared/tailwind-ui';
 import { StackedMeasurementChart } from '@/shared/charts';
 
 import { MeasurementStatisticsContainer } from '../../containers';
+import { useResultSelectCharts } from '../../hooks';
+import { useMemo } from 'react';
 
 function ModeOverlay() {
 	const { runId, resultId } = useParams<MeasurementsRouterParams>();
@@ -33,6 +35,12 @@ interface OverlayContainerProps {
 
 function OverlayContainer({ resultId }: OverlayContainerProps) {
 	const { data, isLoading, error } = useGetSingleMeasurementQuery(resultId);
+	const { selectedCharts } = useResultSelectCharts();
+
+	const charts = useMemo(() => {
+		if (!selectedCharts.length) return data?.charts;
+		return data?.charts?.filter((chart) => selectedCharts.includes(chart.id));
+	}, [data?.charts, selectedCharts]);
 
 	if (error) return <div>Error...</div>;
 
@@ -44,11 +52,9 @@ function OverlayContainer({ resultId }: OverlayContainerProps) {
 		);
 	}
 
-	if (!data || !data.charts.length) return <div>No Data!</div>;
+	if (!data || !charts?.length) return <div>No Data!</div>;
 
-	return (
-		<StackedMeasurementChart charts={data.charts} style={{ height: '100%' }} />
-	);
+	return <StackedMeasurementChart charts={charts} style={{ height: '100%' }} />;
 }
 
 export { ModeOverlay };

--- a/libs/bublik/features/measurements/src/lib/containers/charts/charts.container.tsx
+++ b/libs/bublik/features/measurements/src/lib/containers/charts/charts.container.tsx
@@ -4,12 +4,20 @@ import { FC } from 'react';
 
 import {
 	getErrorMessage,
+	SingleMeasurementChart,
 	useGetSingleMeasurementQuery
 } from '@/services/bublik-api';
 import { getColorByIdx } from '@/shared/charts';
-import { Skeleton, Icon, cn, useSidebar } from '@/shared/tailwind-ui';
-
+import {
+	Skeleton,
+	Icon,
+	cn,
+	useSidebar,
+	ToolbarButton
+} from '@/shared/tailwind-ui';
 import { MeasurementChart } from '@/shared/charts';
+
+import { useResultSelectCharts } from '../../hooks';
 
 export const ChartsEmpty = () => <div>Chart is empty</div>;
 
@@ -68,6 +76,7 @@ export function ChartsContainer(props: ChartsProps) {
 	const { resultId, layout } = props;
 	const { isSidebarOpen } = useSidebar();
 	const { data, isLoading, error } = useGetSingleMeasurementQuery(resultId);
+	const { selectedCharts, handleChartClick } = useResultSelectCharts();
 
 	if (isLoading) return <ChartsLoading layout={layout} />;
 
@@ -86,12 +95,23 @@ export function ChartsContainer(props: ChartsProps) {
 				)}
 			>
 				{data.charts.map((plot, idx) => {
+					const state = selectedCharts.includes(plot.id) ? 'active' : 'default';
+
 					return (
 						<div className="py-2.5 px-4" key={plot.id}>
 							<MeasurementChart
 								key={plot.id}
 								chart={plot}
 								color={getColorByIdx(idx)}
+								additionalToolBarItems={
+									<ToolbarButton
+										aria-label="Add to combined chart"
+										state={state}
+										onClick={() => handleChartClick(plot)}
+									>
+										<Icon name="AddSymbol" className="size-5" />
+									</ToolbarButton>
+								}
 							/>
 						</div>
 					);
@@ -103,12 +123,23 @@ export function ChartsContainer(props: ChartsProps) {
 	return (
 		<div className="flex flex-col children-but-last:border-b children-but-last:border-b-border-primary">
 			{data.charts.map((plot, idx) => {
+				const state = selectedCharts.includes(plot.id) ? 'active' : 'default';
+
 				return (
 					<div className="py-2.5 px-4" key={plot.id}>
 						<MeasurementChart
 							key={plot.id}
 							chart={plot}
 							color={getColorByIdx(idx)}
+							additionalToolBarItems={
+								<ToolbarButton
+									aria-label="Add to combined chart"
+									state={state}
+									onClick={() => handleChartClick(plot)}
+								>
+									<Icon name="AddSymbol" className="size-5" />
+								</ToolbarButton>
+							}
 						/>
 					</div>
 				);

--- a/libs/bublik/features/measurements/src/lib/hooks/index.ts
+++ b/libs/bublik/features/measurements/src/lib/hooks/index.ts
@@ -1,0 +1,58 @@
+import { useNavigate } from 'react-router';
+import { useSearchParams } from 'react-router-dom';
+import {
+	useQueryParam,
+	NumericArrayParam,
+	withDefault
+} from 'use-query-params';
+
+import { SingleMeasurementChart } from '@/services/bublik-api';
+import { MeasurementsMode } from '@/shared/types';
+
+const SELECTED_CHARTS_KEY = 'selectedCharts';
+
+function useResultSelectCharts() {
+	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
+	const [selectedCharts = [], setSelectedCharts] = useQueryParam(
+		SELECTED_CHARTS_KEY,
+		withDefault(NumericArrayParam, [])
+	);
+
+	const handleOpenButtonClick = () => {
+		const nextParams = new URLSearchParams(searchParams);
+		nextParams.set('mode', MeasurementsMode.Overlay);
+		navigate({ search: nextParams.toString() });
+	};
+
+	function addChart(chartId: number) {
+		setSelectedCharts((prev) => [...(prev || []), chartId]);
+	}
+
+	function removeChart(chartId: number) {
+		setSelectedCharts((prev) => (prev || []).filter((id) => id !== chartId));
+	}
+
+	function resetCharts() {
+		setSelectedCharts([]);
+	}
+
+	function handleChartClick(plot: SingleMeasurementChart) {
+		if (selectedCharts.includes(plot.id)) {
+			removeChart(plot.id);
+		} else {
+			addChart(plot.id);
+		}
+	}
+
+	return {
+		selectedCharts,
+		addChart,
+		removeChart,
+		resetCharts,
+		handleChartClick,
+		handleOpenButtonClick
+	};
+}
+
+export { useResultSelectCharts };

--- a/libs/shared/charts/src/index.ts
+++ b/libs/shared/charts/src/index.ts
@@ -16,3 +16,4 @@ export * from './lib/pie-chart';
 export * from './lib/bar-chart';
 export * from './lib/line-chart';
 export * from './lib/single-measurement-chart';
+export * from './lib/selected-charts';

--- a/libs/shared/charts/src/lib/selected-charts/index.ts
+++ b/libs/shared/charts/src/lib/selected-charts/index.ts
@@ -1,0 +1,1 @@
+export * from './selected-charts.component';

--- a/libs/shared/charts/src/lib/selected-charts/selected-charts.component.tsx
+++ b/libs/shared/charts/src/lib/selected-charts/selected-charts.component.tsx
@@ -1,0 +1,97 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import { useMemo } from 'react';
+import { Link, To, useSearchParams } from 'react-router-dom';
+import { AnimatePresence, motion, Transition, Variants } from 'framer-motion';
+
+import { ButtonTw, Icon, Tooltip } from '@/shared/tailwind-ui';
+import { SingleMeasurementChart } from '@/services/bublik-api';
+import { getChartName } from '../utils';
+
+const variants: Variants = {
+	visible: { opacity: 1, y: '0%' },
+	hidden: { opacity: 0, y: '100%' },
+	exit: { opacity: 0, y: '100%' }
+};
+
+const transition: Transition = { bounce: 0.1 };
+
+interface SelectedChartsPopoverProps {
+	label: string;
+	open: boolean;
+	plots: { plot: SingleMeasurementChart; color: string }[];
+	onResetButtonClick?: () => void;
+	onRemoveClick?: (plot: SingleMeasurementChart) => void;
+	onOpenButtonClick?: () => void;
+}
+
+function SelectedChartsPopover(props: SelectedChartsPopoverProps) {
+	return (
+		<AnimatePresence>
+			{props.open ? (
+				<motion.div
+					variants={variants}
+					initial="hidden"
+					animate="visible"
+					exit="exit"
+					transition={transition}
+					className="fixed bottom-4 right-4 bg-white rounded-lg shadow-popover min-w-[360px] px-4 py-2"
+				>
+					<h1 className="text-[0.875rem] leading-[1.125rem] font-semibold mb-2">
+						{props.label}
+					</h1>
+					<ul className="flex flex-col gap-2 mb-4">
+						{props.plots.map(({ plot }) => {
+							return (
+								<li
+									key={plot.id}
+									className="flex items-center justify-between p-2 border rounded border-border-primary hover:bg-gray-50"
+								>
+									<div>
+										<span className="text-[0.6875rem] font-medium leading-[0.875rem]">
+											{getChartName(plot)}
+										</span>
+									</div>
+									<Tooltip
+										content="Remove from combined chart"
+										disableHoverableContent
+									>
+										<button
+											aria-label="Remove from compare"
+											className="grid transition-colors rounded place-items-center text-text-unexpected hover:bg-red-100"
+											onClick={() => props.onRemoveClick?.(plot)}
+										>
+											<Icon name="CrossSimple" />
+										</button>
+									</Tooltip>
+								</li>
+							);
+						})}
+					</ul>
+					<div className="flex items-center gap-2">
+						<ButtonTw
+							variant="primary"
+							size="md"
+							rounded="lg"
+							className="flex-1"
+							onClick={props.onOpenButtonClick}
+						>
+							Open
+						</ButtonTw>
+						<ButtonTw
+							variant="outline"
+							size="md"
+							rounded="lg"
+							className="flex-1"
+							onClick={props.onResetButtonClick}
+						>
+							Reset
+						</ButtonTw>
+					</div>
+				</motion.div>
+			) : null}
+		</AnimatePresence>
+	);
+}
+
+export { SelectedChartsPopover };

--- a/libs/shared/charts/src/lib/utils/index.ts
+++ b/libs/shared/charts/src/lib/utils/index.ts
@@ -1,5 +1,32 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import { SingleMeasurementChart } from '@/services/bublik-api';
+
+function isDisabledForCombined(
+	plot: SingleMeasurementChart,
+	selectedPlots: SingleMeasurementChart[]
+): boolean {
+	if (!selectedPlots.length) return false;
+
+	// Get x-axis values from dataset for current plot
+	const axisX = plot.dataset.slice(1).map((row) => {
+		const xIndex = plot.dataset[0].indexOf(plot.axis_x.key);
+		return row[xIndex];
+	});
+
+	// Get x-axis values from dataset for first selected plot
+	const selectedAxisX = selectedPlots[0].dataset.slice(1).map((row) => {
+		const xIndex = selectedPlots[0].dataset[0].indexOf(
+			selectedPlots[0].axis_x.key
+		);
+		return row[xIndex];
+	});
+
+	// Compare x-axis values to ensure they match
+	return !axisX.every((v, idx) => selectedAxisX[idx] === v);
+}
+
+export { isDisabledForCombined };
 export * from './actions';
 export * from './table-utils';
 export * from './export';


### PR DESCRIPTION
Make behavior and use consistent with history page where users can select multiple chart via `+` sign to view on single stacked chart