### PR TITLE
fix(log): [preview] fix incorrectly handling for first log page

### DIFF
--- a/libs/bublik/features/log-preview-drawer/src/log-preview-drawer.container.tsx
+++ b/libs/bublik/features/log-preview-drawer/src/log-preview-drawer.container.tsx
@@ -155,9 +155,11 @@ interface LogPreviewProps {
 function LogPreview(props: LogPreviewProps) {
 	const { runId, resultId } = props;
 	const [page, setPage] = useState<number | undefined>();
+	const resolvedPage = page === 1 ? undefined : page;
 	const { data, error, isLoading, isFetching } = useGetLogJsonQuery({
 		id: resultId,
-		page: typeof page !== 'undefined' ? page.toString() : undefined
+		page:
+			typeof resolvedPage !== 'undefined' ? resolvedPage.toString() : undefined
 	});
 	const {
 		data: runDetails,


### PR DESCRIPTION
We must not provide page parameter to API when user selects first page since first page is resolved to `node_id<id>.json` and not `node_id<id>_p1.json`.
Now when user selects second page and selects first one again it's not failing with 502 error.