### PR TITLE
feat(url): add ability to copy short URL with page state or without

### DIFF
--- a/libs/bublik/features/copy-url/src/index.tsx
+++ b/libs/bublik/features/copy-url/src/index.tsx
@@ -5,32 +5,47 @@ import { useLocation } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import { useLazyGetShortUrlQuery } from '@/services/bublik-api';
-import { ButtonTw, CommandItem, Icon, Tooltip } from '@/shared/tailwind-ui';
+import { CommandItem, Icon, SplitButton, Tooltip } from '@/shared/tailwind-ui';
 import { useCopyToClipboard } from '@/shared/hooks';
 import { config } from '@/bublik/config';
+
+interface CopyShortUrlConfig {
+	includeSearchParams?: boolean;
+}
 
 interface UseCopyShortUrlConfig {
 	url: string;
 }
 
-function useCopyShortUrl(config: UseCopyShortUrlConfig) {
+function useCopyShortUrl(hookConfig: UseCopyShortUrlConfig) {
 	const [getShortUrl] = useLazyGetShortUrlQuery();
 	const [, copyText] = useCopyToClipboard();
 
-	const copy = useCallback(async () => {
-		try {
-			const promise = getShortUrl({ url: config.url });
-			const { short_url } = await promise.unwrap();
-			toast.promise(promise, {
-				loading: 'Generating a short URL...',
-				error: 'Could not copy the short URL. Please try again.',
-				success: 'Short URL copied to clipboard successfully!'
-			});
-			copyText(short_url);
-		} catch (_) {
-			toast.error('Could not copy the short URL. Please try again.');
-		}
-	}, [config.url, copyText, getShortUrl]);
+	const copy = useCallback(
+		async (copyConfig?: CopyShortUrlConfig) => {
+			const { includeSearchParams = true } = copyConfig || {};
+
+			try {
+				const urlObj = new URL(hookConfig.url);
+				if (!includeSearchParams) urlObj.search = '';
+				const finalUrl = urlObj.toString();
+
+				const promise = getShortUrl({ url: finalUrl });
+				const { short_url } = await promise.unwrap();
+
+				toast.promise(promise, {
+					loading: 'Generating a short URL...',
+					error: 'Could not copy the short URL. Please try again.',
+					success: 'Short URL copied to clipboard successfully!'
+				});
+
+				copyText(short_url);
+			} catch (_) {
+				toast.error('Could not copy the short URL. Please try again.');
+			}
+		},
+		[hookConfig.url, copyText, getShortUrl]
+	);
 
 	return { copyShortUrl: copy };
 }
@@ -43,48 +58,80 @@ function resolveFullUrl(location: ReturnType<typeof useLocation>) {
 	return `${window.location.origin}${config.baseUrl}${location.pathname}${location.search}`;
 }
 
-function CopyShortUrlButtonContainer({
-	variant = 'card'
-}: CopyShortUrlButtonContainerProps) {
+function CopyShortUrlButtonContainer(props: CopyShortUrlButtonContainerProps) {
+	const { variant = 'card' } = props;
 	const location = useLocation();
-	const { copyShortUrl } = useCopyShortUrl({
-		url: resolveFullUrl(location)
-	});
+	const { copyShortUrl } = useCopyShortUrl({ url: resolveFullUrl(location) });
 
 	return (
-		<Tooltip content="Copy short URL to clipboard">
-			<ButtonTw
-				variant={variant === 'card' ? 'secondary' : 'outline'}
-				size={variant === 'card' ? 'xss' : 'md'}
-				onClick={copyShortUrl}
-			>
-				<Icon
-					name="Upload"
-					size={variant === 'card' ? 20 : 24}
-					className={variant === 'card' ? '' : 'text-primary'}
-				/>
-			</ButtonTw>
-		</Tooltip>
+		<SplitButton.Root
+			variant={variant === 'card' ? 'secondary' : 'outline'}
+			size={variant === 'card' ? 'xss' : 'md'}
+		>
+			<Tooltip content="Copy short URL to clipboard with page state">
+				<SplitButton.Button
+					onClick={() => copyShortUrl({ includeSearchParams: true })}
+				>
+					<Icon
+						name="Upload"
+						size={variant === 'card' ? 20 : 24}
+						className={variant === 'card' ? '' : 'text-primary'}
+					/>
+				</SplitButton.Button>
+			</Tooltip>
+			<SplitButton.Separator orientation="vertical" className="h-5" />
+			<SplitButton.Trigger className={variant === 'header' ? 'py-[10px]' : ''}>
+				<Icon name="ArrowShortTop" size={18} className="rotate-180" />
+			</SplitButton.Trigger>
+			<SplitButton.Content className="z-50" align="end">
+				<SplitButton.Label>Copy URL</SplitButton.Label>
+				<SplitButton.Separator className="my-1" />
+				<Tooltip
+					content="Copy short URL to clipboard with page state"
+					side="right"
+					sideOffset={8}
+				>
+					<SplitButton.Item
+						onClick={() => copyShortUrl({ includeSearchParams: true })}
+					>
+						<Icon name="PaperStack" size={20} className="text-primary" />
+						<span>With Page State</span>
+					</SplitButton.Item>
+				</Tooltip>
+				<Tooltip
+					content="Copy short URL to clipboard without page state"
+					side="right"
+					sideOffset={8}
+				>
+					<SplitButton.Item
+						onClick={() => copyShortUrl({ includeSearchParams: false })}
+					>
+						<Icon name="PaperStack" size={20} className="text-primary" />
+						<span>Without Page State</span>
+					</SplitButton.Item>
+				</Tooltip>
+			</SplitButton.Content>
+		</SplitButton.Root>
 	);
 }
 
 interface CopyShortUrlCommandItemContainerProps {
 	onComplete?: () => void;
+	includeSearchParams?: boolean;
 }
 
 function CopyShortUrlCommandItemContainer(
 	props: CopyShortUrlCommandItemContainerProps
 ) {
+	const { includeSearchParams = true, onComplete } = props;
 	const location = useLocation();
-	const { copyShortUrl } = useCopyShortUrl({
-		url: resolveFullUrl(location)
-	});
+	const { copyShortUrl } = useCopyShortUrl({ url: resolveFullUrl(location) });
 
 	return (
 		<CommandItem
 			onSelect={() => {
-				copyShortUrl();
-				props?.onComplete?.();
+				copyShortUrl({ includeSearchParams });
+				onComplete?.();
 			}}
 		>
 			<Icon name="Upload" className="w-4 h-4 mr-2" />

--- a/libs/bublik/features/result-links/src/lib/link-to-history/link-to-history.tsx
+++ b/libs/bublik/features/result-links/src/lib/link-to-history/link-to-history.tsx
@@ -35,7 +35,7 @@ export const LinkToHistory = (props: LinkToHistoryProps) => {
 			</SplitButton.Button>
 			<SplitButton.Separator orientation="vertical" className="h-5" />
 			<SplitButton.Trigger>
-				<Icon name="ChevronDown" size={14} />
+				<Icon name="ArrowShortTop" size={18} className="rotate-180" />
 			</SplitButton.Trigger>
 			<SplitButton.Content align="start">
 				<SplitButton.Label>Open Direct Search</SplitButton.Label>

--- a/libs/shared/tailwind-ui/src/lib/split-button/split-button.component.tsx
+++ b/libs/shared/tailwind-ui/src/lib/split-button/split-button.component.tsx
@@ -25,7 +25,12 @@ const SplitButtonRoot = React.forwardRef<
 	return (
 		<div
 			ref={ref}
-			className={cn('inline-flex group items-center', className)}
+			className={cn(
+				'inline-flex group items-center',
+				variant === 'outline' && 'border rounded-md',
+				variant === 'secondary' && 'bg-primary-wash',
+				className
+			)}
 			{...props}
 		>
 			<SplitButtonContext.Provider value={value}>
@@ -45,7 +50,11 @@ const SplitButtonButton = React.forwardRef<
 	return (
 		<ButtonTw
 			ref={ref}
-			className={cn('rounded-r-none', isOutline && 'border-r-0', className)}
+			className={cn(
+				'rounded-r-none border-none',
+				isOutline && 'border-r-0',
+				className
+			)}
 			{...context}
 			{...props}
 		>
@@ -65,7 +74,12 @@ const SplitButtonTrigger = React.forwardRef<
 		<DropdownMenu.Trigger asChild>
 			<ButtonTw
 				ref={ref}
-				className={cn('rounded-l-none', isOutline && 'border-l-0', className)}
+				className={cn(
+					'rounded-l-none border-none',
+					isOutline && 'border-l-0',
+					'rdx-state-open:bg-primary rdx-state-open:text-white h-full',
+					className
+				)}
 				{...context}
 				{...props}
 			>


### PR DESCRIPTION
Sometimes users want to copy short link to page without containing long list of search parameters with all of the page state. Add dropdown menu to copy short link button with options to create short link with full page state or without.