### PR TITLE
feat(run): add link to history for test filtered by run id and test name

### DIFF
--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.hooks.ts
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.hooks.ts
@@ -44,6 +44,7 @@ export const useHistoryGlobalSearchForm = (
 			revisions: [],
 			revisionExpr: '',
 			runData: [],
+			runIds: '',
 			branchExpr: '',
 			labels: [],
 			branches: [],

--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.types.ts
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.types.ts
@@ -31,6 +31,7 @@ export interface HistoryGlobalSearchFormValues {
 	parameters: BadgeItem[];
 	dates: { startDate: Date; endDate: Date };
 	runData: BadgeItem[];
+	runIds: string;
 	tagExpr: string;
 	branches: BadgeItem[];
 	revisions: BadgeItem[];
@@ -52,6 +53,7 @@ export const defaultValues: HistoryGlobalSearchFormValues = {
 	results: DEFAULT_RESULT_TYPES,
 	runData: [],
 	parameters: [],
+	runIds: '',
 	labels: [],
 	hash: '',
 	dates: { startDate: new Date(), endDate: new Date() },

--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/run-section.tsx
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/run-section.tsx
@@ -38,8 +38,18 @@ export const RunSection = (props: RunSectionProps) => {
 				/>
 			</FormSectionHeader>
 			<div className="flex flex-col gap-4">
-				<div className={'w-1/2'}>
-					<AriaDateRangeField label="Dates" name="dates" control={control} />
+				<div className={'flex gap-4 items-center'}>
+					<div className="flex-1">
+						<AriaDateRangeField label="Dates" name="dates" control={control} />
+					</div>
+					<div className="flex-1">
+						<TextField
+							name="runIds"
+							label="Run ID"
+							placeholder="1"
+							control={control}
+						/>
+					</div>
 				</div>
 				<BadgeField
 					name="labels"

--- a/libs/bublik/features/history/src/lib/slice/history-slice.ts
+++ b/libs/bublik/features/history/src/lib/slice/history-slice.ts
@@ -46,6 +46,7 @@ export const DEFAULT_SEARCH_FORM_STATE: HistorySliceState['searchForm'] = {
 	finishDate: DEFAULT_HISTORY_END_DATE,
 	runData: [],
 	tagExpr: '',
+	runIds: [],
 	/* Result section */
 	runProperties: DEFAULT_RUN_PROPERTIES,
 	resultProperties: DEFAULT_RESULT_PROPERTIES,

--- a/libs/bublik/features/history/src/lib/slice/history-slice.types.ts
+++ b/libs/bublik/features/history/src/lib/slice/history-slice.types.ts
@@ -44,6 +44,7 @@ export type HistoryStateSearch = {
 	startDate: Date;
 	finishDate: Date;
 	runData: string[];
+	runIds: string[];
 	tagExpr: string;
 	/* Result section */
 	runProperties: string[];

--- a/libs/bublik/features/history/src/lib/slice/history-slice.utils.ts
+++ b/libs/bublik/features/history/src/lib/slice/history-slice.utils.ts
@@ -4,6 +4,7 @@ import { parse } from 'date-fns';
 
 import {
 	API_DATE_FORMAT,
+	config,
 	DEFAULT_HISTORY_END_DATE,
 	DEFAULT_HISTORY_START_DATE
 } from '@/bublik/config';
@@ -21,7 +22,7 @@ import { HistorySearchFormState } from './history-slice.types';
 export const parseArray = (str?: string) => {
 	if (!str) return [];
 
-	return str.split(';');
+	return str.split(config.queryDelimiter);
 };
 
 export const arrayToBadgeItem = (array: string[]): BadgeItem[] => {
@@ -35,7 +36,7 @@ export const badgeItemToArray = (items: BadgeItem[]): string[] => {
 export const arrayToString = (array: string[]): string | undefined => {
 	if (!array.length) return undefined;
 
-	return array.join(';');
+	return array.join(config.queryDelimiter);
 };
 
 const withDefault = <T>(
@@ -72,6 +73,7 @@ export const queryToHistorySearchState = (
 		finishDate,
 		runData: withDefault(parseArray(query.tags), []),
 		tagExpr: withDefault(query.tagExpr, ''),
+		runIds: withDefault(parseArray(query.runIds), []),
 		branchExpr: withDefault(query.branchExpr, ''),
 		verdictExpr: withDefault(query.verdictExpr, ''),
 		revisionExpr: withDefault(query.revExpr, ''),
@@ -104,6 +106,7 @@ export const historySearchStateToForm = (
 		labels: arrayToBadgeItem(state.labels),
 		/* Run section */
 		runData: arrayToBadgeItem(state.runData),
+		runIds: state.runIds?.join(config.queryDelimiter) ?? '',
 		tagExpr: state.tagExpr,
 		dates: { startDate: state.startDate, endDate: state.finishDate },
 		/* Result section */
@@ -136,6 +139,7 @@ export function searchQueryToBackendQuery(
 		verdictExpr: query.verdictExpr,
 		fromDate: query.startDate,
 		toDate: query.finishDate,
+		runIds: query.runIds,
 		/* Result section */
 		resultTypes: query.resultProperties,
 		runProperties: query.runProperties,
@@ -170,6 +174,7 @@ export const historySearchStateToQuery = (
 		verdictExpr: withDefault(state.verdictExpr, ''),
 		startDate: formatTimeToAPI(state.startDate),
 		finishDate: formatTimeToAPI(state.finishDate),
+		runIds: withDefault(arrayToString(state.runIds), ''),
 		/* Result section */
 		resultProperties: withDefault(arrayToString(state.resultProperties), ''),
 		runProperties: withDefault(arrayToString(state.runProperties), ''),
@@ -196,6 +201,7 @@ export const formToSearchState = (
 		startDate: form.dates.startDate,
 		finishDate: form.dates.endDate,
 		runData: badgeItemToArray(form.runData),
+		runIds: form.runIds.split(config.queryDelimiter),
 		tagExpr: form.tagExpr,
 		revisionExpr: form.revisionExpr,
 		testArgExpr: form.testArgExpr,

--- a/libs/bublik/features/run/src/lib/run-table/run-table.component.tsx
+++ b/libs/bublik/features/run/src/lib/run-table/run-table.component.tsx
@@ -121,7 +121,14 @@ export const RunTable = (props: RunTableProps) => {
 		projectId
 	} = props;
 
-	const columns = useMemo(() => getColumns({ projectId }), [projectId]);
+	const columns = useMemo(
+		() =>
+			getColumns({
+				projectId,
+				runIds: typeof runId === 'string' ? [Number(runId)] : runId.map(Number)
+			}),
+		[projectId, runId]
+	);
 
 	const table = useReactTable<RunData | MergedRun>({
 		data,

--- a/libs/shared/tailwind-ui/src/lib/dropdown/dropdown-menu.component.tsx
+++ b/libs/shared/tailwind-ui/src/lib/dropdown/dropdown-menu.component.tsx
@@ -165,7 +165,7 @@ const DropdownMenuLabel = React.forwardRef<
 	<DropdownMenuPrimitive.Label
 		ref={ref}
 		className={cn(
-			'px-2 py-1.5 text-sm font-semibold',
+			'px-2 py-1.5 text-xs font-semibold',
 			inset && 'pl-8',
 			className
 		)}

--- a/libs/shared/tailwind-ui/src/lib/table-tree-node/table-tree-node.tsx
+++ b/libs/shared/tailwind-ui/src/lib/table-tree-node/table-tree-node.tsx
@@ -1,6 +1,12 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { ComponentPropsWithRef, CSSProperties, forwardRef } from 'react';
+import {
+	ComponentPropsWithRef,
+	CSSProperties,
+	forwardRef,
+	ReactNode,
+	Ref
+} from 'react';
 
 import { NodeEntity } from '@/shared/types';
 
@@ -32,29 +38,60 @@ export interface TableNodeProps extends ComponentPropsWithRef<'button'> {
 	nodeType: NodeEntity;
 	isExpanded?: boolean;
 	depth: number;
+	trailing?: ReactNode;
 }
 
-export const TableNode = forwardRef<HTMLButtonElement, TableNodeProps>(
-	({ nodeName, nodeType, isExpanded, depth, ...props }, ref) => {
-		return (
-			<button
-				className="flex items-center w-full gap-1 overflow-hidden text-ellipsis whitespace-nowrap hover:text-primary"
-				style={getPaddingStyle(depth)}
-				{...props}
-				ref={ref}
-			>
-				<Icon
-					name="ArrowShortSmall"
-					className={cn(
-						'grid place-items-center',
-						isExpanded && 'text-primary',
-						isExpanded ? 'rotate-360' : '-rotate-90'
-					)}
-				/>
+function _TableNode(props: TableNodeProps, ref: Ref<HTMLButtonElement>) {
+	const { nodeName, nodeType, isExpanded, depth, trailing, ...restProps } =
+		props;
 
-				<div className="grid place-items-center">{getIcon(nodeType)}</div>
-				<span className="truncate">{nodeName}</span>
-			</button>
+	if (trailing) {
+		return (
+			<div className="flex items-center gap-1">
+				<button
+					className="flex items-center w-full gap-1 overflow-hidden text-ellipsis whitespace-nowrap hover:text-primary"
+					style={getPaddingStyle(depth)}
+					{...restProps}
+					ref={ref}
+				>
+					<Icon
+						name="ArrowShortSmall"
+						className={cn(
+							'grid place-items-center',
+							isExpanded && 'text-primary',
+							isExpanded ? 'rotate-360' : '-rotate-90'
+						)}
+					/>
+
+					<div className="grid place-items-center">{getIcon(nodeType)}</div>
+					<span className="truncate">{nodeName}</span>
+				</button>
+				{trailing}
+			</div>
 		);
 	}
-);
+
+	return (
+		<button
+			className="flex items-center w-full gap-1 overflow-hidden text-ellipsis whitespace-nowrap hover:text-primary"
+			style={getPaddingStyle(depth)}
+			{...restProps}
+			ref={ref}
+		>
+			<Icon
+				name="ArrowShortSmall"
+				className={cn(
+					'grid place-items-center',
+					isExpanded && 'text-primary',
+					isExpanded ? 'rotate-360' : '-rotate-90'
+				)}
+			/>
+
+			<div className="grid place-items-center">{getIcon(nodeType)}</div>
+			<span className="truncate">{nodeName}</span>
+			{trailing}
+		</button>
+	);
+}
+
+export const TableNode = forwardRef(_TableNode);

--- a/libs/shared/types/src/lib/history.ts
+++ b/libs/shared/types/src/lib/history.ts
@@ -32,6 +32,7 @@ export type HistoryAPIBackendQuery = {
 	testArgExpr?: string;
 
 	runProperties?: string;
+	runIds?: string;
 	resultTypes?: string;
 	resultStatuses?: string;
 
@@ -68,6 +69,7 @@ export type HistoryAPIQuery = {
 	runProperties?: string;
 	resultProperties?: string;
 	results?: string;
+	runIds?: string;
 
 	verdictLookup?: VERDICT_TYPE;
 	verdict?: string;


### PR DESCRIPTION
Add shortcut link to open direct search to history view with
filtered results by run id and test name
<img width="842" height="663" alt="Screenshot 2025-08-25 at 4 30 20 am" src="https://github.com/user-attachments/assets/9819ee2d-4b4b-4101-804e-414c41a7cf42" />
<img width="758" height="593" alt="Screenshot 2025-08-25 at 4 30 48 am" src="https://github.com/user-attachments/assets/454bba4f-0fe5-4649-83f2-1a36f4f03b9b" />

