### PR TITLE
feat(run): add ExpectedTotal and UnexpectedTotal columns

### DIFF
--- a/libs/bublik/features/run/src/lib/run-table/columns/badge-columns.tsx
+++ b/libs/bublik/features/run/src/lib/run-table/columns/badge-columns.tsx
@@ -13,7 +13,9 @@ import {
 	getSkippedExpected,
 	getSkippedUnexpected,
 	getTotalRunStats,
-	getRunRunStats
+	getRunRunStats,
+	getExpectedTotal,
+	getUnexpectedTotal
 } from '@/bublik/run-utils';
 
 import { createRunColumn } from './utils';
@@ -54,6 +56,44 @@ const columnConfigs: RunTableColumnConfig[] = [
 			RESULT_TYPE.Cored,
 			RESULT_TYPE.Incomplete
 		]
+	},
+	{
+		id: ColumnId.ExpectedTotal,
+		accessor: getExpectedTotal,
+		header: 'Total',
+		variant: BadgeVariants.ExpectedActive,
+		resultProperties: [RESULT_PROPERTIES.Expected],
+		results: [RESULT_TYPE.Passed, RESULT_TYPE.Failed, RESULT_TYPE.Skipped],
+		icon: (
+			<Icon
+				name="InformationCircleCheckmark"
+				size={16}
+				className="text-text-expected"
+			/>
+		)
+	},
+	{
+		id: ColumnId.UnexpectedTotal,
+		accessor: getUnexpectedTotal,
+		header: 'Total',
+		variant: BadgeVariants.UnexpectedActive,
+		resultProperties: [RESULT_PROPERTIES.Unexpected],
+		results: [
+			RESULT_TYPE.Passed,
+			RESULT_TYPE.Failed,
+			RESULT_TYPE.Killed,
+			RESULT_TYPE.Cored,
+			RESULT_TYPE.Skipped,
+			RESULT_TYPE.Incomplete,
+			RESULT_TYPE.Faked
+		],
+		icon: (
+			<Icon
+				name="InformationCircleExclamationMark"
+				size={16}
+				className="text-text-unexpected"
+			/>
+		)
 	},
 	{
 		id: ColumnId.PassedExpected,

--- a/libs/bublik/features/run/src/lib/run-table/constants/index.tsx
+++ b/libs/bublik/features/run/src/lib/run-table/constants/index.tsx
@@ -13,6 +13,7 @@ import { Icon } from '@/shared/tailwind-ui';
 import { ColumnId } from '../types';
 
 export const UnexpectedColumns: string[] = [
+	ColumnId.UnexpectedTotal,
 	ColumnId.PassedUnexpected,
 	ColumnId.FailedUnexpected,
 	ColumnId.SkippedUnexpected,
@@ -27,6 +28,19 @@ export const getUnexpectedResultForColumnId = (
 	columnId: string
 ): ResultTableFilter => {
 	switch (columnId) {
+		case ColumnId.UnexpectedTotal:
+			return {
+				results: [
+					RESULT_TYPE.Passed,
+					RESULT_TYPE.Failed,
+					RESULT_TYPE.Killed,
+					RESULT_TYPE.Cored,
+					RESULT_TYPE.Skipped,
+					RESULT_TYPE.Incomplete,
+					RESULT_TYPE.Faked
+				],
+				resultProperties: [RESULT_PROPERTIES.Unexpected]
+			};
 		case ColumnId.PassedUnexpected:
 			return {
 				results: [RESULT_TYPE.Passed],
@@ -55,6 +69,8 @@ export const isUnexpectedColumn =
 
 export const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
 	[ColumnId.Total]: false,
+	[ColumnId.ExpectedTotal]: false,
+	[ColumnId.UnexpectedTotal]: false,
 	[ColumnId.Objective]: false,
 	[ColumnId.Comments]: false
 };
@@ -87,7 +103,11 @@ export const COLUMN_GROUPS: ColumnGroup[] = [
 				/>
 			</div>
 		),
-		columns: [ColumnId.PassedExpected, ColumnId.FailedExpected],
+		columns: [
+			ColumnId.ExpectedTotal,
+			ColumnId.PassedExpected,
+			ColumnId.FailedExpected
+		],
 		className: 'bg-badge-3'
 	},
 	{
@@ -102,7 +122,11 @@ export const COLUMN_GROUPS: ColumnGroup[] = [
 				/>
 			</div>
 		),
-		columns: [ColumnId.PassedUnexpected, ColumnId.FailedUnexpected],
+		columns: [
+			ColumnId.UnexpectedTotal,
+			ColumnId.PassedUnexpected,
+			ColumnId.FailedUnexpected
+		],
 		className: 'bg-bg-fillError'
 	},
 	{

--- a/libs/bublik/features/run/src/lib/run-table/types/index.ts
+++ b/libs/bublik/features/run/src/lib/run-table/types/index.ts
@@ -17,6 +17,8 @@ export const enum ColumnId {
 	Tree = 'TREE',
 	Total = 'TOTAL',
 	Run = 'RUN',
+	ExpectedTotal = 'EXPECTED_TOTAL',
+	UnexpectedTotal = 'UNEXPECTED_TOTAL',
 	PassedExpected = 'PASSED_EXPECTED',
 	FailedExpected = 'FAILED_EXPECTED',
 	PassedUnexpected = 'PASSED_UNEXPECTED',

--- a/libs/bublik/run-utils/src/data-getters.ts
+++ b/libs/bublik/run-utils/src/data-getters.ts
@@ -68,6 +68,19 @@ export const getAbnormal = (data?: RunData | MergedRun | null) => {
 	return getStats(['abnormal'])(data);
 };
 
+export const getExpectedTotal = (data?: RunData | MergedRun | null) => {
+	return getStats(['passed', 'failed', 'skipped'])(data);
+};
+
+export const getUnexpectedTotal = (data?: RunData | MergedRun | null) => {
+	return getStats([
+		'passed_unexpected',
+		'failed_unexpected',
+		'skipped_unexpected',
+		'abnormal'
+	])(data);
+};
+
 /** Return all aggregated stats for purpose of comparing */
 export const getCalculatedStats = (
 	data?: RunData | MergedRun | null
@@ -81,6 +94,8 @@ export const getCalculatedStats = (
 		failedUnexpected: getFailedUnexpected(data),
 		skippedExpected: getSkippedExpected(data),
 		skippedUnexpected: getSkippedUnexpected(data),
-		abnormal: getAbnormal(data)
+		abnormal: getAbnormal(data),
+		expectedTotal: getExpectedTotal(data),
+		unexpectedTotal: getUnexpectedTotal(data)
 	} as const;
 };


### PR DESCRIPTION
Adds two new aggregate columns to display total counts for expected and unexpected test results. 

Expected:
- RESULT_TYPE.Passed
- RESULT_TYPE.Failed
- RESULT_TYPE.Skipped

Unexpected:
- RESULT_TYPE.Passed
- RESULT_TYPE.Failed
- RESULT_TYPE.Killed
- RESULT_TYPE.Cored
- RESULT_TYPE.Skipped
- RESULT_TYPE.Incomplete
- RESULT_TYPE.Faked

Both columns are hidden by default and are placed at the start of their respective column groups for easy access to summary counts.