### PR TITLE
feat(run,log): show message for runs in progress instead of error

### DIFF
--- a/libs/bublik/features/history/src/lib/history-measurements-combined/history-measurements-combined.container.tsx
+++ b/libs/bublik/features/history/src/lib/history-measurements-combined/history-measurements-combined.container.tsx
@@ -65,13 +65,15 @@ function HistoryMeasurementsCombinedContainer() {
 
 	return (
 		<>
-			<LogPreviewContainer
-				runId={point?.run_id}
-				resultId={point?.result_id}
-				measurementId={point?.result_id}
-				open={isPointDialogOpen}
-				onOpenChange={setIsPointDialogOpen}
-			/>
+			{point && (
+				<LogPreviewContainer
+					runId={point?.run_id}
+					resultId={point?.result_id}
+					measurementId={point?.result_id}
+					open={isPointDialogOpen}
+					onOpenChange={setIsPointDialogOpen}
+				/>
+			)}
 			<div className="bg-white rounded-md">
 				<CardHeader label="Combined" />
 				<div

--- a/libs/bublik/features/history/src/lib/history-measurements/plot-list.component.tsx
+++ b/libs/bublik/features/history/src/lib/history-measurements/plot-list.component.tsx
@@ -55,13 +55,15 @@ const PlotListItem = (props: PlotListItemProps) => {
 
 	return (
 		<>
-			<LogPreviewContainer
-				runId={point?.run_id}
-				resultId={point?.result_id}
-				measurementId={point?.result_id}
-				open={isDialogOpen}
-				onOpenChange={setIsDialogOpen}
-			/>
+			{point && (
+				<LogPreviewContainer
+					runId={point.run_id}
+					resultId={point.result_id}
+					measurementId={point.result_id}
+					open={isDialogOpen}
+					onOpenChange={setIsDialogOpen}
+				/>
+			)}
 			<li className="py-2.5 px-4">
 				<MeasurementChart
 					chart={plot}

--- a/libs/bublik/features/log/src/lib/containers/log-container/log-container.tsx
+++ b/libs/bublik/features/log/src/lib/containers/log-container/log-container.tsx
@@ -5,7 +5,8 @@ import { skipToken } from '@reduxjs/toolkit/query';
 import {
 	getErrorMessage,
 	useGetLogJsonQuery,
-	useGetLogUrlByResultIdQuery
+	useGetLogUrlByResultIdQuery,
+	useGetRunDetailsQuery
 } from '@/services/bublik-api';
 import {
 	LogTableContext,
@@ -13,7 +14,8 @@ import {
 	SessionLoading,
 	SessionRoot
 } from '@/bublik/features/session-log';
-import { cn, Icon } from '@/shared/tailwind-ui';
+import { cn, Icon, RunRunning } from '@/shared/tailwind-ui';
+import { RUN_STATUS } from '@/shared/types';
 
 import { useIsLogLegacy, useLogPage } from '../../hooks';
 
@@ -186,16 +188,29 @@ const JsonLog = (props: JsonLogProps) => {
 		: skipToken;
 
 	const { data, isLoading, isFetching, error } = useGetLogJsonQuery(idToFetch);
+	const {
+		data: details,
+		isLoading: detailsLoading,
+		error: detailsError
+	} = useGetRunDetailsQuery(runId ?? skipToken);
 
-	if (isLoading) {
+	if (isLoading || detailsLoading) {
 		return <SessionLoading />;
 	}
 
-	if (error) {
-		return <LogFrameError error={error} />;
+	if (details?.conclusion === RUN_STATUS.Running) {
+		return (
+			<div className="flex justify-center items-center w-full h-full">
+				<RunRunning />
+			</div>
+		);
 	}
 
-	if (!data) {
+	if (error || detailsError) {
+		return <LogFrameError error={error || detailsError} />;
+	}
+
+	if (!data || !details) {
 		return <LogFrameEmpty />;
 	}
 

--- a/libs/shared/tailwind-ui/src/index.ts
+++ b/libs/shared/tailwind-ui/src/index.ts
@@ -67,3 +67,4 @@ export * from './lib/conclusion-hover-card';
 export * from './lib/conclusion-badge';
 export * from './lib/instruction-dialog';
 export * from './lib/data-table-faceted-filter';
+export * from './lib/run-running';

--- a/libs/shared/tailwind-ui/src/lib/run-running/index.ts
+++ b/libs/shared/tailwind-ui/src/lib/run-running/index.ts
@@ -1,0 +1,1 @@
+export * from './run-running.component';

--- a/libs/shared/tailwind-ui/src/lib/run-running/run-running.component.tsx
+++ b/libs/shared/tailwind-ui/src/lib/run-running/run-running.component.tsx
@@ -1,0 +1,18 @@
+import { Icon } from '../icon';
+
+function RunRunning() {
+	return (
+		<div className="flex gap-4">
+			<Icon name="TriangleExclamationMark" size={48} className="text-primary" />
+			<div>
+				<h1 className="text-2xl font-bold">Run is in progress</h1>
+				<p className="mt-1 text-xl">
+					Due to current technical limitations, logs will only be available once
+					the entire run — including all tests — has completed.
+				</p>
+			</div>
+		</div>
+	);
+}
+
+export { RunRunning };


### PR DESCRIPTION
When run is in progress we can't show log until run is fully finished Show clear message instead of some generic 404 error
<img width="2304" alt="Screenshot 2025-05-21 at 11 06 35 am" src="https://github.com/user-attachments/assets/65b4306b-f395-4a2f-a6a1-6815a15eac9f" />
