### PR TITLE
chore(projects): [config] update default project label

### DIFF
--- a/apps/bublik/src/pages/configs/config.constants.ts
+++ b/apps/bublik/src/pages/configs/config.constants.ts
@@ -2,3 +2,4 @@
 /* SPDX-FileCopyrightText: 2024 OKTET LTD */
 
 export const DEFAULT_URI = 'memory://model';
+export const DEFAULT_PROJECT_LABEL = 'No Project (Default)';

--- a/apps/bublik/src/pages/configs/constants/index.ts
+++ b/apps/bublik/src/pages/configs/constants/index.ts
@@ -1,3 +1,0 @@
-const DEFAULT_PROJECT_NAME = 'Default';
-
-export { DEFAULT_PROJECT_NAME };

--- a/apps/bublik/src/pages/configs/create-config-form/create-new-config.container.tsx
+++ b/apps/bublik/src/pages/configs/create-config-form/create-new-config.container.tsx
@@ -34,6 +34,7 @@ import {
 	ValidJsonStringSchema
 } from '../utils';
 import { ConfigEditor } from '../components/editor.component';
+import { DEFAULT_PROJECT_LABEL } from '../config.constants';
 
 const CreateConfigSchema = z.object({
 	name: z.string().min(1, 'Name is required').max(32, 'Name is too long'),
@@ -227,7 +228,7 @@ function CreateNewConfigScreen() {
 										}}
 										className="w-full px-3.5 py-[7px] outline-none border border-border-primary rounded text-text-secondary transition-all hover:border-primary disabled:text-text-menu disabled:cursor-not-allowed focus:border-primary focus:shadow-text-field active:shadow-none focus:ring-transparent"
 									>
-										<option value="default">Default Project</option>
+										<option value="default">{DEFAULT_PROJECT_LABEL}</option>
 										{projectsQuery.data?.map((project) => (
 											<option key={project.id} value={project.id.toString()}>
 												{project.name}

--- a/apps/bublik/src/pages/configs/sidebar/config-list.component.tsx
+++ b/apps/bublik/src/pages/configs/sidebar/config-list.component.tsx
@@ -13,7 +13,7 @@ import { useConfirm } from '@/shared/hooks';
 
 import { formatTimeV } from '../utils';
 import { InactiveBadge } from '../components/badges.component';
-import { DEFAULT_PROJECT_NAME } from '../constants';
+import { DEFAULT_PROJECT_LABEL } from '../config.constants';
 
 type GroupedConfigs = { [key: string]: ConfigItem[] };
 
@@ -49,14 +49,14 @@ function ConfigList(props: ConfigListProps) {
 		projects.forEach((project) => projectMap.set(project.id, project.name));
 
 		const groupedByProject: GroupedConfigs = {
-			Default: defaultConfigs,
+			[DEFAULT_PROJECT_LABEL]: defaultConfigs,
 			...Object.fromEntries(projects.map((project) => [project.name, []]))
 		};
 
 		Object.entries(
 			groupBy(
 				projectConfigs,
-				(config) => projectMap.get(config.project || 0) || DEFAULT_PROJECT_NAME
+				(config) => projectMap.get(config.project || 0) || DEFAULT_PROJECT_LABEL
 			)
 		).forEach(([projectName, configs]) => {
 			if (projectName in groupedByProject) {
@@ -81,7 +81,7 @@ function ConfigList(props: ConfigListProps) {
 				const missingGlobalConfigs: typeof REQUIRED_GLOBAL_CONFIGS = [];
 
 				const foundProject =
-					projectName !== DEFAULT_PROJECT_NAME
+					projectName !== DEFAULT_PROJECT_LABEL
 						? projects.find((p) => p.name === projectName)
 						: undefined;
 


### PR DESCRIPTION
Unify and clarify project labels to avoid confusion

Changes:
- Change label from `Default` to `No Project (Default)` in sidebar
- Change label from `Default` to `No Project (Default)` in create config form

Fixes #375