### PR TITLE
feat(run): add dim mode to visually highlight common parameters

### DIFF
--- a/apps/bublik/src/pages/run-page/run-page.tsx
+++ b/apps/bublik/src/pages/run-page/run-page.tsx
@@ -51,6 +51,10 @@ const RunHeader = ({ runId }: RunHeaderProps) => {
 		<header className="flex flex-col bg-white rounded">
 			<CardHeader label="Info">
 				<div className="flex h-full gap-3">
+					<RunModeToggle
+						isFullMode={isModeFull}
+						onToggleClick={() => setIsModeFull(!isModeFull)}
+					/>
 					<Tooltip content="Copy identifier for comparison">
 						<ButtonTw variant="secondary" size="xss" onClick={handleCopyRunId}>
 							<Icon name="PaperStack" size={16} className="mr-1 text-primary" />
@@ -67,10 +71,6 @@ const RunHeader = ({ runId }: RunHeaderProps) => {
 							Log
 						</LinkWithProject>
 					</ButtonTw>
-					<RunModeToggle
-						isFullMode={isModeFull}
-						onToggleClick={() => setIsModeFull(!isModeFull)}
-					/>
 					<NewBugContainer runId={Number(runId)} resultId={Number(runId)} />
 					<CopyShortUrlButtonContainer />
 				</div>

--- a/libs/bublik/features/run/src/lib/hooks.tsx
+++ b/libs/bublik/features/run/src/lib/hooks.tsx
@@ -46,7 +46,7 @@ export interface RowState {
 	rowId: string;
 	requests?: Record<string, ResultTableFilter>;
 	referenceDiffRowId?: string;
-	mode?: 'default' | 'diff';
+	mode?: 'default' | 'diff' | 'dim';
 	showToolbar?: boolean;
 }
 

--- a/libs/bublik/features/run/src/lib/result-table/matcher.ts
+++ b/libs/bublik/features/run/src/lib/result-table/matcher.ts
@@ -31,6 +31,30 @@ export function calculateGroupSize(
 	return groupSize;
 }
 
+export function getCommonParameters(allParameters: string[][]): Set<string> {
+	if (allParameters.length === 0) return new Set();
+
+	// Start with all parameters from first row
+	const commonSet = new Set(allParameters[0]);
+
+	// Intersect with each subsequent row
+	for (let i = 1; i < allParameters.length; i++) {
+		const currentSet = new Set(allParameters[i]);
+		// Collect items to delete first, then remove them after iteration
+		const toDelete: string[] = [];
+		for (const param of commonSet) {
+			if (!currentSet.has(param)) {
+				toDelete.push(param);
+			}
+		}
+		for (const param of toDelete) {
+			commonSet.delete(param);
+		}
+	}
+
+	return commonSet;
+}
+
 export type DiffValue = {
 	value: string;
 	isDifferent?: boolean;

--- a/libs/bublik/features/run/src/lib/result-table/result-table.columns.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.columns.tsx
@@ -73,36 +73,7 @@ export const getColumns = ({
 
 	return [
 		helper.accessor((data) => data, {
-			header: () => (
-				<div className="flex items-center gap-2">
-					<span>Actions</span>
-					<Tooltip content={showToolbar ? 'Hide toolbar' : 'Show toolbar'}>
-						<ButtonTw
-							variant={showToolbar ? 'primary' : 'secondary'}
-							size="xss"
-							onClick={() => setShowToolbar(!showToolbar)}
-							className={cn(
-								'border',
-								showToolbar
-									? 'border-primary hover:border-[#94b0ff]'
-									: 'border-border-primary hover:shadow-none hover:border-primary'
-							)}
-						>
-							<div
-								className={cn(
-									'flex items-center justify-center mr-1.5',
-									!showToolbar && 'rotate-180'
-								)}
-							>
-								<Icon name="ArrowLeanUp" size={18} />
-							</div>
-							<span className="w-[6ch] text-left">
-								{showToolbar ? 'Hide' : 'Expose'}
-							</span>
-						</ButtonTw>
-					</Tooltip>
-				</div>
-			),
+			header: 'Actions',
 			id: 'links',
 			cell: (cell) => {
 				const value = cell.getValue();
@@ -119,7 +90,7 @@ export const getColumns = ({
 					</div>
 				);
 			},
-			meta: { width: 'max-content' }
+			meta: { width: 'max-content', headerCellClassName: 'pl-9' }
 		}),
 		helper.accessor(
 			(data) => ({
@@ -295,7 +266,36 @@ export const getColumns = ({
 			meta: { headerCellClassName: 'pl-[12px]' }
 		}),
 		helper.accessor('parameters', {
-			header: 'Parameters',
+			header: () => (
+				<div className="flex items-center gap-2">
+					<span>Parameters</span>
+					<Tooltip content={showToolbar ? 'Hide toolbar' : 'Show toolbar'}>
+						<ButtonTw
+							variant={showToolbar ? 'primary' : 'secondary'}
+							size="xss"
+							onClick={() => setShowToolbar(!showToolbar)}
+							className={cn(
+								'border',
+								showToolbar
+									? 'border-primary hover:border-[#94b0ff]'
+									: 'border-border-primary hover:shadow-none hover:border-primary'
+							)}
+						>
+							<div
+								className={cn(
+									'flex items-center justify-center mr-1.5',
+									!showToolbar && 'rotate-180'
+								)}
+							>
+								<Icon name="ArrowLeanUp" size={18} />
+							</div>
+							<span className="w-[6ch] text-left">
+								{showToolbar ? 'Hide' : 'Expose'}
+							</span>
+						</ButtonTw>
+					</Tooltip>
+				</div>
+			),
 			id: COLUMN_ID.PARAMETERS,
 			cell: ({ cell, getValue }) => {
 				const parameters = getValue();

--- a/libs/bublik/features/run/src/lib/result-table/result-table.component.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.component.tsx
@@ -136,10 +136,7 @@ export const ResultTable = memo((props: ResultTableProps) => {
 		[rowId, showLinkToRun, data, mode, hasToolbar, setShowToolbar, path]
 	);
 
-	const { stickyOffset } = useStickyHeader({
-		hasFilters: hasToolbar,
-		height
-	});
+	const { stickyOffset } = useStickyHeader({ height });
 
 	const table = useReactTable<RunDataResults>({
 		data,
@@ -163,88 +160,13 @@ export const ResultTable = memo((props: ResultTableProps) => {
 		offset: stickyOffset
 	});
 
+	const HEADER_ROW_HEIGHT = 42;
+	const columnCount = columns.length;
+
 	return (
 		<div className="px-4 pb-2">
-			{hasToolbar ? (
-				<div
-					className={cn(
-						'flex items-center justify-between px-4',
-						'bg-white h-9 sticky border-x border-b border-border-primary z-20'
-					)}
-					style={{ top: `${height + 102}px` }}
-				>
-					<div className="flex gap-2 items-center">
-						<DataTableFacetedFilter
-							title="Artifacts"
-							size="xss"
-							options={artifacts}
-							value={artifactsFilter}
-							onChange={(values) => onFilterChange(COLUMN_ID.ARTIFACTS, values)}
-							disabled={!artifacts.length || isDiffMode || isDimMode}
-						/>
-						<DataTableFacetedFilter
-							title="Verdicts"
-							size="xss"
-							options={verdicts}
-							value={verdictsFilter}
-							onChange={onVerdictsFilterChange}
-							disabled={!verdicts.length || isDiffMode || isDimMode}
-						/>
-						<DataTableFacetedFilter
-							title="Parameters"
-							size="xss"
-							options={parameters}
-							value={parametersFilter}
-							onChange={(values) =>
-								onFilterChange(COLUMN_ID.PARAMETERS, values)
-							}
-							disabled={!parameters.length || isDiffMode || isDimMode}
-						/>
-						<Tooltip content="Reset">
-							<ButtonTw variant="secondary" size="xss" onClick={onClearFilters}>
-								<Icon name="Bin" size={18} className="mr-1.5" />
-								<span>Reset</span>
-							</ButtonTw>
-						</Tooltip>
-					</div>
-					<div className="flex gap-2 items-center">
-						<Tooltip content="Click on the row to compare parameters">
-							<ButtonTw
-								variant={mode === 'diff' ? 'primary' : 'secondary'}
-								size="xss"
-								onClick={() => {
-									const nextMode = mode === 'diff' ? 'default' : 'diff';
-									setMode(nextMode);
-
-									if (nextMode === 'diff') setColumnFilters([]);
-								}}
-							>
-								<Icon
-									name="SwapArrows"
-									size={18}
-									className="rotate-90 mr-1.5"
-								/>
-								<span>Parameters Compare</span>
-							</ButtonTw>
-						</Tooltip>
-						<Tooltip content="Dim parameters that are the same. Click a row to compare against it.">
-							<ButtonTw
-								variant={isDimMode ? 'primary' : 'secondary'}
-								size="xss"
-								onClick={() => {
-									const nextMode = isDimMode ? 'default' : 'dim';
-									setMode(nextMode);
-								}}
-							>
-								<Icon name="EyeHide" size={18} className="mr-1.5" />
-								<span>Dim Common</span>
-							</ButtonTw>
-						</Tooltip>
-					</div>
-				</div>
-			) : null}
 			<div className="w-full">
-				<div className="grid relative" style={{ gridTemplateColumns }}>
+				<div className="grid relative z-[5]" style={{ gridTemplateColumns }}>
 					{table.getHeaderGroups().map((headerGroup) => (
 						<Fragment key={headerGroup.id}>
 							{headerGroup.headers.map((header, idx, headers) => {
@@ -256,19 +178,23 @@ export const ResultTable = memo((props: ResultTableProps) => {
 									<div
 										key={header.id}
 										className={cn(
-											'mb-1 px-1 py-2 text-left text-[0.6875rem] font-semibold leading-[0.875rem] z-10',
+											'px-1 py-2 text-left text-[0.6875rem] font-semibold leading-[0.875rem] z-20',
 											'bg-primary-wash sticky',
 											'flex items-center',
-											idx === 0 && 'rounded-bl-md',
-											idx === headers.length - 1 && 'rounded-br-md',
+											idx === 0 && !hasToolbar && 'rounded-bl-md',
+											idx === headers.length - 1 &&
+												!hasToolbar &&
+												'rounded-br-md',
+											!hasToolbar && 'mb-1',
 											className,
 											headerCellClassName
 										)}
 										style={{
-											top: Math.abs(stickyOffset) - 1,
-											boxShadow: isSticky
-												? `rgba(0, 0, 0, 0.1) ${idx === 0 ? 0 : 7}px 2px 10px`
-												: 'none'
+											top: height + HEADER_HEIGHT,
+											boxShadow:
+												isSticky && !hasToolbar
+													? `rgba(0, 0, 0, 0.1) ${idx === 0 ? 0 : 7}px 2px 10px`
+													: 'none'
 										}}
 										ref={(el) => {
 											if (idx === 0) {
@@ -287,6 +213,94 @@ export const ResultTable = memo((props: ResultTableProps) => {
 							})}
 						</Fragment>
 					))}
+
+					{hasToolbar ? (
+						<div
+							className={cn(
+								'flex items-center justify-between px-4 mb-1',
+								'bg-white h-9 sticky shadow-sticky z-10 border-t border-border-primary'
+							)}
+							style={{
+								gridColumn: `1 / ${columnCount + 1}`,
+								top: `${height + HEADER_HEIGHT + HEADER_ROW_HEIGHT}px`
+							}}
+						>
+							<div className="flex gap-2 items-center">
+								<DataTableFacetedFilter
+									title="Artifacts"
+									size="xss"
+									options={artifacts}
+									value={artifactsFilter}
+									onChange={(values) =>
+										onFilterChange(COLUMN_ID.ARTIFACTS, values)
+									}
+									disabled={!artifacts.length || isDiffMode || isDimMode}
+								/>
+								<DataTableFacetedFilter
+									title="Verdicts"
+									size="xss"
+									options={verdicts}
+									value={verdictsFilter}
+									onChange={onVerdictsFilterChange}
+									disabled={!verdicts.length || isDiffMode || isDimMode}
+								/>
+								<DataTableFacetedFilter
+									title="Parameters"
+									size="xss"
+									options={parameters}
+									value={parametersFilter}
+									onChange={(values) =>
+										onFilterChange(COLUMN_ID.PARAMETERS, values)
+									}
+									disabled={!parameters.length || isDiffMode || isDimMode}
+								/>
+								<Tooltip content="Reset">
+									<ButtonTw
+										variant="secondary"
+										size="xss"
+										onClick={onClearFilters}
+									>
+										<Icon name="Bin" size={18} className="mr-1.5" />
+										<span>Reset</span>
+									</ButtonTw>
+								</Tooltip>
+							</div>
+							<div className="flex gap-2 items-center">
+								<Tooltip content="Click on the row to compare parameters">
+									<ButtonTw
+										variant={mode === 'diff' ? 'primary' : 'secondary'}
+										size="xss"
+										onClick={() => {
+											const nextMode = mode === 'diff' ? 'default' : 'diff';
+											setMode(nextMode);
+
+											if (nextMode === 'diff') setColumnFilters([]);
+										}}
+									>
+										<Icon
+											name="SwapArrows"
+											size={18}
+											className="rotate-90 mr-1.5"
+										/>
+										<span>Parameters Compare</span>
+									</ButtonTw>
+								</Tooltip>
+								<Tooltip content="Dim parameters that are the same. Click a row to compare against it.">
+									<ButtonTw
+										variant={isDimMode ? 'primary' : 'secondary'}
+										size="xss"
+										onClick={() => {
+											const nextMode = isDimMode ? 'default' : 'dim';
+											setMode(nextMode);
+										}}
+									>
+										<Icon name="EyeHide" size={18} className="mr-1.5" />
+										<span>Dim Common</span>
+									</ButtonTw>
+								</Tooltip>
+							</div>
+						</div>
+					) : null}
 
 					{table.getRowModel().rows.map((row, idx, arr) => (
 						<ResultRow
@@ -383,14 +397,13 @@ function ResultRow(props: ResultRowProps) {
 }
 
 interface StickyHeaderOptions {
-	hasFilters: boolean;
 	height: number;
 }
 
-function useStickyHeader({ hasFilters, height }: StickyHeaderOptions) {
-	const stickyOffset = hasFilters
-		? -(height * 2 + STICKY_OFFSET)
-		: -(height + STICKY_OFFSET);
+function useStickyHeader({ height }: StickyHeaderOptions) {
+	// Sticky offset is used for the useIsSticky hook to detect when header becomes sticky
+	// Now that toolbar is below header, offset doesn't depend on toolbar visibility
+	const stickyOffset = -(height + STICKY_OFFSET);
 
 	const getHeaderProps = useCallback<
 		NonNullable<TwTableProps<RunDataResults>['getHeaderProps']>
@@ -398,15 +411,13 @@ function useStickyHeader({ hasFilters, height }: StickyHeaderOptions) {
 		(_, { isSticky }) => {
 			return {
 				style: {
-					top: `${
-						hasFilters ? height * 2 + HEADER_HEIGHT : height + HEADER_HEIGHT
-					}px`,
+					top: `${height + HEADER_HEIGHT}px`,
 					position: 'sticky',
 					boxShadow: isSticky ? '0 0 10px rgba(0, 0, 0, 0.1)' : 'none'
 				} as CSSProperties
 			};
 		},
-		[hasFilters, height]
+		[height]
 	);
 
 	return { stickyOffset, getHeaderProps };

--- a/libs/bublik/features/run/src/lib/result-table/result-table.component.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.component.tsx
@@ -364,19 +364,24 @@ function ResultRow(props: ResultRowProps) {
 						className={cn(
 							'px-1 py-2 bg-white text-text-primary text-[0.75rem] leading-[1.125rem] font-medium',
 							'flex items-start whitespace-pre-wrap',
-							'bg-primary-wash border-y border-y-transparent transition-colors',
+							'bg-primary-wash transition-colors',
+							isReferenceDiffRow
+								? 'border-y border-primary'
+								: 'border-y border-y-transparent',
 							idx !== arr.length - 1 && 'mb-1',
-							cellIdx === 0 && 'rounded-l-md border-l border-l-transparent',
+							cellIdx === 0 &&
+								(isReferenceDiffRow
+									? 'rounded-l-md border-l border-primary'
+									: 'rounded-l-md border-l border-l-transparent'),
 							cellIdx === cellArr.length - 1 &&
-								'rounded-r-md border-r border-r-transparent',
+								(isReferenceDiffRow
+									? 'rounded-r-md border-r border-primary'
+									: 'rounded-r-md border-r border-r-transparent'),
 							className,
-							isReferenceDiffRow && 'border-y border-primary',
-							isReferenceDiffRow && cellIdx === 0 && 'border-primary',
-							isReferenceDiffRow &&
-								cellIdx === cellArr.length - 1 &&
-								'border-primary',
 							isTarget && 'animate-border-pulse',
-							hovered && 'border-y-primary border-l-primary border-r-primary'
+							!isReferenceDiffRow &&
+								hovered &&
+								'border-y-primary border-l-primary border-r-primary'
 						)}
 						style={{
 							overflowWrap: 'anywhere',

--- a/libs/bublik/features/run/src/lib/result-table/result-table.component.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.component.tsx
@@ -41,7 +41,7 @@ import {
 	StringArraySchema
 } from './constants';
 import { useTargetIterationId } from '../run-table/run-table.hooks';
-import { RowState, useGlobalRequirements, useRunTableRowState } from '../hooks';
+import { RowState, useGlobalRequirements } from '../hooks';
 
 const HEADER_HEIGHT = 102;
 const STICKY_OFFSET = HEADER_HEIGHT + 1;
@@ -102,7 +102,6 @@ export const ResultTable = memo((props: ResultTableProps) => {
 		setColumnFilters,
 		hasFilters: hasColumnFilters
 	} = useColumnFilters(rowId);
-	const { updateRowState } = useRunTableRowState();
 	const {
 		parameters,
 		verdicts,
@@ -218,14 +217,6 @@ export const ResultTable = memo((props: ResultTableProps) => {
 									setMode(nextMode);
 
 									if (nextMode === 'diff') setColumnFilters([]);
-									// Clear dim mode when entering diff mode
-									if (nextMode === 'diff') {
-										updateRowState({
-											rowId,
-											mode: nextMode,
-											referenceDiffRowId: undefined
-										});
-									}
 								}}
 							>
 								<Icon
@@ -243,16 +234,6 @@ export const ResultTable = memo((props: ResultTableProps) => {
 								onClick={() => {
 									const nextMode = isDimMode ? 'default' : 'dim';
 									setMode(nextMode);
-									// Clear reference when toggling off
-									if (nextMode === 'default') {
-										updateRowState({
-											rowId,
-											mode: nextMode,
-											referenceDiffRowId: undefined
-										});
-									} else {
-										updateRowState({ rowId, mode: nextMode });
-									}
 								}}
 							>
 								<Icon name="EyeHide" size={18} className="mr-1.5" />

--- a/libs/bublik/features/run/src/lib/result-table/result-table.container.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.container.tsx
@@ -5,7 +5,6 @@ import { Row } from '@tanstack/react-table';
 
 import { MergedRun, RunData, RunDataResults } from '@/shared/types';
 import { useGetResultsTableQuery } from '@/services/bublik-api';
-import { TwTableProps } from '@/shared/tailwind-ui';
 
 import { useRunTableRowState } from '../hooks';
 import { ColumnId } from '../run-table/types';
@@ -76,7 +75,7 @@ export function ResultTableContainer(props: ResultTableContainerProps) {
 				showToolbar: showToolbar
 			});
 		},
-		[rowState, updateRowState, rowId, showToolbar]
+		[updateRowState, rowState, rowId, showToolbar]
 	);
 
 	const setShowToolbar = useCallback(
@@ -108,7 +107,7 @@ export function ResultTableContainer(props: ResultTableContainerProps) {
 				});
 			}
 		},
-		[row.id, rowId, rowState, updateRowState]
+		[rowId, rowState, updateRowState]
 	);
 
 	if (isError) return <div className="">Something went wrong...</div>;

--- a/libs/bublik/features/run/src/lib/result-table/result-table.container.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.container.tsx
@@ -64,13 +64,15 @@ export function ResultTableContainer(props: ResultTableContainerProps) {
 	}, [rowState?.showToolbar]);
 
 	const setMode = useCallback(
-		(mode: 'default' | 'diff') => {
+		(mode: 'default' | 'diff' | 'dim') => {
 			return updateRowState({
 				...rowState,
 				mode,
 				rowId,
 				referenceDiffRowId:
-					mode === 'diff' ? rowState?.referenceDiffRowId : undefined,
+					mode === 'diff' || mode === 'dim'
+						? rowState.referenceDiffRowId
+						: undefined,
 				showToolbar: showToolbar
 			});
 		},
@@ -86,23 +88,23 @@ export function ResultTableContainer(props: ResultTableContainerProps) {
 
 	const onRowClick = useCallback(
 		(row: Row<RunDataResults>) => {
-			if (rowState?.mode === 'default' || !rowState?.mode) return;
+			if (!rowState || rowState.mode === 'default') return;
 
-			if (rowState?.referenceDiffRowId === row.id) {
+			if (rowState.referenceDiffRowId === row.id) {
 				updateRowState({
 					...rowState,
 					rowId,
 					referenceDiffRowId: undefined,
-					requests: rowState?.requests,
-					mode: 'diff'
+					requests: rowState.requests,
+					mode: rowState.mode
 				});
 			} else {
 				updateRowState({
 					...rowState,
 					rowId,
 					referenceDiffRowId: row.id,
-					requests: rowState?.requests,
-					mode: 'diff'
+					requests: rowState.requests,
+					mode: rowState.mode
 				});
 			}
 		},

--- a/libs/bublik/features/run/src/lib/run-table/toolbar.tsx
+++ b/libs/bublik/features/run/src/lib/run-table/toolbar.tsx
@@ -83,11 +83,12 @@ export const Toolbar = ({ table }: ToolbarProps) => {
 								onCheckedChange={column.toggleVisibility}
 								className="text-xs"
 							>
-								{`${column.id.charAt(0).toUpperCase()}${column.id
+								{column.id
 									.toLowerCase()
-									.replace(/_expected|_unexpected/i, '')
-									.slice(1)
-									.trim()}`}
+									.replace(/_/g, ' ')
+									.replace(/ expected$| unexpected$/i, '')
+									.replace(/\b\w/g, (c) => c.toUpperCase())
+									.trim()}
 								{column.id.toLowerCase().includes('unexpected')
 									? toolbarIcon['unexpected']
 									: column.id.toLowerCase().includes('expected')


### PR DESCRIPTION
## Summary
- Add new 'dim' mode alongside existing 'diff' mode for parameter comparison
- Dim parameters that are common across all rows or match reference row
- Add getCommonParameters utility function to find intersection of parameters
- Change opacity of common parameters to 40%

<img width="1668" height="708" alt="Screenshot 2026-01-26 at 22 40 05" src="https://github.com/user-attachments/assets/b59fa473-35ed-4dd6-aa12-4570d7d7bf51" />
<img width="1666" height="872" alt="Screenshot 2026-01-26 at 22 40 26" src="https://github.com/user-attachments/assets/744bc144-9108-418b-8fcc-9b31126bd9c2" />
