### PR TITLE
feat(history): [aggregation] add important tags to results hover card

### DIFF
--- a/libs/bublik/features/history/src/lib/history-aggregation/column-components/aggregation-tooltip/aggregation-tooltip.tsx
+++ b/libs/bublik/features/history/src/lib/history-aggregation/column-components/aggregation-tooltip/aggregation-tooltip.tsx
@@ -1,40 +1,57 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { FC, ReactNode, useMemo } from 'react';
+import { ReactNode, useMemo } from 'react';
+import { format, parseISO } from 'date-fns';
 
-import { BadgeListItem, BadgeList, HoverCard } from '@/shared/tailwind-ui';
+import {
+	BadgeListItem,
+	BadgeList,
+	HoverCard,
+	Icon
+} from '@/shared/tailwind-ui';
 
-export interface BadgesCardList {
+interface BadgesCardListProps {
 	startDate: string;
 	badges: BadgeListItem[];
 }
 
-const BadgesCardList: FC<BadgesCardList> = (props) => {
+function BadgesCardList(props: BadgesCardListProps) {
 	const { startDate, badges } = props;
 
 	return (
-		<div className="flex flex-col max-w-md gap-2 p-2 bg-white rounded-lg shadow-popover">
-			<p className="text-[0.875rem] leading-[1.125rem]">
-				<span className="text-[0.875rem] font-semibold">Start Date:</span>
-				<span> {startDate}</span>
-			</p>
+		<div className="flex flex-col w-80 gap-3 p-4 bg-white rounded-xl shadow-lg border border-gray-100">
+			<div className="flex items-center gap-2 pb-2 border-b border-gray-100">
+				<Icon name="Clock" size={18} />
+				<p className="text-sm text-gray-600">
+					<span className="text-sm text-text-primary font-semibold">
+						Start Date:
+					</span>
+					<span className="ml-1.5 text-sm text-gray-800">
+						{format(parseISO(startDate), 'MMMM d, yyyy')}
+					</span>
+				</p>
+			</div>
 			<BadgeList badges={badges} />
 		</div>
 	);
-};
+}
 
-export interface AggregationTooltipProps {
-	badges: string[];
+interface AggregationTooltipProps {
+	relevantTags: string[];
+	importantTags: string[];
 	startDate: string;
 	children?: ReactNode;
 }
 
-export const AggregationTooltip: FC<AggregationTooltipProps> = (props) => {
-	const { badges, children, startDate } = props;
+function AggregationTooltip(props: AggregationTooltipProps) {
+	const { relevantTags, importantTags, startDate, children } = props;
 
-	const badgesWithColor = useMemo(
-		() => badges.map((badge) => ({ payload: badge })),
-		[badges]
+	const badgesWithColor = useMemo<BadgeListItem[]>(
+		() => [
+			...importantTags.map((tag) => ({ payload: tag, isImportant: true })),
+			...relevantTags.map((tag) => ({ payload: tag }))
+		],
+		[relevantTags, importantTags]
 	);
 
 	return (
@@ -46,4 +63,6 @@ export const AggregationTooltip: FC<AggregationTooltipProps> = (props) => {
 			{children}
 		</HoverCard>
 	);
-};
+}
+
+export { AggregationTooltip };

--- a/libs/bublik/features/history/src/lib/history-aggregation/column-components/results-list/results-list.tsx
+++ b/libs/bublik/features/history/src/lib/history-aggregation/column-components/results-list/results-list.tsx
@@ -33,7 +33,8 @@ export const LinkList = ({ results }: LinkListProps) => {
 				return (
 					<AggregationTooltip
 						key={resultData.result_id}
-						badges={resultData.relevant_tags}
+						relevantTags={resultData.relevant_tags}
+						importantTags={resultData.important_tags}
 						startDate={resultData.start_date}
 					>
 						<LinkWithProject

--- a/libs/shared/tailwind-ui/src/lib/hover-card/hover-card.tsx
+++ b/libs/shared/tailwind-ui/src/lib/hover-card/hover-card.tsx
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { FC, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import * as RadixHoverCard from '@radix-ui/react-hover-card';
 
 import { cva } from '../utils';
@@ -30,7 +30,7 @@ export interface HoverCardProps extends RadixHoverCard.HoverCardProps {
 	align?: RadixHoverCard.HoverCardContentProps['align'];
 }
 
-export const HoverCard: FC<HoverCardProps> = (props) => {
+export const HoverCard = (props: HoverCardProps) => {
 	const {
 		children,
 		content,
@@ -50,7 +50,7 @@ export const HoverCard: FC<HoverCardProps> = (props) => {
 
 			<RadixHoverCard.Portal container={container}>
 				<RadixHoverCard.Content
-					className={hoverCardContentStyles()}
+					className={hoverCardContentStyles({ className: 'p-1' })}
 					side={side}
 					sideOffset={sideOffset}
 					align={align}

--- a/libs/shared/types/src/lib/history.ts
+++ b/libs/shared/types/src/lib/history.ts
@@ -135,6 +135,7 @@ export type ResultDataArrayObj = {
 	run_id: number;
 	start_date: string;
 	relevant_tags: string[];
+	important_tags: string[];
 };
 
 /**


### PR DESCRIPTION
We were missing important tags for results in hover card when user hovering over result in grouped history mode.

Changes:
- Add important tags to history aggregation results hover card