### PR TITLE
chore(run): change default link to direct to history

### DIFF
--- a/libs/bublik/features/result-links/src/lib/link-to-history/link-to-history.tsx
+++ b/libs/bublik/features/result-links/src/lib/link-to-history/link-to-history.tsx
@@ -23,7 +23,7 @@ export const LinkToHistory = (props: LinkToHistoryProps) => {
 		<SplitButton.Root variant="secondary" size="xss">
 			<SplitButton.Button asChild>
 				<LinkWithProject
-					{...search.prefilled.testNameAndParametersAndImportantTags}
+					{...search.direct.testNameAndParametersAndImportantTags}
 				>
 					<Icon
 						name="BoxArrowRight"
@@ -86,7 +86,10 @@ export const LinkToHistory = (props: LinkToHistoryProps) => {
 							{...search.direct.testNameAndParametersAndImportantTags}
 						>
 							<Icon name="BoxArrowRight" size={20} className="text-primary" />
-							<span>Test Name + Parameters + Important Tags</span>
+							<span>
+								Test Name + Parameters + Important Tags{' '}
+								<strong>(Default)</strong>
+							</span>
 						</LinkWithProject>
 					</SplitButton.Item>
 				</Tooltip>
@@ -141,10 +144,7 @@ export const LinkToHistory = (props: LinkToHistoryProps) => {
 							{...search.prefilled.testNameAndParametersAndImportantTags}
 						>
 							<Icon name="BoxArrowRight" size={20} className="text-primary" />
-							<span>
-								Test Name + Parameters + Important Tags{' '}
-								<strong>(Default)</strong>
-							</span>
+							<span>Test Name + Parameters + Important Tags</span>
 						</LinkWithProject>
 					</SplitButton.Item>
 				</Tooltip>


### PR DESCRIPTION
Make so history link by clicking history button goes to history without prefilled form and also highlight it in dropdown menu which option is default