### PR TITLE
fix(config): make description field optional in config forms and API

### DIFF
--- a/apps/bublik/src/pages/configs/create-config-form/create-new-config.container.tsx
+++ b/apps/bublik/src/pages/configs/create-config-form/create-new-config.container.tsx
@@ -38,10 +38,7 @@ import { DEFAULT_PROJECT_LABEL } from '../config.constants';
 
 const CreateConfigSchema = z.object({
 	name: z.string().min(1, 'Name is required').max(32, 'Name is too long'),
-	description: z
-		.string()
-		.min(1, 'Description is required')
-		.max(255, 'Description is too long'),
+	description: z.string().optional(),
 	is_active: z.boolean(),
 	project: z.number().optional().nullable(),
 	content: ValidJsonStringSchema

--- a/apps/bublik/src/pages/configs/update-config-form/update-config-form.component.tsx
+++ b/apps/bublik/src/pages/configs/update-config-form/update-config-form.component.tsx
@@ -34,7 +34,7 @@ import { ValidJsonStringSchema } from '../utils';
 const ConfigFormSchema = z.object({
 	name: z.string(),
 	content: ValidJsonStringSchema,
-	description: z.string(),
+	description: z.string().optional(),
 	is_active: z.boolean()
 });
 

--- a/libs/services/bublik-api/src/lib/endpoints/configs-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/configs-endpoints.ts
@@ -16,7 +16,7 @@ type ConfigParams = z.infer<typeof ConfigParamsSchema>;
 const CreateConfigBodySchema = z.object({
 	type: z.string(),
 	name: z.string().min(1),
-	description: z.string(),
+	description: z.string().optional(),
 	is_active: z.boolean(),
 	content: z.any(),
 	project: z.number().optional().nullable()
@@ -36,8 +36,8 @@ type CreateConfigParams = z.infer<typeof CreateConfigBodySchema>;
 
 const EditConfigBodySchema = z.object({
 	name: z.string().optional(),
-	description: z.string().min(1).optional(),
-	content: z.string().min(1).optional(),
+	description: z.string().optional(),
+	content: z.string().optional(),
 	is_active: z.boolean().optional()
 });
 


### PR DESCRIPTION
Changes:
- Make `description` field optional in form schemas
- Make `description` field optional in API endpoints schema

Fixes #377