### PR TITLE
Use correct endpoint for getting bug storage url

### DIFF
--- a/libs/bublik/features/compromised-form/src/lib/compromise-form.tsx
+++ b/libs/bublik/features/compromised-form/src/lib/compromise-form.tsx
@@ -236,11 +236,11 @@ export const DefineCompromiseContainer = ({
 	});
 
 	const bugStorageKeys = useMemo<SelectValue[]>(() => {
-		return Object.entries(refData?.logs || {}).map(([key, value]) => ({
+		return Object.entries(refData?.issues || {}).map(([key, value]) => ({
 			value: key,
 			displayValue: value.name
 		}));
-	}, [refData?.logs]);
+	}, [refData?.issues]);
 
 	const initialValues: DefineCompromisedFormValues = useMemo(() => {
 		const bugStorageKey = bugStorageKeys?.[0]?.value ?? '';

--- a/libs/services/bublik-api/src/lib/endpoints/run-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/run-endpoints.ts
@@ -234,7 +234,10 @@ export const runEndpoints = {
 			}
 		}),
 		getCompromisedTags: build.query<CompromisedTagsResponse, void>({
-			query: () => withApiV2('/outside_domains/logs')
+			query: () => ({
+				url: withApiV2('/outside_domains/issues'),
+				cache: 'no-cache'
+			})
 		}),
 		getRunRequirements: build.query<string[], string[] | number[]>({
 			queryFn: async (runId, _api, _extraOptions, fetchWithBQ) => {

--- a/libs/shared/types/src/lib/run.ts
+++ b/libs/shared/types/src/lib/run.ts
@@ -215,14 +215,13 @@ export interface CompromisedPostResponse {
 /** Individual info about bugs storage */
 export type CompromisedTagValue = {
 	name: string;
-	uri: string[];
-	aliases?: string[];
+	uri: string;
 };
 
 /** Information about bugs storages */
 export type CompromisedTagsResponse = {
 	/** Keys are bugs storage id and values are meta about storage */
-	logs: Record<string, CompromisedTagValue>;
+	issues: Record<string, CompromisedTagValue>;
 };
 
 /**


### PR DESCRIPTION
In some release configuration changed and front-end uses incorrect endpoint to retrieve urls for bug storage when marking runs as compromised

Depends on: https://github.com/ts-factory/bublik/pull/183