### PR TITLE
refactor(projects): get tab title prefix from API

### DIFF
--- a/apps/bublik/src/pages/dashboard-page/dashboard-page-v2.tsx
+++ b/apps/bublik/src/pages/dashboard-page/dashboard-page-v2.tsx
@@ -10,14 +10,14 @@ import {
 	ModePickerContainer,
 	SearchBarContainer,
 	TodayButtonContainer,
-	TvModeContainer,
-	useDashboardTitle
+	TvModeContainer
 } from '@/bublik/features/dashboard-v2';
 import { formatTimeToAPI, parseTimeApi } from '@/shared/utils';
 import { CopyShortUrlButtonContainer } from '@/bublik/features/copy-url';
+import { useTabTitleWithPrefix } from '@/bublik/features/projects';
 
 export const DashboardPageV2 = () => {
-	useDashboardTitle();
+	useTabTitleWithPrefix('Dashboard - Bublik');
 	const [searchParams] = useSearchParams();
 
 	const search = Object.fromEntries(searchParams.entries());

--- a/apps/bublik/src/pages/developers-page/developers-page.tsx
+++ b/apps/bublik/src/pages/developers-page/developers-page.tsx
@@ -3,11 +3,11 @@
 import { Outlet } from 'react-router-dom';
 
 import { config } from '@/bublik/config';
-import { useDocumentTitle } from '@/shared/hooks';
 import { IframeToOldBublik } from '@/shared/tailwind-ui';
+import { useTabTitleWithPrefix } from '@/bublik/features/projects';
 
 export const FlowerFeature = () => {
-	useDocumentTitle('Flower - Bublik');
+	useTabTitleWithPrefix('Flower - Bublik');
 
 	return (
 		<IframeToOldBublik
@@ -19,7 +19,7 @@ export const FlowerFeature = () => {
 };
 
 export const DevelopersLayout = () => {
-	useDocumentTitle('Dev - Bublik');
+	useTabTitleWithPrefix('Dev - Bublik');
 
 	return <Outlet />;
 };

--- a/apps/bublik/src/pages/import-page/import-page.tsx
+++ b/apps/bublik/src/pages/import-page/import-page.tsx
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { useDocumentTitle } from '@/shared/hooks';
+import { useTabTitleWithPrefix } from '@/bublik/features/projects';
 import {
 	ImportEventsTableContainer,
 	ImportLogProvider,
@@ -8,7 +8,7 @@ import {
 } from '@/bublik/features/run-import';
 
 export const ImportPage = () => {
-	useDocumentTitle('Import - Bublik');
+	useTabTitleWithPrefix('Import - Bublik');
 
 	return (
 		<div className="p-2 overflow-hidden h-full">

--- a/apps/bublik/src/pages/not-found-page/not-found-page.tsx
+++ b/apps/bublik/src/pages/not-found-page/not-found-page.tsx
@@ -1,12 +1,11 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { FC } from 'react';
-
-import { useDocumentTitle } from '@/shared/hooks';
 import { NotFound } from '@/shared/tailwind-ui';
 
-export const NoMatchFeature: FC = () => {
-	useDocumentTitle('Not Found - Bublik');
+import { useTabTitleWithPrefix } from '@/bublik/features/projects';
+
+export const NoMatchFeature = () => {
+	useTabTitleWithPrefix('Not Found - Bublik');
 
 	return <NotFound />;
 };

--- a/apps/bublik/src/pages/run-diff-page/run-diff-page.tsx
+++ b/apps/bublik/src/pages/run-diff-page/run-diff-page.tsx
@@ -3,7 +3,6 @@
 import { memo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-import { useDocumentTitle } from '@/shared/hooks';
 import { routes } from '@/router';
 import { usePrefetchImmediately } from '@/services/bublik-api';
 import {
@@ -19,7 +18,10 @@ import {
 	RunDetailsDiffContainer,
 	RunDiffContainer
 } from '@/bublik/features/run-diff';
-import { LinkWithProject } from '@/bublik/features/projects';
+import {
+	LinkWithProject,
+	useTabTitleWithPrefix
+} from '@/bublik/features/projects';
 
 export interface RunDiffHeaderProps {
 	leftRunId: string;
@@ -143,7 +145,7 @@ export const RunDiffPage = () => {
 	const leftRunId = searchParams.get('left');
 	const rightRunId = searchParams.get('right');
 
-	useDocumentTitle(`Diff - ${leftRunId} | ${rightRunId} - Bublik`);
+	useTabTitleWithPrefix(`Diff - ${leftRunId} | ${rightRunId} - Bublik`);
 
 	if (!leftRunId || !rightRunId) {
 		return (

--- a/apps/bublik/src/pages/run-report/run-report.page.tsx
+++ b/apps/bublik/src/pages/run-report/run-report.page.tsx
@@ -1,12 +1,13 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2024 OKTET LTD */
-import { useEffect } from 'react';
+import { skipToken } from '@reduxjs/toolkit/query';
+import { useParams } from 'react-router-dom';
 
 import { RunReportContainer } from '@/bublik/features/run-report';
-import { useGetRunDetailsQuery } from '@/services/bublik-api';
 import { formatTimeToDot } from '@/shared/utils';
-import { useParams } from 'react-router-dom';
-import { skipToken } from '@reduxjs/toolkit/query';
+import { useGetRunDetailsQuery } from '@/services/bublik-api';
+
+import { useTabTitleWithPrefix } from '@/bublik/features/projects';
 
 function RunReportPage() {
 	const { runId } = useParams<{ runId: string }>();
@@ -26,19 +27,15 @@ interface UseRunReportPageNameConfig {
 function useRunReportPageName({ runId }: UseRunReportPageNameConfig) {
 	const { data: details } = useGetRunDetailsQuery(runId ?? skipToken);
 
-	useEffect(() => {
-		if (!runId) return;
+	let title = 'Report - Bublik';
 
-		if (!details) {
-			document.title = 'Report - Bublik';
-			return;
-		}
-
+	if (runId && details) {
 		const { main_package: name, start } = details;
 		const formattedTime = formatTimeToDot(start);
+		title = `${name} | ${formattedTime} | ${runId} | Report - Bublik`;
+	}
 
-		document.title = `${name} | ${formattedTime} | ${runId} | Report - Bublik`;
-	}, [details, runId]);
+	useTabTitleWithPrefix(title);
 }
 
 export { RunReportPage };

--- a/apps/bublik/src/pages/runs-page/runs-page.tsx
+++ b/apps/bublik/src/pages/runs-page/runs-page.tsx
@@ -7,8 +7,38 @@ import {
 	SelectionPopoverContainer
 } from '@/bublik/features/runs';
 import { CopyShortUrlButtonContainer } from '@/bublik/features/copy-url';
+import { useTabTitleWithPrefix } from '@/bublik/features/projects';
+import { useSearchParams } from 'react-router-dom';
+import { formatTimeToDot, parseISODuration } from '@/shared/utils';
+import { formatDuration } from 'date-fns';
+
+function useRunsPageTitle() {
+	const [searchParams] = useSearchParams();
+
+	const startDate = searchParams.get('startDate') ?? '';
+	const endDate = searchParams.get('finishDate') ?? '';
+	const searchDuration = searchParams.get('duration') ?? '';
+	const calendarMode = searchParams.get('calendarMode') ?? '';
+
+	let title = 'Runs - Bublik';
+
+	if (startDate || endDate || searchDuration) {
+		if (calendarMode === 'default') {
+			const start = formatTimeToDot(startDate);
+			const end = formatTimeToDot(endDate);
+			title = `${start} - ${end} | Runs - Bublik`;
+		} else if (calendarMode === 'duration') {
+			const duration = parseISODuration(searchDuration);
+			title = `${formatDuration(duration)} | Runs - Bublik`;
+		}
+	}
+
+	useTabTitleWithPrefix(title);
+}
 
 function RunsPage() {
+	useRunsPageTitle();
+
 	return (
 		<>
 			<div className="flex flex-col gap-1 p-2">

--- a/libs/bublik/features/dashboard-v2/src/lib/hooks/index.ts
+++ b/libs/bublik/features/dashboard-v2/src/lib/hooks/index.ts
@@ -11,10 +11,8 @@ import {
 import { addDays } from 'date-fns';
 
 import {
-	bublikAPI,
 	useGetDashboardByDateQuery,
 	useGetDashboardModeQuery,
-	useGetDeployInfoQuery,
 	usePrefetch
 } from '@/services/bublik-api';
 import { useProjectSearch } from '@/bublik/features/projects';
@@ -149,36 +147,6 @@ export const useDashboardClock = () => {
 		),
 		refetch
 	};
-};
-
-export const useDashboardTitle = () => {
-	const { projectIds } = useProjectSearch();
-	const { data } = bublikAPI.useGetAllProjectsQuery();
-
-	useEffect(() => {
-		if (!data || data.length === 0) {
-			document.title = 'Dashboard - Bublik';
-			return;
-		}
-
-		const projectMapById = new Map(data.map((d) => [d.id, d.name]));
-
-		const selectedProjectNames = projectIds
-			.map((id) => projectMapById.get(id))
-			.filter(Boolean)
-			.join(' | ');
-
-		if (selectedProjectNames) {
-			document.title = `${selectedProjectNames} - Dashboard - Bublik`;
-		} else if (projectIds.length > 0) {
-			console.warn(
-				"could not map project id to data retrieved from backend, it' either stale or incorrect"
-			);
-			document.title = 'Dashboard - Bublik';
-		} else {
-			document.title = 'All - Dashboard - Bublik';
-		}
-	}, [data, projectIds]);
 };
 
 export const useDashboardMode = () => {

--- a/libs/bublik/features/history/src/lib/history-aggregation/history-aggregation.container.tsx
+++ b/libs/bublik/features/history/src/lib/history-aggregation/history-aggregation.container.tsx
@@ -14,6 +14,7 @@ import { HistoryEmpty } from '../history-empty';
 import { useHistoryActions } from '../slice';
 import { HistoryError } from '../history-error';
 import { useLocation } from 'react-router-dom';
+import { useTabTitleWithPrefix } from '@/bublik/features/projects';
 
 export const HistoryAggregationContainer = () => {
 	const actions = useHistoryActions();
@@ -22,6 +23,8 @@ export const HistoryAggregationContainer = () => {
 		useAggregationGlobalFilter();
 	const state = useLocation().state as { fromRun?: boolean };
 	const { query } = useHistoryQuery();
+
+	useTabTitleWithPrefix([query?.testName, 'Aggregation - History - Bublik']);
 
 	const { data, isLoading, isFetching, error } = useGetHistoryAggregationQuery(
 		query,
@@ -32,15 +35,6 @@ export const HistoryAggregationContainer = () => {
 		() => actions.toggleIsGlobalSearchOpen(true),
 		[actions]
 	);
-
-	useEffect(() => {
-		if (!query.testName) {
-			document.title = 'Linear - History - Bublik';
-			return;
-		}
-
-		document.title = `${query.testName} | Aggregation - History - Bublik`;
-	}, [query]);
 
 	if (!query.testName) {
 		return (

--- a/libs/bublik/features/history/src/lib/history-linear/history-linear.hooks.ts
+++ b/libs/bublik/features/history/src/lib/history-linear/history-linear.hooks.ts
@@ -1,10 +1,12 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { OnChangeFn } from '@tanstack/react-table';
 
 import { isFunction } from '@/shared/utils';
+
+import { useTabTitleWithPrefix } from '@/bublik/features/projects';
 
 import { HistoryLinearGlobalFilter } from './history-linear.types';
 import { selectLinearGlobalFilter, useHistoryActions } from '../slice';
@@ -43,12 +45,5 @@ export const useHistoryLinearGlobalFilter = () => {
 };
 
 export const useHistoryLinearTitle = (config: { testName?: string }) => {
-	useEffect(() => {
-		if (!config.testName) {
-			document.title = 'Linear - History - Bublik';
-			return;
-		}
-
-		document.title = `${config.testName} | Linear - History - Bublik`;
-	}, [config.testName]);
+	useTabTitleWithPrefix([config?.testName, 'Linear - History - Bublik']);
 };

--- a/libs/bublik/features/history/src/lib/history-measurements/plot-list.hooks.ts
+++ b/libs/bublik/features/history/src/lib/history-measurements/plot-list.hooks.ts
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { useEffect } from 'react';
+
 import { skipToken } from '@reduxjs/toolkit/query';
 
 import {
@@ -10,6 +10,7 @@ import {
 	useGetMeasurementsQuery
 } from '@/services/bublik-api';
 import { HISTORY_MAX_RESULTS_IDS } from '@/bublik/config';
+import { useTabTitleWithPrefix } from '@/bublik/features/projects';
 
 import { useHistoryQuery } from '../hooks';
 import { useCombinedCharts } from './combined-charts.context';
@@ -93,11 +94,7 @@ function useCombinedView() {
 }
 
 function useHistoryMeasurementsTitle(testName?: string) {
-	useEffect(() => {
-		document.title = testName
-			? `${testName} | Measurements - History - Bublik`
-			: 'Measurements - History - Bublik';
-	}, [testName]);
+	useTabTitleWithPrefix([testName, 'Measurements - History - Bublik']);
 }
 
 export {

--- a/libs/bublik/features/log/src/lib/log-feature.tsx
+++ b/libs/bublik/features/log/src/lib/log-feature.tsx
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { ReactNode, useEffect, useRef } from 'react';
+import { ReactNode, useRef } from 'react';
 import { skipToken } from '@reduxjs/toolkit/query';
 
 import { formatTimeToDot } from '@/shared/utils';
@@ -20,6 +20,7 @@ import { RunReportConfigsContainer } from '@/bublik/features/run-report';
 import { LogAttachmentsContainer } from '@/bublik/features/log-artifacts';
 import { NewBugContainer } from '@/bublik/features/log-preview-drawer';
 import { LinkToSourceContainer } from '@/bublik/features/link-to-source';
+import { useTabTitleWithPrefix } from '@/bublik/features/projects';
 
 import {
 	LinkToHistoryContainer,
@@ -35,20 +36,16 @@ function useLogTitle() {
 	const { data: details } = useGetRunDetailsQuery(runId ?? skipToken);
 	const { data: tree } = useGetTreeByRunIdQuery(runId ?? skipToken);
 
-	useEffect(() => {
-		if (!details) {
-			document.title = 'Log - Bublik';
-			return;
-		}
+	const formattedTime = details?.start ? formatTimeToDot(details.start) : '';
+	const focusedTestName = focusId ? tree?.tree?.[focusId]?.name : '';
 
-		const { main_package: name, start } = details;
-		const formattedTime = formatTimeToDot(start);
-		const focusedTestName = focusId ? tree?.tree?.[focusId]?.name : '';
-
-		document.title = `${
-			focusedTestName ? `${focusedTestName} - ` : ''
-		}${name} | ${formattedTime} | ${runId} | Log - Bublik`;
-	}, [details, runId, focusId, tree?.tree]);
+	useTabTitleWithPrefix([
+		focusedTestName,
+		details?.main_package,
+		formattedTime,
+		runId,
+		'Log - Bublik'
+	]);
 }
 
 export interface LogFeatureProps {

--- a/libs/bublik/features/measurements/src/lib/measurement.hooks.ts
+++ b/libs/bublik/features/measurements/src/lib/measurement.hooks.ts
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { useEffect } from 'react';
-
 import { formatTimeToDot } from '@/shared/utils';
+import { useTabTitleWithPrefix } from '@/bublik/features/projects';
 
 export type useMeasurementTitleConfig = {
 	name?: string;
@@ -15,14 +14,7 @@ export const useMeasurementTitle = ({
 	start,
 	runId
 }: useMeasurementTitleConfig) => {
-	useEffect(() => {
-		if (!name || !start || !runId) {
-			document.title = 'Measurements - Bublik';
-			return;
-		}
+	const formattedTime = start ? formatTimeToDot(start) : '';
 
-		const formattedTime = formatTimeToDot(start);
-
-		document.title = `${name} | ${formattedTime} | ${runId} | Measurements - Bublik`;
-	}, [name, runId, start]);
+	useTabTitleWithPrefix([name, formattedTime, runId, 'Measurements - Bublik']);
 };

--- a/libs/bublik/features/projects/src/hooks/index.ts
+++ b/libs/bublik/features/projects/src/hooks/index.ts
@@ -1,8 +1,7 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { toast } from 'sonner';
 import { z } from 'zod';
 import {
-	NavigateFunction,
 	NavigateOptions,
 	To,
 	useNavigate,
@@ -62,6 +61,22 @@ function useNavigateWithProject() {
 	return navigate;
 }
 
+function useTabTitleWithPrefix(title: string | (string | undefined)[]) {
+	const { projectIds } = useProjectSearch();
+	const { data: prefix } = bublikAPI.useGetTabTitlePrefixQuery(
+		{ projects: projectIds },
+		{ refetchOnMountOrArgChange: true }
+	);
+	useEffect(() => {
+		const titleParts = [
+			prefix,
+			...(Array.isArray(title) ? title.filter(Boolean) : [title])
+		].filter(Boolean);
+
+		document.title = titleParts.join(' - ');
+	}, [prefix, title]);
+}
+
 interface UseProjectParams {
 	id: number | null;
 }
@@ -97,4 +112,9 @@ function useDeleteProject({ id }: UseProjectParams) {
 	return { deleteProject };
 }
 
-export { useProjectSearch, useDeleteProject, useNavigateWithProject };
+export {
+	useProjectSearch,
+	useDeleteProject,
+	useNavigateWithProject,
+	useTabTitleWithPrefix
+};

--- a/libs/bublik/features/runs/src/lib/runs-form/runs-form.container.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-form/runs-form.container.tsx
@@ -1,21 +1,12 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import { getLocalTimeZone, parseDate } from '@internationalized/date';
-import {
-	formatDuration,
-	formatISODuration,
-	intervalToDuration,
-	sub
-} from 'date-fns';
+import { formatISODuration, intervalToDuration, sub } from 'date-fns';
 
-import {
-	formatTimeToAPI,
-	formatTimeToDot,
-	parseISODuration
-} from '@/shared/utils';
+import { formatTimeToAPI, parseISODuration } from '@/shared/utils';
 import { BUBLIK_TAG, bublikAPI } from '@/services/bublik-api';
 import { BoxValue } from '@/shared/tailwind-ui';
 import { useMount } from '@/shared/hooks';
@@ -30,7 +21,6 @@ function RunsFormContainer() {
 	const [searchParams, setSearchParams] = useSearchParams(location.search);
 	const localGlobalFilter = useSelector(selectGlobalFilter);
 	const allTags = useSelector(selectAllTags);
-	useRunsPageTitle();
 
 	useMount(() => {
 		const initialGlobalFilter =
@@ -169,35 +159,6 @@ function formToSearchParams(
 
 	params.set('page', '1');
 	return params;
-}
-
-function useRunsPageTitle() {
-	const [searchParams] = useSearchParams();
-
-	useEffect(() => {
-		const startDate = searchParams.get('startDate') ?? '';
-		const endDate = searchParams.get('finishDate') ?? '';
-		const searchDuration = searchParams.get('duration') ?? '';
-		const calendarMode = searchParams.get('calendarMode') ?? '';
-
-		if (!startDate && !endDate && !searchDuration) {
-			document.title = 'Runs - Bublik';
-			return;
-		}
-
-		if (calendarMode === 'default') {
-			const start = formatTimeToDot(startDate);
-			const end = formatTimeToDot(endDate);
-			document.title = `${start} - ${end} | Runs - Bublik`;
-			return;
-		}
-
-		if (calendarMode === 'duration') {
-			const duration = parseISODuration(searchDuration);
-			document.title = `${formatDuration(duration)} | Runs - Bublik`;
-			return;
-		}
-	}, [searchParams]);
 }
 
 export { RunsFormContainer };

--- a/libs/services/bublik-api/src/lib/endpoints/deploy-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/deploy-endpoints.ts
@@ -15,6 +15,12 @@ import { BUBLIK_TAG } from '../types';
 import { BublikBaseQueryFn, withApiV2 } from '../config';
 import { API_REDUCER_PATH } from '../constants';
 import { MaybePromise } from '../utils';
+import { z } from 'zod';
+import { config } from '@/bublik/config';
+
+const TabTitlePrefixResponseSchema = z.object({
+	tab_title_prefix: z.string().nullable()
+});
 
 export const deployEndpoints = {
 	endpoints: (
@@ -60,6 +66,21 @@ export const deployEndpoints = {
 				url: '/performance_check/',
 				params: { project: query.projects?.[0] }
 			})
+		}),
+		getTabTitlePrefix: build.query({
+			query: (query) => ({
+				url: withApiV2('/server/tab_title_prefix'),
+				params: {
+					project_id: query?.projects.length
+						? query?.projects?.join(config.queryDelimiter)
+						: undefined
+				}
+			}),
+			rawResponseSchema: TabTitlePrefixResponseSchema,
+			responseSchema: z.string().nullable(),
+			transformResponse: (resp: z.infer<typeof TabTitlePrefixResponseSchema>) =>
+				resp.tab_title_prefix,
+			argSchema: z.object({ projects: z.array(z.number()) }).optional()
 		})
 	})
 };


### PR DESCRIPTION
Fetch tab title prefix from an API, now users can add custom tab title prefix in config section for projects. When user specifies `TAB_TITLE_PREFIX` in config it's added based on currently selected project in the sidebar