### PR TITLE
fix(log): [mi] ensure last data point is included in chart

### DIFF
--- a/libs/bublik/features/run-report/src/lib/run-report-chart/run-report-chart.component.tsx
+++ b/libs/bublik/features/run-report/src/lib/run-report-chart/run-report-chart.component.tsx
@@ -34,7 +34,7 @@ function RunReportChart(props: RunReportChartProps) {
 					? chart.axis_y.label
 					: d.series,
 			type: 'line',
-			data: d.points.map((d) => d?.[chart.axis_y.key]),
+			data: d.points.map((d) => [d?.[chart.axis_x.key], d?.[chart.axis_y.key]]),
 			itemStyle: {
 				color: (params: unknown) => {
 					const parsedParams = ParamsSchema.safeParse(params);
@@ -161,13 +161,15 @@ function RunReportChart(props: RunReportChartProps) {
 						},
 						dataZoom,
 						xAxis: {
-							type: 'category',
+							type: 'value',
 							name: chart.axis_x.label,
 							nameLocation: 'middle',
 							nameGap: 30,
 							nameTextStyle: chartStyles.text,
 							axisLabel: { ...chartStyles.text },
-							data: chart.axis_x.values
+							scale: true,
+							min: (value) => value.min * 0.9,
+							max: (value) => value.max * 1.1
 						},
 						yAxis: {
 							type: 'value',

--- a/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/blocks/log-content-mi/blocks/log-mi-chart/log-mi-chart.utils.ts
+++ b/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/blocks/log-content-mi/blocks/log-mi-chart/log-mi-chart.utils.ts
@@ -80,7 +80,7 @@ export const convertRawToCharts = (config: Config): ChartConfig[] => {
 				axis: {
 					type: 'category',
 					axisTick: { alignWithLabel: true },
-					data: Array.from({ length: maxLength - 1 }, (_, idx) => idx)
+					data: Array.from({ length: maxLength }, (_, idx) => idx)
 				}
 			};
 		}

--- a/libs/shared/charts/src/lib/selected-charts/selected-charts.component.tsx
+++ b/libs/shared/charts/src/lib/selected-charts/selected-charts.component.tsx
@@ -35,7 +35,7 @@ function SelectedChartsPopover(props: SelectedChartsPopoverProps) {
 					animate="visible"
 					exit="exit"
 					transition={transition}
-					className="fixed bottom-4 right-4 bg-white rounded-lg shadow-popover min-w-[360px] px-4 py-2"
+					className="fixed bottom-4 right-4 bg-white rounded-lg shadow-popover min-w-[360px] px-4 py-2 z-30"
 				>
 					<h1 className="text-[0.875rem] leading-[1.125rem] font-semibold mb-2">
 						{props.label}

--- a/libs/shared/charts/src/lib/single-measurement-chart/measurement-chart.component.utils.ts
+++ b/libs/shared/charts/src/lib/single-measurement-chart/measurement-chart.component.utils.ts
@@ -20,7 +20,7 @@ function resolveXAxisType(
 		);
 	});
 
-	return isTimeAxis ? 'time' : 'category';
+	return isTimeAxis ? 'time' : 'value';
 }
 
 type ChartState = {


### PR DESCRIPTION
Previously, the final data point was omitted from the X-axis due to an off-by-one error in series generation.
This change updates the logic to include the full data range by adjusting `Array.from` to generate `maxLength` elements instead of `maxLength - 1`.