### PR TITLE
feat(run): add link to run straight to iteration

### DIFF
--- a/apps/bublik/src/styles/tailwind.css
+++ b/apps/bublik/src/styles/tailwind.css
@@ -8,6 +8,22 @@ body {
 	font-family: var(--fonts-body);
 }
 
+@keyframes borderPulse {
+	0% {
+		border-color: transparent;
+	}
+	50% {
+		border-color: hsl(var(--colors-primary));
+	}
+	100% {
+		border-color: transparent;
+	}
+}
+
+.animate-border-pulse {
+	animation: borderPulse 1s ease-in-out 6;
+}
+
 html,
 body,
 #root {

--- a/libs/bublik/features/history/src/lib/history-linear/column-components/links/links.tsx
+++ b/libs/bublik/features/history/src/lib/history-linear/column-components/links/links.tsx
@@ -36,7 +36,12 @@ export const Links = ({ row }: LinksProps) => {
 				</LinkWithProject>
 			</ButtonTw>
 			<ButtonTw asChild size="xss" variant="secondary">
-				<LinkWithProject to={routes.run({ runId: row.run_id })}>
+				<LinkWithProject
+					to={routes.run({
+						runId: row.run_id,
+						targetIterationId: Number(row.result_id)
+					})}
+				>
 					<Icon name="BoxArrowRight" className="mr-1.5" />
 					Run
 				</LinkWithProject>

--- a/libs/bublik/features/log-preview-drawer/src/log-preview-drawer.container.tsx
+++ b/libs/bublik/features/log-preview-drawer/src/log-preview-drawer.container.tsx
@@ -111,7 +111,10 @@ function LogPreviewContainer(
 											{runId ? (
 												<ButtonTw asChild variant="secondary" size="xss">
 													<LinkWithProject
-														to={routes.run({ runId })}
+														to={routes.run({
+															runId,
+															targetIterationId: resultId
+														})}
 														target="_blank"
 													>
 														<Icon name="BoxArrowRight" className="mr-1.5" />

--- a/libs/bublik/features/log/src/lib/components/link-to-run/component.tsx
+++ b/libs/bublik/features/log/src/lib/components/link-to-run/component.tsx
@@ -1,18 +1,25 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import { routes } from '@/router';
 import { ButtonTw, Icon } from '@/shared/tailwind-ui';
 import { LinkWithProject } from '@/bublik/features/projects';
 
 export interface LinkToRunProps {
 	runId: string;
+	targetIterationId?: number | null;
 }
 
-export function LinkToRun({ runId }: LinkToRunProps) {
-	const to = { pathname: `/runs/${runId}` };
+export function LinkToRun(props: LinkToRunProps) {
+	const { runId, targetIterationId } = props;
 
 	return (
 		<ButtonTw asChild variant="secondary" size="xss">
-			<LinkWithProject to={to}>
+			<LinkWithProject
+				to={routes.run({
+					runId,
+					targetIterationId: targetIterationId ?? undefined
+				})}
+			>
 				<Icon name="BoxArrowRight" className="mr-1.5" />
 				Run
 			</LinkWithProject>

--- a/libs/bublik/features/log/src/lib/log-feature.tsx
+++ b/libs/bublik/features/log/src/lib/log-feature.tsx
@@ -96,7 +96,7 @@ function LogFeature(props: LogFeatureProps) {
 								runId={Number(runId)}
 								focusId={focusId}
 							/>
-							<LinkToRun runId={runId} />
+							<LinkToRun runId={runId} targetIterationId={focusId} />
 							<LinkToHistoryContainer runId={runId} focusId={focusId} />
 							<LinkToMeasurementsContainer focusId={focusId} />
 							<RunReportConfigsContainer runId={runId} />

--- a/libs/bublik/features/measurements/src/lib/containers/measurement-statistics/link-to-run.tsx
+++ b/libs/bublik/features/measurements/src/lib/containers/measurement-statistics/link-to-run.tsx
@@ -1,19 +1,25 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import { routes } from '@/router';
 import { ButtonTw, Icon } from '@/shared/tailwind-ui';
 import { LinkWithProject } from '@/bublik/features/projects';
 
-export interface LinkToRunProps {
+interface LinkToRunProps {
 	runId: string;
+	targetIterationId?: number;
 }
 
-export const LinkToRun = ({ runId }: LinkToRunProps) => {
+function LinkToRun(props: LinkToRunProps) {
+	const { runId, targetIterationId } = props;
+
 	return (
 		<ButtonTw asChild variant="secondary" size="xss">
-			<LinkWithProject to={`/runs/${runId}`}>
+			<LinkWithProject to={routes.run({ runId, targetIterationId })}>
 				<Icon name="BoxArrowRight" className="mr-1.5" />
 				Run
 			</LinkWithProject>
 		</ButtonTw>
 	);
-};
+}
+
+export { LinkToRun };

--- a/libs/bublik/features/measurements/src/lib/containers/measurement-statistics/measurement-statistics.container.tsx
+++ b/libs/bublik/features/measurements/src/lib/containers/measurement-statistics/measurement-statistics.container.tsx
@@ -27,7 +27,7 @@ export const MeasurementStatisticsLoading: FC<
 		<div className="flex-shrink-0 w-full bg-white rounded-md">
 			<CardHeader label="Test result">
 				<div className="flex items-center gap-3">
-					<LinkToRun runId={runId} />
+					<LinkToRun runId={runId} targetIterationId={Number(resultId)} />
 					<LinkToHistory runId={runId} resultId={resultId} />
 					<LinkToLog runId={runId} resultId={resultId} />
 				</div>
@@ -105,7 +105,7 @@ export const MeasurementStatisticsContainer: FC = () => {
 		<div className="flex-shrink-0 w-full bg-white rounded-md">
 			<CardHeader label="Test result">
 				<div className="flex items-center gap-3">
-					<LinkToRun runId={runId} />
+					<LinkToRun runId={runId} targetIterationId={Number(resultId)} />
 					<LinkToHistory runId={runId} resultId={resultId} />
 					<LinkToLog runId={runId} resultId={resultId} />
 					<CopyShortUrlButtonContainer />

--- a/libs/bublik/features/result-links/src/lib/result-links.container.tsx
+++ b/libs/bublik/features/result-links/src/lib/result-links.container.tsx
@@ -46,7 +46,7 @@ export const ResultLinks = (props: ResultLinksProps) => {
 					<li className="pl-2">
 						<LinkWithProject
 							className="flex items-center w-full gap-1"
-							to={routes.run({ runId })}
+							to={routes.run({ runId, targetIterationId: resultId })}
 						>
 							<Icon name="Paper" className="size-5" />
 							Run {runId}

--- a/libs/bublik/features/run/src/lib/result-table/result-table.container.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.container.tsx
@@ -84,39 +84,29 @@ export function ResultTableContainer(props: ResultTableContainerProps) {
 		[updateRowState, rowId, rowState]
 	);
 
-	const getRowProps = useCallback<
-		NonNullable<TwTableProps<RunDataResults>['getRowProps']>
-	>(
-		(_, row) => {
-			const className =
-				rowState?.referenceDiffRowId === row.id ? 'border-primary' : '';
+	const onRowClick = useCallback(
+		(row: Row<RunDataResults>) => {
+			if (rowState?.mode === 'default' || !rowState?.mode) return;
 
-			return {
-				className,
-				onClick: () => {
-					if (rowState?.mode === 'default' || !rowState?.mode) return;
-
-					if (rowState?.referenceDiffRowId === row.id) {
-						updateRowState({
-							...rowState,
-							rowId,
-							referenceDiffRowId: undefined,
-							requests: rowState?.requests,
-							mode: 'diff'
-						});
-					} else {
-						updateRowState({
-							...rowState,
-							rowId,
-							referenceDiffRowId: row.id,
-							requests: rowState?.requests,
-							mode: 'diff'
-						});
-					}
-				}
-			};
+			if (rowState?.referenceDiffRowId === row.id) {
+				updateRowState({
+					...rowState,
+					rowId,
+					referenceDiffRowId: undefined,
+					requests: rowState?.requests,
+					mode: 'diff'
+				});
+			} else {
+				updateRowState({
+					...rowState,
+					rowId,
+					referenceDiffRowId: row.id,
+					requests: rowState?.requests,
+					mode: 'diff'
+				});
+			}
 		},
-		[rowId, rowState, updateRowState]
+		[row.id, rowId, rowState, updateRowState]
 	);
 
 	if (isError) return <div className="">Something went wrong...</div>;
@@ -130,13 +120,14 @@ export function ResultTableContainer(props: ResultTableContainerProps) {
 			showLinkToRun={Array.isArray(runId)}
 			data={data}
 			rowId={rowId}
-			getRowProps={getRowProps}
 			height={height}
 			mode={rowState?.mode}
 			setMode={setMode}
 			showToolbar={showToolbar}
 			setShowToolbar={setShowToolbar}
 			targetIterationId={targetIterationId}
+			rowState={rowState}
+			onRowClick={onRowClick}
 		/>
 	);
 }

--- a/libs/bublik/features/run/src/lib/result-table/result-table.container.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.container.tsx
@@ -28,13 +28,11 @@ export interface ResultTableContainerProps {
 	runId: string | string[];
 	row: Row<RunData | MergedRun>;
 	height: number;
+	targetIterationId?: number;
 }
 
-export const ResultTableContainer = ({
-	runId,
-	row,
-	height
-}: ResultTableContainerProps) => {
+export function ResultTableContainer(props: ResultTableContainerProps) {
+	const { runId, row, height, targetIterationId } = props;
 	const { id: rowId } = row;
 	const rowState = useRunTableRowState().rowState[rowId];
 	const { updateRowState } = useRunTableRowState();
@@ -92,6 +90,7 @@ export const ResultTableContainer = ({
 		(_, row) => {
 			const className =
 				rowState?.referenceDiffRowId === row.id ? 'border-primary' : '';
+
 			return {
 				className,
 				onClick: () => {
@@ -137,6 +136,7 @@ export const ResultTableContainer = ({
 			setMode={setMode}
 			showToolbar={showToolbar}
 			setShowToolbar={setShowToolbar}
+			targetIterationId={targetIterationId}
 		/>
 	);
-};
+}

--- a/libs/bublik/features/run/src/lib/run-table/components/row/row.tsx
+++ b/libs/bublik/features/run/src/lib/run-table/components/row/row.tsx
@@ -12,9 +12,10 @@ import { useMeasure } from 'react-use';
 export interface RowProps {
 	row: Row<RunData | MergedRun>;
 	runId: string | string[];
+	targetIterationId?: number;
 }
 
-export const RunRow = ({ row, runId }: RowProps) => {
+export const RunRow = ({ row, runId, targetIterationId }: RowProps) => {
 	const isExpanded = row.getIsExpanded();
 	const isTest = row.original?.type === NodeEntity.Test;
 	const isExpandedTest = isTest && isExpanded;
@@ -56,7 +57,12 @@ export const RunRow = ({ row, runId }: RowProps) => {
 				<tr role="row">
 					<td colSpan={row.getVisibleCells().length} className="p-0 bg-white">
 						<div style={{ paddingLeft: `${row.depth * 0.8}rem` }}>
-							<ResultTableContainer runId={runId} row={row} height={height} />
+							<ResultTableContainer
+								runId={runId}
+								row={row}
+								height={height}
+								targetIterationId={targetIterationId}
+							/>
 						</div>
 					</td>
 				</tr>

--- a/libs/bublik/features/run/src/lib/run-table/run-table.component.tsx
+++ b/libs/bublik/features/run/src/lib/run-table/run-table.component.tsx
@@ -101,6 +101,7 @@ export interface RunTableProps {
 	isFetching?: boolean;
 	runId: string | string[];
 	projectId?: number;
+	targetIterationId?: number;
 }
 
 export const RunTable = (props: RunTableProps) => {
@@ -118,7 +119,8 @@ export const RunTable = (props: RunTableProps) => {
 		onColumnVisibilityChange,
 		isFetching,
 		runId,
-		projectId
+		projectId,
+		targetIterationId
 	} = props;
 
 	const columns = useMemo(
@@ -151,11 +153,14 @@ export const RunTable = (props: RunTableProps) => {
 		autoResetAll: false
 	});
 
-	const { showUnexpected, expandUnexpected } = useExpandUnexpected({ table });
+	const { showUnexpected, expandUnexpected, expandToIteration } =
+		useExpandUnexpected({ table });
 
 	useMount(() => {
 		if (openUnexpected) showUnexpected();
 		if (openUnexpectedResults) expandUnexpected();
+		if (targetIterationId) expandToIteration(targetIterationId);
+
 		if (shouldMigrateExpandedState(expanded)) {
 			migrateExpandedStateUrl(expanded, table.getCoreRowModel().rowsById);
 		}
@@ -189,7 +194,12 @@ export const RunTable = (props: RunTableProps) => {
 					<RunHeader instance={table} />
 					<tbody className="text-[0.75rem] leading-[1.125rem] font-medium [&>*:not(:last-child)>*]:border-b [&>*:not(:last-child)>*]:border-border-primary">
 						{table.getRowModel().rows.map((row) => (
-							<RunRow key={row.id} row={row} runId={runId} />
+							<RunRow
+								key={row.id}
+								row={row}
+								runId={runId}
+								targetIterationId={targetIterationId}
+							/>
 						))}
 					</tbody>
 				</table>

--- a/libs/bublik/features/run/src/lib/run-table/run-table.container.tsx
+++ b/libs/bublik/features/run/src/lib/run-table/run-table.container.tsx
@@ -48,7 +48,8 @@ export const RunTableContainer = ({ runId }: RunTableContainerProps) => {
 		setExpanded,
 		setGlobalFilter,
 		setSorting,
-		sorting
+		sorting,
+		targetIterationId
 	} = useRunTableQueryState(data);
 
 	if (error || detailsQuery.error) {
@@ -76,6 +77,7 @@ export const RunTableContainer = ({ runId }: RunTableContainerProps) => {
 				columnVisibility={columnVisibility}
 				onColumnVisibilityChange={setColumnVisibility}
 				isFetching={isFetching}
+				targetIterationId={targetIterationId}
 			/>
 		</RunRowStateContextProvider>
 	);

--- a/libs/bublik/features/run/src/lib/run-table/run-table.hooks.ts
+++ b/libs/bublik/features/run/src/lib/run-table/run-table.hooks.ts
@@ -2,7 +2,12 @@
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
 import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
-import { useQueryParam, JsonParam, withDefault } from 'use-query-params';
+import {
+	useQueryParam,
+	JsonParam,
+	withDefault,
+	NumberParam
+} from 'use-query-params';
 import {
 	ExpandedState,
 	Row,
@@ -118,18 +123,29 @@ export function migrateExpandedState(
 export function shouldMigrateExpandedState(expanded: ExpandedState): boolean {
 	return Object.keys(expanded).some((key) => key.includes('.'));
 }
+
 export function migrateExpandedStateUrl(
 	oldExpanded: ExpandedState,
 	rows: Record<string, Row<RunData | MergedRun>>
 ) {
 	const newExpanded = migrateExpandedState(oldExpanded, rows);
 	const currentUrl = new URL(window.location.href);
+
 	try {
 		const expandedJson = JSON.stringify(newExpanded);
 		currentUrl.searchParams.set('expanded', expandedJson);
 	} catch (error) {
 		console.error('Failed to stringify expanded state:', error, newExpanded);
 	}
+}
+
+export function useTargetIterationId() {
+	const [targetIterationId, setTargetIterationId] = useQueryParam(
+		'targetIterationId',
+		NumberParam
+	);
+
+	return { targetIterationId, setTargetIterationId };
 }
 
 export const useRunTableQueryState = (
@@ -139,6 +155,7 @@ export const useRunTableQueryState = (
 		openUnexpected?: boolean;
 		openUnexpectedResults?: boolean;
 	};
+	const { targetIterationId } = useTargetIterationId();
 
 	const [expanded, setExpanded] = useQueryParam<ExpandedState>(
 		'expanded',
@@ -181,7 +198,8 @@ export const useRunTableQueryState = (
 		setRowState,
 		columnVisibility,
 		setColumnVisibility,
-		rowStateContext
+		rowStateContext,
+		targetIterationId: targetIterationId ?? undefined
 	};
 };
 

--- a/libs/bublik/router/src/lib/router.ts
+++ b/libs/bublik/router/src/lib/router.ts
@@ -31,7 +31,11 @@ const buildRoute =
 
 export const routes = {
 	dashboard: buildRoute<DashboardConfig>({ getPathname: () => `/dashboard` }),
-	run: buildRoute<RunConfig>({ getPathname: ({ runId }) => `/runs/${runId}` }),
+	run: buildRoute<RunConfig>({
+		getPathname: ({ runId }) => `/runs/${runId}`,
+		getSearch: ({ targetIterationId }) =>
+			targetIterationId ? `targetIterationId=${targetIterationId}` : ''
+	}),
 	history: buildRoute<HistoryConfig>({ getPathname: () => `/history` }),
 	log: buildRoute<LogConfig>({
 		getPathname: ({ runId }) => `/log/${runId}`,

--- a/libs/bublik/router/src/lib/types.ts
+++ b/libs/bublik/router/src/lib/types.ts
@@ -9,6 +9,7 @@ import {
 
 export type RunConfig = {
 	runId: number | string;
+	targetIterationId?: number;
 };
 
 export type DashboardConfig = {


### PR DESCRIPTION
When user sees some test iteration log and want to navigate to run we currently navigate just to run page without anchor to this iteration now we can optionally pass `targetIterationId` which will help to open run and scroll into view iteration user saw on the log page or any other page so user can understand where this test is located.