### PR TITLE
fix(report): [table] fix react duplicate key error

### DIFF
--- a/libs/bublik/features/run-report/src/lib/run-report-table/run-report-table.component.tsx
+++ b/libs/bublik/features/run-report/src/lib/run-report-table/run-report-table.component.tsx
@@ -117,7 +117,7 @@ function SingleSeriesTable({ table, runId }: SingleSeriesTableProps) {
 					{seriesNames.map((seriesName, idx, arr) => {
 						return (
 							<th
-								key={seriesName}
+								key={idx}
 								className={headerCellStyles({
 									className: `text-right border-r h-9 ${
 										idx !== arr.length - 1 && 'border-r'


### PR DESCRIPTION
React requires not duplicate keys in case of reorder of components Since we don't plan to reorder table headers it's okay to use index