### PR TITLE
perf(measurements): use canvas renderer for plots

### DIFF
--- a/libs/shared/charts/src/lib/echart.tsx
+++ b/libs/shared/charts/src/lib/echart.tsx
@@ -31,7 +31,7 @@ import {
 	TooltipComponent,
 	DataZoomComponentOption
 } from 'echarts/components';
-import { SVGRenderer } from 'echarts/renderers';
+import { CanvasRenderer } from 'echarts/renderers';
 import type {
 	SeriesOption,
 	XAXisComponentOption,
@@ -55,7 +55,7 @@ echarts.use([
 	LegendComponent,
 	PieChart,
 	BarChart,
-	SVGRenderer
+	CanvasRenderer
 ]);
 
 export type {


### PR DESCRIPTION
SVG renderer produces a lot of DOM elements which reduce performance on large plots. 
Swap to canvas renderer for improved performance