### PR TITLE
fix(report): [table] don't show "undefined" when formatter is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 
 
+### [1.10.2](https://github.com/ts-factory/bublik-ui/compare/v1.10.1...v1.10.2) (2025-07-16)
+
+
+### 🐛 Bug Fix
+
+* **report:** [table] don't show "undefined" when formatter is not present ([7876216](https://github.com/ts-factory/bublik-ui/commit/78762163a5bad460ed573fd1814c9685e8430b2a))
+
 ## [1.10.0](https://github.com/ts-factory/bublik-ui/compare/v1.9.0...v1.10.0) (2025-07-09)
 
 

--- a/libs/bublik/features/deploy-info/src/lib/git-info.json
+++ b/libs/bublik/features/deploy-info/src/lib/git-info.json
@@ -1,7 +1,7 @@
 {
-	"date": "2025.07.10",
-	"summary": "fix(history): [charts] incorrect label in loading skeleton for \"Series Charts\"",
-	"revision": "fdcd615",
-	"branch": "release-1.10.1",
-	"latestTag": "v1.10.1"
+	"date": "2025.07.16",
+	"summary": "fix(report): [table] don't show \"undefined\" when formatter is not present",
+	"revision": "7876216",
+	"branch": "release-1.10.2",
+	"latestTag": "v1.10.2"
 }

--- a/libs/bublik/features/run-report/src/lib/run-report-table/run-report-table.component.tsx
+++ b/libs/bublik/features/run-report/src/lib/run-report-table/run-report-table.component.tsx
@@ -32,7 +32,7 @@ function formatValue(
 ) {
 	if (value === undefined || value === null) return <>&ndash;</>;
 
-	const formatter = seriesName ? formatters?.[seriesName] : '';
+	const formatter = seriesName ? formatters?.[seriesName] ?? '' : '';
 
 	return `${Number(value)}${formatter}`;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bublik-ui",
-	"version": "1.10.1",
+	"version": "1.10.2",
 	"license": "Apache-2.0",
 	"scripts": {
 		"preinstall": "npx only-allow pnpm",


### PR DESCRIPTION
Prevent incorrectly showing "undefined" when no formatter is specified for the given series of data points since it's not required