### PR TITLE
fix(report): hide empty `arg-val-block` in report

### DIFF
--- a/libs/bublik/features/run-report/src/lib/run-report-test/run-report-test.component.tsx
+++ b/libs/bublik/features/run-report/src/lib/run-report-test/run-report-test.component.tsx
@@ -51,6 +51,10 @@ function RunReportTestBlock(props: RunReportTestBlockProps) {
 					})
 				);
 
+				const isEmpty =
+					Object.keys(argsValBlock.args_vals).length === 0 &&
+					!argsValBlock.label;
+
 				return (
 					<li
 						id={encodeURIComponent(argsValBlock.id)}
@@ -63,7 +67,10 @@ function RunReportTestBlock(props: RunReportTestBlockProps) {
 						/>
 						{/* LEVEL 2 */}
 						<div
-							className="border-y border-border-primary bg-white"
+							className={cn(
+								'border-y border-border-primary bg-white',
+								isEmpty && 'hidden'
+							)}
 							style={{ position: 'sticky', top: offsetTop, zIndex: 8 }}
 							ref={handleRef}
 						>

--- a/libs/bublik/features/run-report/src/lib/run-report.component.tsx
+++ b/libs/bublik/features/run-report/src/lib/run-report.component.tsx
@@ -79,14 +79,16 @@ function RunReportTableOfContents({ contents }: RunReportTableOfContentsProps) {
 		<div className="bg-white flex flex-col rounded">
 			<CardHeader label="Table Of Contents" />
 			<ul className="flex flex-col py-2">
-				{contents.map((item, idx, arr) => (
-					<li key={item.id}>
-						<TableOfContentsItem item={item} />
-						{idx < arr.length - 1 && (
-							<Separator orientation="horizontal" className="my-2" />
-						)}
-					</li>
-				))}
+				{contents.map((item, idx, arr) => {
+					return (
+						<li key={item.id}>
+							<TableOfContentsItem item={item} />
+							{idx < arr.length - 1 && (
+								<Separator orientation="horizontal" className="my-2" />
+							)}
+						</li>
+					);
+				})}
 			</ul>
 		</div>
 	);
@@ -121,7 +123,11 @@ function TableOfContentsItem({ item, depth = 0 }: TableOfContentsItemProps) {
 	return (
 		<Collapsible open={open} onOpenChange={setOpen} className="">
 			<div
-				className="flex items-center gap-1 h-[22px] pr-2"
+				className={cn(
+					'flex items-center gap-1 h-[22px] pr-2',
+					// In case of an empty label, hide the item (argument values block might be empty)
+					!item.label && 'hidden'
+				)}
 				style={{ paddingLeft: `${depth * 12 + 16}px` }}
 			>
 				<div className="border h-full rounded border-transparent px-1 hover:border-primary flex items-center gap-1 w-full">


### PR DESCRIPTION
Sometime report might contain empty arg vals block in this case it's best to not display it and hide