### PR TITLE
fix(log): generate CMD based on top level config key

### DIFF
--- a/libs/bublik/features/log-preview-drawer/src/new-bug.component.tsx
+++ b/libs/bublik/features/log-preview-drawer/src/new-bug.component.tsx
@@ -127,6 +127,7 @@ function getBugProps(
 		path,
 		tags: {
 			specialCategories: details.special_categories ?? {},
+			configuration: details.configuration,
 			revisions: details.revisions ?? [],
 			branches: details.branches ?? [],
 			important: details.important_tags ?? [],
@@ -270,11 +271,17 @@ function getFormattedMarkdown(
 		const haveHashes = Boolean(options.hashes?.length);
 
 		if (haveHashes) {
-			const configurations = hasConfigurationKey
-				? options.tags.specialCategories['Configuration'] ||
-				  options.tags.specialCategories['configuration'] ||
-				  []
-				: Object.values(options.tags.specialCategories).flat();
+			let configurations: string[];
+
+			if (options.tags.configuration) {
+				configurations = [options.tags.configuration];
+			} else {
+				configurations = hasConfigurationKey
+					? options.tags.specialCategories['Configuration'] ||
+					  options.tags.specialCategories['configuration'] ||
+					  []
+					: Object.values(options.tags.specialCategories).flat();
+			}
 
 			const matches = findAllMatches(configurations, options.hashes ?? []);
 
@@ -415,6 +422,7 @@ type BugTags = {
 	revisions?: { name?: string; value: string; url?: string }[];
 	parameters?: { name: string; value: string }[];
 	specialCategories: Record<string, string[]>;
+	configuration?: string;
 };
 
 interface NewBugButtonProps {

--- a/libs/shared/types/src/lib/run.ts
+++ b/libs/shared/types/src/lib/run.ts
@@ -285,6 +285,7 @@ export type RunDetailsAPIResponse = {
 	labels: string[];
 	revisions: DetailsItem[];
 	special_categories: Record<string, string[]>;
+	configuration?: string;
 	status: string;
 	status_by_nok: string;
 	conclusion: RUN_STATUS;


### PR DESCRIPTION
## Summary
- Fix log generation to use top level `config` key for CMD generation

This addresses a bug where CMD generation wasn't correctly using the top level config key.