### PR TITLE
fix(run): reset `open` state for history search form on back navigation

### DIFF
--- a/libs/bublik/features/history/src/lib/history-global-search-form/history-global-search-form.container.tsx
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/history-global-search-form.container.tsx
@@ -1,10 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 
-import { useMount } from '@/shared/hooks';
+import { useMount, useUnmount } from '@/shared/hooks';
 
 import { HistoryGlobalSearchFormButton } from './history-global-search-button.component';
 import {
@@ -44,6 +44,8 @@ export const HistoryGlobalSearchFormContainer = () => {
 			actions.toggleIsGlobalSearchOpen(true);
 		}
 	});
+
+	useUnmount(() => actions.toggleIsGlobalSearchOpen(false));
 
 	return (
 		<HistoryGlobalSearchFormButton


### PR DESCRIPTION
This caused form to be stuck in `open` state and not closing when user made following actions:
1. Go to history with open prefilled form (state: "open")
2. Navigate back via clicking button to run for example (state: "open")
3. Open direct search link to history (state: "open")

Since user never closed form and immediatly gone back to another page it is stucked in open state without resetting even when going to other pages

Fixes #383