### PR TITLE
fix(ci): increase node memory limit to prevent out-of-memory errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     branches: [main]
 env:
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+  NODE_OPTIONS: '--max-old-space-size=4096'
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Set NODE_OPTIONS="--max-old-space-size=4098" during the build steps to increase the default memory allocation for Node.js. This helps avoid JavaScript heap out-of-memory errors when building on github runners for private repos which have smaller limit by default allocated to node