### PR TITLE
fix(config): outdated config list right after auth

### DIFF
--- a/apps/bublik/src/pages/configs/sidebar/config-sidebar.container.tsx
+++ b/apps/bublik/src/pages/configs/sidebar/config-sidebar.container.tsx
@@ -15,7 +15,9 @@ interface ConfigsSidebarContainerProps {
 
 function ConfigsSidebarContainer(props: ConfigsSidebarContainerProps) {
 	const { createProjectButton } = props;
-	const configsQuery = bublikAPI.useGetListOfConfigsQuery();
+	const configsQuery = bublikAPI.useGetListOfConfigsQuery(undefined, {
+		refetchOnMountOrArgChange: true
+	});
 	const projectsQuery = bublikAPI.useGetAllProjectsQuery();
 	const { setConfigId, configId, setNewConfigParams } =
 		useConfigPageSearchParams();


### PR DESCRIPTION
When user is unauthenticated and some configs are not available for read if we login and go back to config page we don't see all configs since we might serve them from cash. Fix this by reloading config list on each page mount