### PR TITLE
style(ui): make placeholder text color dimmer for inputs

### DIFF
--- a/apps/bublik/src/pages/configs/create-config-form/create-new-config.container.tsx
+++ b/apps/bublik/src/pages/configs/create-config-form/create-new-config.container.tsx
@@ -274,7 +274,7 @@ function CreateNewConfigScreen() {
 										{...field}
 										id="description"
 										rows={4}
-										className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
+										className="mt-1 block w-full rounded-md border-border-primary shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 placeholder:text-text-menu"
 										placeholder="Enter description for the new config"
 									/>
 									{form.formState.errors.description && (

--- a/apps/bublik/src/pages/configs/update-config-form/update-config-form.component.tsx
+++ b/apps/bublik/src/pages/configs/update-config-form/update-config-form.component.tsx
@@ -187,8 +187,8 @@ const ConfigEditorForm = forwardRef<
 										{...field}
 										id="description"
 										rows={4}
-										className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
-										placeholder="Enter description for the new config"
+										className="mt-1 block w-full rounded-md border-border-primary shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 placeholder:text-text-menu"
+										placeholder="Enter description for the update"
 									/>
 									{form.formState.errors.description && (
 										<p className="mt-1 text-[0.75rem] font-normal text-bg-error">

--- a/libs/bublik/features/auth/src/lib/forgot-password/__snapshots__/forgot-password.component.spec.tsx.snap
+++ b/libs/bublik/features/auth/src/lib/forgot-password/__snapshots__/forgot-password.component.spec.tsx.snap
@@ -48,7 +48,7 @@ exports[`ForgotPasswordForm > should dispaly error when email is not correct 1`]
           </label>
           <input
             autocomplete="off"
-            class="w-full px-3.5 py-[7px] outline-none border rounded text-text-secondary transition-all disabled:text-text-menu disabled:cursor-not-allowed focus:ring-transparent border-bg-error hover:border-bg-error caret-bg-error shadow-text-field-error focus:border-bg-error active:shadow-none focus:shadow-text-field-error"
+            class="w-full px-3.5 py-[7px] outline-none border rounded text-text-secondary transition-all disabled:text-text-menu disabled:cursor-not-allowed focus:ring-transparent placeholder:text-text-menu font-medium text-[0.875rem] border-bg-error hover:border-bg-error caret-bg-error shadow-text-field-error focus:border-bg-error active:shadow-none focus:shadow-text-field-error"
             data-testid="input"
             id="email"
             name="email"
@@ -139,7 +139,7 @@ exports[`ForgotPasswordForm > should match snapshot 1`] = `
           </label>
           <input
             autocomplete="off"
-            class="w-full px-3.5 py-[7px] outline-none border border-border-primary rounded text-text-secondary transition-all hover:border-primary disabled:text-text-menu disabled:cursor-not-allowed focus:border-primary focus:shadow-text-field active:shadow-none focus:ring-transparent"
+            class="w-full px-3.5 py-[7px] outline-none border border-border-primary rounded text-text-secondary transition-all hover:border-primary disabled:text-text-menu disabled:cursor-not-allowed focus:border-primary focus:shadow-text-field active:shadow-none focus:ring-transparent placeholder:text-text-menu font-medium text-[0.875rem]"
             data-testid="input"
             id="email"
             name="email"

--- a/libs/bublik/features/auth/src/lib/login-form/__snapshots__/login-form.component.spec.tsx.snap
+++ b/libs/bublik/features/auth/src/lib/login-form/__snapshots__/login-form.component.spec.tsx.snap
@@ -43,7 +43,7 @@ exports[`LoginForm > should match snapshot 1`] = `
           </label>
           <input
             autocomplete="off"
-            class="w-full px-3.5 py-[7px] outline-none border border-border-primary rounded text-text-secondary transition-all hover:border-primary disabled:text-text-menu disabled:cursor-not-allowed focus:border-primary focus:shadow-text-field active:shadow-none focus:ring-transparent"
+            class="w-full px-3.5 py-[7px] outline-none border border-border-primary rounded text-text-secondary transition-all hover:border-primary disabled:text-text-menu disabled:cursor-not-allowed focus:border-primary focus:shadow-text-field active:shadow-none focus:ring-transparent placeholder:text-text-menu font-medium text-[0.875rem]"
             data-testid="input"
             id="email"
             name="email"
@@ -69,7 +69,7 @@ exports[`LoginForm > should match snapshot 1`] = `
           </label>
           <input
             autocomplete="off"
-            class="w-full px-3.5 py-[7px] outline-none border border-border-primary rounded text-text-secondary transition-all hover:border-primary disabled:text-text-menu disabled:cursor-not-allowed focus:border-primary focus:shadow-text-field active:shadow-none focus:ring-transparent"
+            class="w-full px-3.5 py-[7px] outline-none border border-border-primary rounded text-text-secondary transition-all hover:border-primary disabled:text-text-menu disabled:cursor-not-allowed focus:border-primary focus:shadow-text-field active:shadow-none focus:ring-transparent placeholder:text-text-menu font-medium text-[0.875rem]"
             data-testid="input"
             id="password"
             name="password"

--- a/libs/bublik/features/auth/src/lib/reset-password/__snapshots__/reset-password.component.spec.tsx.snap
+++ b/libs/bublik/features/auth/src/lib/reset-password/__snapshots__/reset-password.component.spec.tsx.snap
@@ -48,7 +48,7 @@ exports[`ChangePasswordForm > should match snapshot 1`] = `
           </label>
           <input
             autocomplete="new-password"
-            class="w-full px-3.5 py-[7px] outline-none border border-border-primary rounded text-text-secondary transition-all hover:border-primary disabled:text-text-menu disabled:cursor-not-allowed focus:border-primary focus:shadow-text-field active:shadow-none focus:ring-transparent"
+            class="w-full px-3.5 py-[7px] outline-none border border-border-primary rounded text-text-secondary transition-all hover:border-primary disabled:text-text-menu disabled:cursor-not-allowed focus:border-primary focus:shadow-text-field active:shadow-none focus:ring-transparent placeholder:text-text-menu font-medium text-[0.875rem]"
             data-testid="input"
             id="new_password"
             name="new_password"
@@ -74,7 +74,7 @@ exports[`ChangePasswordForm > should match snapshot 1`] = `
           </label>
           <input
             autocomplete="new-password"
-            class="w-full px-3.5 py-[7px] outline-none border border-border-primary rounded text-text-secondary transition-all hover:border-primary disabled:text-text-menu disabled:cursor-not-allowed focus:border-primary focus:shadow-text-field active:shadow-none focus:ring-transparent"
+            class="w-full px-3.5 py-[7px] outline-none border border-border-primary rounded text-text-secondary transition-all hover:border-primary disabled:text-text-menu disabled:cursor-not-allowed focus:border-primary focus:shadow-text-field active:shadow-none focus:ring-transparent placeholder:text-text-menu font-medium text-[0.875rem]"
             data-testid="input"
             id="new_password_confirm"
             name="new_password_confirm"

--- a/libs/shared/tailwind-ui/src/lib/badge-input/badge-input.tsx
+++ b/libs/shared/tailwind-ui/src/lib/badge-input/badge-input.tsx
@@ -184,7 +184,7 @@ export const BadgeInput = forwardRef<HTMLDivElement, BadgeInputProps>(
 					<div className="flex flex-wrap flex-grow h-full">
 						{!disabled ? <BadgeList label={label} badges={badges} /> : null}
 						<input
-							className="flex w-full outline-none disabled:bg-bg-body p-2 cursor-[inherit] bg-transparent border-none text-text-secondary focus:ring-transparent  "
+							className="flex w-full outline-none disabled:bg-bg-body pr-2 pl-4 py-2 cursor-[inherit] bg-transparent placeholder:text-text-menu border-none text-text-secondary leading-[1.5rem] font-medium text-[0.875rem] focus:ring-transparent"
 							value={value}
 							id={label}
 							onChange={handleChange}

--- a/libs/shared/tailwind-ui/src/lib/input/input.tsx
+++ b/libs/shared/tailwind-ui/src/lib/input/input.tsx
@@ -24,7 +24,9 @@ const inputStyles = cva({
 		'focus:border-primary',
 		'focus:shadow-text-field',
 		'active:shadow-none',
-		'focus:ring-transparent'
+		'focus:ring-transparent',
+		'placeholder:text-text-menu',
+		'leading-[1.5rem] font-medium text-[0.875rem]'
 	]
 });
 


### PR DESCRIPTION
Current placeholder color is too bright which causes confusion: which fields are filled in and which are not.

Changes:
- Made text color for input placeholder dimmer