### PR TITLE
fix(run-import): handle null celery_task in events table

### DIFF
--- a/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.columns.tsx
+++ b/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.columns.tsx
@@ -85,7 +85,19 @@ export const columns = [
 			const { toggle } = useImportLog();
 			const runId = cell.row.original.run_id;
 
-			if (!taskId) return null;
+			if (!taskId) {
+				return (
+					<div className="flex items-center gap-2 px-2">
+						<Tooltip content="No celery task available">
+							<Icon
+								name="TriangleExclamationMark"
+								size={16}
+								className="text-warning"
+							/>
+						</Tooltip>
+					</div>
+				);
+			}
 
 			return (
 				<div className="flex flex-col justify-center gap-1 w-fit">

--- a/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.columns.tsx
+++ b/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.columns.tsx
@@ -52,6 +52,68 @@ export function getIconByStatus(status: string) {
 
 const columnHelper = createColumnHelper<LogEventWithChildren>();
 
+interface ActionCellProps {
+	taskId?: string | null;
+	runId?: number | null;
+	status?: string;
+}
+
+function ActionsCell(props: ActionCellProps) {
+	const { runId, taskId, status } = props;
+	const { toggle } = useImportLog();
+
+	if (!taskId) {
+		return (
+			<div className="flex items-center gap-2 px-2">
+				<Tooltip content="No celery task available">
+					<Icon
+						name="TriangleExclamationMark"
+						size={20}
+						className="text-text-unexpected"
+					/>
+				</Tooltip>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col justify-center gap-1 w-fit">
+			{runId && (
+				<LinkWithProject to={routes.run({ runId })}>
+					<ButtonTw variant="secondary" size="xss" className="justify-start">
+						<Icon name="BoxArrowRight" size={20} className="mr-1.5" />
+						<span>Run</span>
+					</ButtonTw>
+				</LinkWithProject>
+			)}
+			<ButtonTw
+				variant="secondary"
+				size="xss"
+				className="justify-start"
+				onClick={toggle(taskId, status === 'STARTED')}
+			>
+				<Icon name="Paper" size={20} className="mr-1.5" />
+				<span>Log</span>
+			</ButtonTw>
+			<ButtonTw
+				variant="secondary"
+				size="xss"
+				className="justify-start"
+				asChild
+			>
+				<a
+					href={`${config.oldBaseUrl}/flower/task/${taskId}`}
+					target="_blank"
+					rel="noreferrer"
+				>
+					<RocketIcon className="mr-1.5 size-4" />
+					<span>Task</span>
+				</a>
+			</ButtonTw>
+		</div>
+	);
+}
+
 export const columns = [
 	columnHelper.accessor('status', {
 		id: 'EVENT_TYPE',
@@ -79,67 +141,13 @@ export const columns = [
 	columnHelper.accessor('celery_task', {
 		id: 'ACTIONS',
 		header: () => <span className="pl-2">Actions</span>,
-		cell: (cell) => {
-			const taskId = cell.getValue();
-			// eslint-disable-next-line
-			const { toggle } = useImportLog();
-			const runId = cell.row.original.run_id;
-
-			if (!taskId) {
-				return (
-					<div className="flex items-center gap-2 px-2">
-						<Tooltip content="No celery task available">
-							<Icon
-								name="TriangleExclamationMark"
-								size={16}
-								className="text-warning"
-							/>
-						</Tooltip>
-					</div>
-				);
-			}
-
-			return (
-				<div className="flex flex-col justify-center gap-1 w-fit">
-					{runId && (
-						<LinkWithProject to={routes.run({ runId })}>
-							<ButtonTw
-								variant="secondary"
-								size="xss"
-								className="justify-start"
-							>
-								<Icon name="BoxArrowRight" size={20} className="mr-1.5" />
-								<span>Run</span>
-							</ButtonTw>
-						</LinkWithProject>
-					)}
-					<ButtonTw
-						variant="secondary"
-						size="xss"
-						className="justify-start"
-						onClick={toggle(taskId, cell.row.original.status === 'STARTED')}
-					>
-						<Icon name="Paper" size={20} className="mr-1.5" />
-						<span>Log</span>
-					</ButtonTw>
-					<ButtonTw
-						variant="secondary"
-						size="xss"
-						className="justify-start"
-						asChild
-					>
-						<a
-							href={`${config.oldBaseUrl}/flower/task/${taskId}`}
-							target="_blank"
-							rel="noreferrer"
-						>
-							<RocketIcon className="mr-1.5 size-4" />
-							<span>Task</span>
-						</a>
-					</ButtonTw>
-				</div>
-			);
-		},
+		cell: (cell) => (
+			<ActionsCell
+				taskId={cell.getValue()}
+				runId={cell.row.original.run_id}
+				status={cell.row.original.status}
+			/>
+		),
 		meta: { width: 'min-content' }
 	}),
 	columnHelper.accessor('timestamp', {

--- a/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.component.tsx
+++ b/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.component.tsx
@@ -137,6 +137,7 @@ interface EventRowProps {
 
 function EventRow({ row }: EventRowProps) {
 	const [isHovered, setIsHovered] = useState(false);
+	const { toggle } = useImportLog();
 
 	return (
 		<Fragment key={row.id}>
@@ -174,7 +175,7 @@ function EventRow({ row }: EventRowProps) {
 				);
 			})}
 			{row.getIsExpanded() && (
-				<div className={'col-span-full'}>{renderTimeline({ row })}</div>
+				<div className={'col-span-full'}>{renderTimeline({ row, toggle })}</div>
 			)}
 		</Fragment>
 	);
@@ -239,7 +240,10 @@ const ImportEventTableEmpty = () => {
 	);
 };
 
-type TimelineOptions = { row: Row<LogEventWithChildren> };
+type TimelineOptions = {
+	row: Row<LogEventWithChildren>;
+	toggle: ReturnType<typeof useImportLog>['toggle'];
+};
 
 const NO_TASK_GROUP = '__no-task__';
 
@@ -247,7 +251,8 @@ function renderTimeline(props: TimelineOptions) {
 	const {
 		row: {
 			original: { children: events }
-		}
+		},
+		toggle
 	} = props;
 	const groupedEvents = events.reduce<Record<string, typeof events>>(
 		(acc, evt) => {
@@ -258,9 +263,6 @@ function renderTimeline(props: TimelineOptions) {
 		},
 		{}
 	);
-
-	// eslint-disable-next-line react-hooks/rules-of-hooks
-	const { toggle } = useImportLog();
 
 	return (
 		<div className="bg-white px-4 py-8 border-t border-border-primary mb-1">

--- a/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.component.tsx
+++ b/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.component.tsx
@@ -112,8 +112,8 @@ function ImportEventTable(props: ImportEventTableProps) {
 						</Fragment>
 					))}
 
-					{table.getRowModel().rows.map((row, idx, arr) => (
-						<EventRow key={row.id} row={row} idx={idx} arr={arr} />
+					{table.getRowModel().rows.map((row) => (
+						<EventRow key={row.id} row={row} />
 					))}
 				</div>
 			</div>
@@ -133,8 +133,6 @@ function ImportEventTable(props: ImportEventTableProps) {
 
 interface EventRowProps {
 	row: Row<LogEventWithChildren>;
-	idx: number;
-	arr: Row<LogEventWithChildren>[];
 }
 
 function EventRow({ row }: EventRowProps) {

--- a/libs/bublik/features/run-import/src/lib/import-events-table/import-log.component.tsx
+++ b/libs/bublik/features/run-import/src/lib/import-events-table/import-log.component.tsx
@@ -451,20 +451,22 @@ export const ImportLogTable = (props: ImportLogTableProps) => {
 			<table className="w-full border-collapse">
 				{table.getHeaderGroups().map((group) => (
 					<thead key={group.id}>
-						{group.headers.map((header) => (
-							<th
-								key={header.id}
-								className={cn(
-									'px-1 py-2 text-left text-gray-400 font-semibold sticky top-0',
-									BG_CLASS
-								)}
-							>
-								{flexRender(
-									header.column.columnDef.header,
-									header.getContext()
-								)}
-							</th>
-						))}
+						<tr>
+							{group.headers.map((header) => (
+								<th
+									key={header.id}
+									className={cn(
+										'px-1 py-2 text-left text-gray-400 font-semibold sticky top-0',
+										BG_CLASS
+									)}
+								>
+									{flexRender(
+										header.column.columnDef.header,
+										header.getContext()
+									)}
+								</th>
+							))}
+						</tr>
 					</thead>
 				))}
 				<tbody>

--- a/libs/shared/types/src/lib/run-import.ts
+++ b/libs/shared/types/src/lib/run-import.ts
@@ -20,7 +20,7 @@ export const LogEventSchema = z.object({
 	event_id: z.number(),
 	status: z.enum(['SUCCESS', 'FAILURE', 'STARTED']).or(z.string()),
 	uri: z.string(),
-	celery_task: z.string(),
+	celery_task: z.string().optional().nullable(),
 	facility: z.nativeEnum(Facility),
 	severity: z.nativeEnum(Severity),
 	timestamp: z.string(),


### PR DESCRIPTION
Make `celery_task` optional in LogEventSchema to prevent crashes when API returns null values. 
Events without `celery_task` are now visible with a warning badge instead of being hidden or causing errors.

## Changes
- Made `celery_task` optional and nullable in LogEventSchema
- Added warning badge in timeline for events without celery_task
- Added warning icon in Actions column
- Disabled Log/Task buttons for events without celery_task