### PR TITLE
Improve history and report charts

### DIFF
--- a/libs/bublik/features/history/src/lib/history-measurements-combined/history-measurements-combined.container.tsx
+++ b/libs/bublik/features/history/src/lib/history-measurements-combined/history-measurements-combined.container.tsx
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { ComponentProps, useMemo, useState } from 'react';
+import { ComponentProps, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { Point } from '@/shared/types';
@@ -28,7 +28,19 @@ function HistoryMeasurementsCombinedContainer() {
 	} = useGetHistoryMeasurementsByResult();
 	const [point, setPoint] = useState<Point | null>(null);
 	const [isPointDialogOpen, setIsPointDialogOpen] = useState(false);
-	const { selectedGroup, selectedCharts } = useCombinedView();
+	const { selectedGroup, selectedCharts, syncChartsFromData } =
+		useCombinedView();
+
+	useEffect(() => {
+		if (!data || !byResult) return;
+
+		const allCharts = [
+			...data,
+			...byResult.flatMap((c) => c.measurement_series_charts)
+		];
+
+		syncChartsFromData(allCharts);
+	}, [data, byResult, syncChartsFromData]);
 
 	const plots = useMemo(() => {
 		if (!data) return [];

--- a/libs/bublik/features/history/src/lib/history-measurements-combined/history-measurements-combined.container.tsx
+++ b/libs/bublik/features/history/src/lib/history-measurements-combined/history-measurements-combined.container.tsx
@@ -28,7 +28,7 @@ function HistoryMeasurementsCombinedContainer() {
 	} = useGetHistoryMeasurementsByResult();
 	const [point, setPoint] = useState<Point | null>(null);
 	const [isPointDialogOpen, setIsPointDialogOpen] = useState(false);
-	const { selectedGroup } = useCombinedView();
+	const { selectedGroup, selectedCharts } = useCombinedView();
 
 	const plots = useMemo(() => {
 		if (!data) return [];
@@ -45,8 +45,13 @@ function HistoryMeasurementsCombinedContainer() {
 
 		const plotIds = plotIdsStr.split(';').map(String);
 
-		return allCharts.filter((p) => plotIds.includes(String(p.id)));
-	}, [byResult, data, searchParams]);
+		return allCharts
+			.filter((p) => plotIds.includes(String(p.id)))
+			.map((p) => ({
+				...p,
+				parameters: selectedCharts.find((c) => c.plot.id === p.id)?.parameters
+			}));
+	}, [byResult, data, searchParams, selectedCharts]);
 
 	const handleCombinedPointClick: ComponentProps<
 		typeof StackedMeasurementChart

--- a/libs/bublik/features/history/src/lib/history-measurements/combined-charts.context.tsx
+++ b/libs/bublik/features/history/src/lib/history-measurements/combined-charts.context.tsx
@@ -11,8 +11,9 @@ import { useQueryParam } from 'use-query-params';
 
 import { SingleMeasurementChart } from '@/services/bublik-api';
 
-interface SelectedChart {
+export interface SelectedChart {
 	plot: SingleMeasurementChart;
+	parameters?: string[];
 	color: string;
 }
 
@@ -50,11 +51,12 @@ export const CombinedChartsProvider = ({
 			plot: SingleMeasurementChart;
 			color: string;
 			group: 'trend' | 'measurement';
+			parameters?: string[];
 		}) => {
-			const { plot, color, group } = args;
+			const { plot, color, group, parameters } = args;
 			const plotId = String(plot.id);
 			if (!selectedCharts.find(({ plot: p }) => String(p.id) === plotId)) {
-				setSelectedCharts([...selectedCharts, { plot, color }]);
+				setSelectedCharts([...selectedCharts, { plot, color, parameters }]);
 				if (selectedCharts.length === 0) {
 					setSelectedGroup(group);
 				}
@@ -70,6 +72,8 @@ export const CombinedChartsProvider = ({
 		},
 		[selectedCharts, setSelectedGroup]
 	);
+
+	console.log('SELECTED CHARTS:', selectedCharts);
 
 	const handleRemoveClick = useCallback(
 		(plot: SingleMeasurementChart) => {

--- a/libs/bublik/features/history/src/lib/history-measurements/combined-charts.context.tsx
+++ b/libs/bublik/features/history/src/lib/history-measurements/combined-charts.context.tsx
@@ -34,11 +34,12 @@ const CombinedChartsContext = createContext<
 	CombinedChartsContextValue | undefined
 >(undefined);
 
-export const CombinedChartsProvider = ({
-	children
-}: {
+interface CombinedChartsProviderProps {
 	children: ReactNode;
-}) => {
+}
+
+export const CombinedChartsProvider = (props: CombinedChartsProviderProps) => {
+	const { children } = props;
 	const [selectedCharts, setSelectedCharts] = useState<SelectedChart[]>([]);
 	const [selectedGroup, setSelectedGroup] = useQueryParam<
 		null | 'trend' | 'measurement'
@@ -57,23 +58,17 @@ export const CombinedChartsProvider = ({
 			const plotId = String(plot.id);
 			if (!selectedCharts.find(({ plot: p }) => String(p.id) === plotId)) {
 				setSelectedCharts([...selectedCharts, { plot, color, parameters }]);
-				if (selectedCharts.length === 0) {
-					setSelectedGroup(group);
-				}
+				if (selectedCharts.length === 0) setSelectedGroup(group);
 			} else {
 				const newCharts = selectedCharts.filter(
 					({ plot: p }) => String(p.id) !== plotId
 				);
 				setSelectedCharts(newCharts);
-				if (newCharts.length === 0) {
-					setSelectedGroup(null);
-				}
+				if (newCharts.length === 0) setSelectedGroup(null);
 			}
 		},
 		[selectedCharts, setSelectedGroup]
 	);
-
-	console.log('SELECTED CHARTS:', selectedCharts);
 
 	const handleRemoveClick = useCallback(
 		(plot: SingleMeasurementChart) => {
@@ -82,9 +77,7 @@ export const CombinedChartsProvider = ({
 				({ plot: p }) => String(p.id) !== plotId
 			);
 			setSelectedCharts(newCharts);
-			if (newCharts.length === 0) {
-				setSelectedGroup(null);
-			}
+			if (newCharts.length === 0) setSelectedGroup(null);
 		},
 		[selectedCharts, setSelectedGroup]
 	);

--- a/libs/bublik/features/history/src/lib/history-measurements/plot-list.component.tsx
+++ b/libs/bublik/features/history/src/lib/history-measurements/plot-list.component.tsx
@@ -8,8 +8,7 @@ import {
 	cn,
 	Icon,
 	Skeleton,
-	ToolbarButton,
-	useSidebar
+	ToolbarButton
 } from '@/shared/tailwind-ui';
 import { ExportChart, getColorByIdx, MeasurementChart } from '@/shared/charts';
 import { SingleMeasurementChart } from '@/services/bublik-api';
@@ -21,10 +20,12 @@ import { resolvePoint } from './plot-list.utils';
 interface PlotListItemProps {
 	idx: number;
 	plot: SingleMeasurementChart;
+	parameters?: string[];
 	onAddChartClick: (args: {
 		plot: SingleMeasurementChart;
 		color: string;
 		group: 'trend' | 'measurement';
+		parameters?: string[];
 	}) => void;
 	combinedState: 'disabled' | 'active' | 'default' | 'waiting';
 	enableResultErrorHighlight?: boolean;
@@ -36,6 +37,7 @@ const PlotListItem = (props: PlotListItemProps) => {
 	const {
 		idx,
 		plot,
+		parameters,
 		combinedState,
 		onAddChartClick,
 		enableResultErrorHighlight,
@@ -56,7 +58,7 @@ const PlotListItem = (props: PlotListItemProps) => {
 	};
 
 	const handleChartAddClick = (plot: SingleMeasurementChart) => {
-		onAddChartClick({ plot, color: getColorByIdx(idx), group });
+		onAddChartClick({ plot, color: getColorByIdx(idx), group, parameters });
 	};
 
 	const isDisabled =
@@ -129,14 +131,21 @@ export const PlotListLoading = (props: PlotListLoadingProps) => {
 export interface PlotListProps {
 	label: string;
 	plots: SingleMeasurementChart[];
+	parameters?: string[];
 	isFetching?: boolean;
 	enableResultErrorHighlight?: boolean;
 	group: 'trend' | 'measurement';
 }
 
 export function PlotList(props: PlotListProps) {
-	const { plots, isFetching, label, enableResultErrorHighlight, group } = props;
-	const { isSidebarOpen } = useSidebar();
+	const {
+		plots,
+		isFetching,
+		label,
+		enableResultErrorHighlight,
+		group,
+		parameters
+	} = props;
 	const { handleAddChartClick, selectedCharts, selectedGroup } =
 		useCombinedView();
 
@@ -157,9 +166,7 @@ export function PlotList(props: PlotListProps) {
 			<ul
 				className={cn(
 					'[&>li]:border-b [&>li]:border-border-primary',
-					isSidebarOpen
-						? 'min-[1465px]:chart-mosaic'
-						: 'min-[1368px]:chart-mosaic'
+					plots.length !== 1 && 'min-[1465px]:chart-mosaic'
 				)}
 			>
 				{plots.map((plot, idx) => {
@@ -177,6 +184,7 @@ export function PlotList(props: PlotListProps) {
 							plot={plot}
 							onAddChartClick={handleAddChartClick}
 							combinedState={state}
+							parameters={parameters}
 							enableResultErrorHighlight={enableResultErrorHighlight}
 							group={group}
 							selectedGroup={selectedGroup}

--- a/libs/bublik/features/history/src/lib/history-measurements/plot-list.container.tsx
+++ b/libs/bublik/features/history/src/lib/history-measurements/plot-list.container.tsx
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { ArrayParam, useQueryParam, withDefault } from 'use-query-params';
 
@@ -41,8 +41,13 @@ export function PlotListContainer() {
 		handleRemoveClick,
 		handleResetButtonClick,
 		selectedCharts,
-		handleOpenButtonClick
+		handleOpenButtonClick,
+		syncChartsFromData
 	} = useCombinedView();
+
+	useEffect(() => {
+		if (data) syncChartsFromData(data);
+	}, [data, syncChartsFromData]);
 
 	if (!query.testName) {
 		return (
@@ -108,8 +113,16 @@ export function PlotListContainerByResult() {
 		handleRemoveClick,
 		handleResetButtonClick,
 		selectedCharts,
-		handleOpenButtonClick
+		handleOpenButtonClick,
+		syncChartsFromData
 	} = useCombinedView();
+
+	useEffect(() => {
+		if (!data) return;
+
+		const allCharts = data.flatMap((d) => d.measurement_series_charts);
+		syncChartsFromData(allCharts);
+	}, [data, syncChartsFromData]);
 
 	const uniqueParameters = useMemo(() => {
 		const all = Array.from(

--- a/libs/bublik/features/run-report/src/lib/run-report-chart/run-report-chart.component.tsx
+++ b/libs/bublik/features/run-report/src/lib/run-report-chart/run-report-chart.component.tsx
@@ -21,10 +21,11 @@ interface RunReportChartProps {
 	chart: ReportChart;
 	isFullScreen?: boolean;
 	stackedButton?: ReactNode;
+	idx: number;
 }
 
 function RunReportChart(props: RunReportChartProps) {
-	const { chart, isFullScreen = false, stackedButton } = props;
+	const { chart, isFullScreen = false, stackedButton, idx } = props;
 	const { runId } = useParams<{ runId: string }>();
 	const [resultId, setResultId] = useState<number>();
 	const [open, setOpen] = useState(false);
@@ -82,13 +83,20 @@ function RunReportChart(props: RunReportChartProps) {
 		changeMode,
 		toggleFullScreen,
 		toggleLimitYAxis
-	} = useRunReportChartState({ chart, chartRef, isCtrlPressed, isFullScreen });
+	} = useRunReportChartState({
+		chart,
+		chartRef,
+		isCtrlPressed,
+		isFullScreen,
+		idx
+	});
 
 	const options = resolveRunReportChartOptions({
 		chart,
 		state,
 		isCtrlPressed,
-		isFullScreen
+		isFullScreen,
+		idx
 	});
 
 	return (
@@ -102,7 +110,7 @@ function RunReportChart(props: RunReportChartProps) {
 			/>
 			<DrawerRoot open={state.isFullScreen} onOpenChange={toggleFullScreen}>
 				<DrawerContent className="w-[75vw] p-4">
-					<RunReportChart chart={chart} isFullScreen={true} />
+					<RunReportChart chart={chart} isFullScreen={true} idx={idx} />
 				</DrawerContent>
 			</DrawerRoot>
 			<div className="w-full flex flex-col gap-2 h-full pb-2">

--- a/libs/bublik/features/run-report/src/lib/run-report-chart/run-report-chart.hooks.ts
+++ b/libs/bublik/features/run-report/src/lib/run-report-chart/run-report-chart.hooks.ts
@@ -11,10 +11,11 @@ interface UseRunReportChartStateOptions {
 	chartRef: RefObject<ReactEChartsCore>;
 	isCtrlPressed: boolean;
 	isFullScreen: boolean;
+	idx: number;
 }
 
 function useRunReportChartState(options: UseRunReportChartStateOptions) {
-	const { chartRef, chart, isCtrlPressed, isFullScreen } = options;
+	const { chartRef, chart, isCtrlPressed, isFullScreen, idx } = options;
 	const [state, setState] = useState<ChartState>({
 		isGlobalZoomEnabled: false,
 		isFullScreen: false,
@@ -72,7 +73,8 @@ function useRunReportChartState(options: UseRunReportChartStateOptions) {
 				chart,
 				isCtrlPressed,
 				state,
-				isFullScreen
+				isFullScreen,
+				idx
 			}),
 			true
 		);

--- a/libs/bublik/features/run-report/src/lib/run-report-chart/run-report-chart.utils.ts
+++ b/libs/bublik/features/run-report/src/lib/run-report-chart/run-report-chart.utils.ts
@@ -3,7 +3,13 @@
 import { ComponentProps } from 'react';
 import { z } from 'zod';
 
-import { ChartState, chartStyles, EChartsOption, Plot } from '@/shared/charts';
+import {
+	ChartState,
+	chartStyles,
+	EChartsOption,
+	getColorByIdx,
+	Plot
+} from '@/shared/charts';
 import { ReportChart } from '@/shared/types';
 import { DataZoomComponentOption } from 'echarts';
 
@@ -17,49 +23,13 @@ interface RunReportChartConfigOptions {
 	state: ChartState;
 	isCtrlPressed: boolean;
 	isFullScreen: boolean;
-}
-
-function resolveDataZoom(
-	state: ChartState,
-	isModifierPressed = false,
-	isFullScreen = false
-) {
-	const dataZoom = [];
-
-	dataZoom.push({
-		type: 'inside',
-		xAxisIndex: [0],
-		zoomLock: !isModifierPressed
-	});
-	dataZoom.push({
-		type: 'inside',
-		yAxisIndex: [0],
-		zoomLock: !isModifierPressed
-	});
-
-	if (state.isSlidersVisible) {
-		dataZoom.push({
-			type: 'slider',
-			show: true,
-			xAxisIndex: [0],
-			bottom: isFullScreen ? 50 : 15
-		});
-		dataZoom.push({
-			type: 'slider',
-			show: true,
-			yAxisIndex: [0],
-			right: isFullScreen ? 70 : 0,
-			bottom: isFullScreen ? '15%' : '30%'
-		});
-	}
-
-	return dataZoom;
+	idx: number;
 }
 
 function resolveRunReportChartOptions(
 	options: RunReportChartConfigOptions
 ): EChartsOption {
-	const { chart, isCtrlPressed, state, isFullScreen } = options;
+	const { chart, isCtrlPressed, state, isFullScreen, idx } = options;
 
 	const dataZoom: DataZoomComponentOption[] = state.isSlidersVisible
 		? [{ left: '8%' }, { type: 'inside', zoomLock: !isCtrlPressed }]
@@ -82,7 +52,7 @@ function resolveRunReportChartOptions(
 					const hasError = point?.metadata?.has_error;
 
 					if (hasError) return '#f95c78';
-					return '#65cd84';
+					return getColorByIdx(idx);
 				}
 			},
 			symbol: (_, params: unknown) => {

--- a/libs/bublik/features/run-report/src/lib/run-report-test/run-report-test.component.tsx
+++ b/libs/bublik/features/run-report/src/lib/run-report-test/run-report-test.component.tsx
@@ -151,6 +151,7 @@ function RunReportTestBlock(props: RunReportTestBlockProps) {
 														enableTableView={enableTableView}
 														block={record}
 														offset={offsetTop + headerOffsetTop + 36}
+														idx={idx}
 													/>
 												</li>
 											))}
@@ -169,10 +170,10 @@ function RunReportTestBlock(props: RunReportTestBlockProps) {
 type RunReportEntityBlockProps = Pick<
 	RunReportTestBlockProps,
 	'enableChartView' | 'enableTableView'
-> & { block: RecordBlock; offset: number };
+> & { block: RecordBlock; offset: number; idx: number };
 
 function MeasurementBlock(props: RunReportEntityBlockProps) {
-	const { enableChartView, enableTableView, block, offset } = props;
+	const { enableChartView, enableTableView, block, offset, idx } = props;
 	const { id, chart, table, label } = block;
 	const [searchParams] = useSearchParams();
 	const ref = useRef<HTMLDivElement>(null);
@@ -275,6 +276,7 @@ function MeasurementBlock(props: RunReportEntityBlockProps) {
 								<RunReportChart
 									chart={chart}
 									stackedButton={<StackedAdd id={id} />}
+									idx={idx}
 								/>
 							</div>
 						</div>

--- a/libs/shared/charts/src/lib/single-measurement-chart/measurement-chart.component.tsx
+++ b/libs/shared/charts/src/lib/single-measurement-chart/measurement-chart.component.tsx
@@ -19,7 +19,8 @@ import { Plot } from '../plot';
 import {
 	ChartState,
 	resolveOptions,
-	resolveStackedOptions
+	resolveStackedOptions,
+	SingleMeasurementChartWithContext
 } from './measurement-chart.component.utils';
 import {
 	useChartState,
@@ -247,7 +248,7 @@ function MeasurementChartToolbar(props: MeasurementChartToolbarProps) {
 }
 
 interface StackedMeasurementChartProps {
-	charts: SingleMeasurementChart[];
+	charts: SingleMeasurementChartWithContext[];
 	style?: CSSProperties;
 	onPointClick?: (config: ChartPointClickProps) => void;
 	enableResultErrorHighlight?: boolean;

--- a/libs/shared/charts/src/lib/single-measurement-chart/measurement-chart.component.utils.ts
+++ b/libs/shared/charts/src/lib/single-measurement-chart/measurement-chart.component.utils.ts
@@ -181,6 +181,10 @@ interface ResolveStackedOptionsProps {
 	enableResultErrorHighlight?: boolean;
 }
 
+export type SingleMeasurementChartWithContext = SingleMeasurementChart & {
+	parameters?: string[];
+};
+
 function resolveStackedOptions(
 	plots: SingleMeasurementChart[],
 	options: ResolveStackedOptionsProps = {}
@@ -193,6 +197,8 @@ function resolveStackedOptions(
 		fontWeight: 500,
 		lineHeight: 18
 	};
+
+	console.log('FROM OPTIONS:', plots);
 
 	// Group plots by y-axis label
 	const yAxisGroups = new Map<string, number[]>();

--- a/libs/shared/charts/src/lib/utils/formatting.ts
+++ b/libs/shared/charts/src/lib/utils/formatting.ts
@@ -8,5 +8,7 @@ export const formatLabel = (label: string) => {
 };
 
 export const getChartName = (plot: SingleMeasurementChart): string => {
-	return plot.title ?? plot.subtitle;
+	return plot.title
+		? `${plot.title} - ${plot.axis_y.label}`
+		: plot.subtitle ?? '';
 };


### PR DESCRIPTION
Add various improvements to report and history charts:
- Added different parameter names for stacked charts as a way to generate unique names in legend
- Merge y-axises with the same label to prevent duplicated axises
- Added parameter/chart name filters to series charts