### PR TITLE
refactor(history,run): [results] allow multiple `expected_results`

### DIFF
--- a/libs/bublik/features/history/src/lib/history-aggregation/column-components/results-list/results-list.tsx
+++ b/libs/bublik/features/history/src/lib/history-aggregation/column-components/results-list/results-list.tsx
@@ -84,6 +84,7 @@ export const ResultList = (props: ResultListProps) => {
 		<div className="flex flex-col gap-1">
 			{results.map((result, idx) => (
 				<HistoryContextMenuContainer
+					key={idx}
 					badges={result.verdict.map((verdict) => ({ payload: verdict }))}
 					filterKey="verdicts"
 					label="verdicts"

--- a/libs/bublik/features/history/src/lib/history-linear/column-components/links/links.tsx
+++ b/libs/bublik/features/history/src/lib/history-linear/column-components/links/links.tsx
@@ -158,7 +158,7 @@ const getHistorySearch = (
 			...row.metadata
 		].join(';'),
 		parameters: row.parameters.join(';'),
-		verdict: row.obtained_result.verdict.join(';'),
+		verdict: row.obtained_result.verdicts.join(';'),
 		results: DEFAULT_RESULT_TYPES.join(';')
 	};
 
@@ -172,7 +172,7 @@ const getHistorySearch = (
 		].join(';'),
 		parameters: row.parameters.join(';'),
 		results: row.obtained_result.result_type,
-		verdict: row.obtained_result.verdict.join(';'),
+		verdict: row.obtained_result.verdicts.join(';'),
 		runProperties: search.runProperties,
 		resultProperties: row.has_error
 			? RESULT_PROPERTIES.Unexpected

--- a/libs/bublik/features/history/src/lib/history-linear/history-linear.columns.tsx
+++ b/libs/bublik/features/history/src/lib/history-linear/history-linear.columns.tsx
@@ -105,17 +105,21 @@ export const columns: ColumnDef<HistoryDataLinear>[] = [
 	{
 		id: HistoryLinearColumns.ExpectedResults,
 		header: 'Expected Results',
-		accessorFn: (data) => data.expected_result,
+		accessorFn: (data) => data.expected_results,
 		cell: (cell) => {
-			const { result_type: expectedResultType, verdict: expectedVerdicts } =
-				cell.getValue<RunResult>();
+			const expectedResults = cell.getValue<RunResult[]>();
 
 			return (
-				<VerdictList
-					variant={VerdictVariant.Expected}
-					result={expectedResultType}
-					verdicts={expectedVerdicts}
-				/>
+				<>
+					{expectedResults.map((result, idx) => (
+						<VerdictList
+							key={idx}
+							variant={VerdictVariant.Expected}
+							result={result.result_type}
+							verdicts={result.verdicts}
+						/>
+					))}
+				</>
 			);
 		}
 	},

--- a/libs/bublik/features/history/src/lib/history-linear/history-linear.utils.ts
+++ b/libs/bublik/features/history/src/lib/history-linear/history-linear.utils.ts
@@ -30,7 +30,7 @@ export const getObtainedResult = (
 	return {
 		isNotExpected: data.has_error,
 		result: data.obtained_result.result_type,
-		verdicts: data.obtained_result.verdict
+		verdicts: data.obtained_result.verdicts
 	};
 };
 
@@ -49,7 +49,7 @@ export const globalFilterFn: FilterFn<HistoryDataLinear> = (
 	const importantTags = row.original.important_tags;
 	const metadata = row.original.metadata;
 	const parameters = row.original.parameters;
-	const verdicts = row.original.obtained_result.verdict;
+	const verdicts = row.original.obtained_result.verdicts;
 	const resultType = row.original.obtained_result.result_type;
 	const isNotExpected = row.original.has_error;
 

--- a/libs/bublik/features/run-diff/src/lib/result-diff/result-diff.columns.tsx
+++ b/libs/bublik/features/run-diff/src/lib/result-diff/result-diff.columns.tsx
@@ -56,11 +56,11 @@ export const getColumns = (
 			cell: (cell) => {
 				const { left, right } = cell.getValue<RunDataResultsWithDiff>();
 				const leftResultType = left?.obtained_result.result_type;
-				const leftVerdicts = left?.obtained_result.verdict;
+				const leftVerdicts = left?.obtained_result.verdicts;
 				const leftIsNotExpected = left?.has_error;
 
 				const rightResultType = right?.obtained_result.result_type;
-				const rightVerdicts = right?.obtained_result.verdict;
+				const rightVerdicts = right?.obtained_result.verdicts;
 				const rightIsNotExpected = right?.has_error;
 
 				return (
@@ -127,11 +127,11 @@ export const getColumns = (
 			cell: (cell) => {
 				const { left, right } = cell.getValue<RunDataResultsWithDiff>();
 				const leftResultType = left?.obtained_result.result_type;
-				const leftVerdicts = left?.obtained_result.verdict;
+				const leftVerdicts = left?.obtained_result.verdicts;
 				const leftIsNotExpected = left?.has_error;
 
 				const rightResultType = right?.obtained_result.result_type;
-				const rightVerdicts = right?.obtained_result.verdict;
+				const rightVerdicts = right?.obtained_result.verdicts;
 				const rightIsNotExpected = right?.has_error;
 
 				return (

--- a/libs/bublik/features/run-diff/src/lib/result-diff/result-diff.utils.ts
+++ b/libs/bublik/features/run-diff/src/lib/result-diff/result-diff.utils.ts
@@ -63,13 +63,13 @@ export const computeResultsDiff = ({
 				const leftData: Record<string, RESULT_TYPE | boolean | string[]> = {
 					resultType: left.obtained_result.result_type,
 					isNotExpected: left.has_error,
-					verdicts: left.obtained_result.verdict
+					verdicts: left.obtained_result.verdicts
 				};
 
 				const rightData: Record<string, RESULT_TYPE | boolean | string[]> = {
 					resultType: right.obtained_result.result_type,
 					isNotExpected: right.has_error,
-					verdicts: right.obtained_result.verdict
+					verdicts: right.obtained_result.verdicts
 				};
 
 				const isChanged =

--- a/libs/bublik/features/run/src/lib/result-table/result-table.columns.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.columns.tsx
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import { Fragment } from 'react';
 import { ColumnDef, createColumnHelper, Row } from '@tanstack/react-table';
 import { createNextState } from '@reduxjs/toolkit';
 
@@ -155,25 +156,31 @@ export const getColumns = ({
 			},
 			filterFn: fitlerIncludesSome
 		}),
-		helper.accessor('expected_result', {
+		helper.accessor('expected_results', {
 			header: 'Expected Results',
 			cell: (cell) => {
-				const expectedResult = cell.getValue();
+				const expectedResults = cell.getValue();
 
-				if (!expectedResult) return;
+				if (expectedResults.length === 0) return;
 
 				return (
 					<div className="flex flex-col flex-wrap gap-1">
-						{expectedResult.verdict && expectedResult.result_type ? (
-							<VerdictList
-								variant="expected"
-								verdicts={expectedResult.verdict}
-								result={expectedResult.result_type}
-							/>
-						) : null}
-						{expectedResult?.key?.length && expectedResult.key ? (
-							<KeyList items={expectedResult.key} />
-						) : null}
+						{expectedResults.map((result, idx) => {
+							return (
+								<Fragment key={idx}>
+									{result.verdicts && result.result_type ? (
+										<VerdictList
+											variant="expected"
+											verdicts={result.verdicts}
+											result={result.result_type}
+										/>
+									) : null}
+									{result?.keys?.length && result.keys ? (
+										<KeyList items={result.keys} />
+									) : null}
+								</Fragment>
+							);
+						})}
 					</div>
 				);
 			}
@@ -181,7 +188,7 @@ export const getColumns = ({
 		helper.accessor(
 			(data) => ({
 				isNotExpected: data.has_error,
-				verdicts: data.obtained_result.verdict,
+				verdicts: data.obtained_result.verdicts,
 				result: data.obtained_result.result_type
 			}),
 			{

--- a/libs/bublik/features/run/src/lib/result-table/result-table.component.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.component.tsx
@@ -327,7 +327,7 @@ function useDataTableFilters(rowId: string, data: RunDataResults[]) {
 			);
 
 			const hasEveryVerdict = verdictsFilter.every((verdict) =>
-				row.obtained_result.verdict?.includes(verdict)
+				row.obtained_result.verdicts?.includes(verdict)
 			);
 
 			const hasEveryArtifact = artifactsFilter.every((artifact) =>
@@ -376,7 +376,7 @@ function useDataTableFilters(rowId: string, data: RunDataResults[]) {
 
 	const verdicts = useMemo(() => {
 		return Array.from(
-			new Set(filteredData.map((row) => row.obtained_result.verdict).flat())
+			new Set(filteredData.map((row) => row.obtained_result.verdicts).flat())
 		)
 			.filter(Boolean)
 			.map((verdict) => ({

--- a/libs/shared/types/src/lib/history.ts
+++ b/libs/shared/types/src/lib/history.ts
@@ -88,7 +88,7 @@ export type HistoryDataLinear = {
 	finish_date: string;
 	duration: string;
 	obtained_result: RunResult;
-	expected_result: RunResult;
+	expected_results: RunResult[];
 	relevant_tags: string[];
 	metadata: string[];
 	parameters: string[];

--- a/libs/shared/types/src/lib/run.ts
+++ b/libs/shared/types/src/lib/run.ts
@@ -51,11 +51,11 @@ export enum RUN_STATUS {
 
 export type RunResult = {
 	result_type: RESULT_TYPE;
-	verdict: string[];
+	verdicts: string[];
 };
 
 export type RunResultWithKeys = RunResult & {
-	key: {
+	keys: {
 		name: string;
 		url?: string;
 	}[];
@@ -140,7 +140,7 @@ export type RunDataResults = {
 	run_id: string;
 	has_measurements: boolean;
 	has_error: boolean;
-	expected_result: RunResultWithKeys;
+	expected_results: RunResultWithKeys[];
 	obtained_result: RunResult;
 	comments: string[];
 	parameters: string[];

--- a/libs/shared/utils/src/lib/router.ts
+++ b/libs/shared/utils/src/lib/router.ts
@@ -113,7 +113,7 @@ const byPrefilled = (
 		resultProperties: result.has_error
 			? RESULT_PROPERTIES.Unexpected
 			: RESULT_PROPERTIES.Expected,
-		verdict: result.obtained_result.verdict.join(';'),
+		verdict: result.obtained_result.verdicts?.join(';'),
 		runData: allTags.join(';')
 	};
 };


### PR DESCRIPTION
Related to https://github.com/ts-factory/bublik/pull/185

Now we can show multiple expected results for each given result