### PR TITLE
fix(dashboard): maintain chronological order in split layout

### DIFF
--- a/libs/bublik/features/dashboard-v2/src/lib/layout-handler/layout-handler.container.tsx
+++ b/libs/bublik/features/dashboard-v2/src/lib/layout-handler/layout-handler.container.tsx
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import { useEffect } from 'react';
 import { addDays } from 'date-fns';
 
 import { DASHBOARD_MODE } from '@/shared/types';
@@ -10,7 +11,9 @@ import { cn } from '@/shared/tailwind-ui';
 import {
 	DASHBOARD_TABLE_ID,
 	useDashboardDate,
-	useDashboardMode
+	useDashboardLayout,
+	useDashboardMode,
+	useRunDates
 } from '../hooks';
 import {
 	DashboardTableContainer,
@@ -29,8 +32,45 @@ const LayoutHandlerLoading = () => {
 export const LayoutHandlerContainer = () => {
 	const modeSettings = useDashboardMode();
 	const dateSearch = useDashboardDate(DASHBOARD_TABLE_ID.Main);
+	const secondaryDateSearch = useDashboardDate(DASHBOARD_TABLE_ID.Secondary);
 	const { projectIds } = useProjectSearch();
 	const todayQuery = useGetDashboardByDateQuery({ projects: projectIds });
+	const { layout, setLayout } = useDashboardLayout();
+	const { dates } = useRunDates();
+
+	// Calculate and store layout if not set (only in Columns mode)
+	useEffect(() => {
+		if (modeSettings.mode !== DASHBOARD_MODE.Columns) return;
+		if (layout) return; // Layout already set, don't recalculate
+
+		const initialMainDate = todayQuery.data?.date
+			? new Date(todayQuery.data.date)
+			: new Date();
+
+		// Use dates from runs if available, otherwise fallback to previous day
+		const initialSecondaryDate = dates[1] || addDays(initialMainDate, -1);
+
+		const effectiveMainDate = dateSearch.date || initialMainDate;
+		const effectiveSecondaryDate =
+			secondaryDateSearch.date || initialSecondaryDate;
+
+		// Check if dates need to be swapped to maintain chronological order (older on left)
+		const shouldSwap =
+			effectiveSecondaryDate &&
+			effectiveMainDate &&
+			effectiveSecondaryDate.getTime() > effectiveMainDate.getTime();
+
+		// Store the layout decision in URL
+		setLayout(shouldSwap ? 'main-left' : 'secondary-left');
+	}, [
+		modeSettings.mode,
+		layout,
+		todayQuery.data?.date,
+		dates,
+		dateSearch.date,
+		secondaryDateSearch.date,
+		setLayout
+	]);
 
 	if (todayQuery.isLoading || modeSettings.isModeLoading) {
 		return <LayoutHandlerLoading />;
@@ -40,10 +80,19 @@ export const LayoutHandlerContainer = () => {
 		const initialMainDate = todayQuery.data?.date
 			? new Date(todayQuery.data?.date)
 			: new Date();
-		const initialSecondaryDate = addDays(
-			todayQuery.data?.date ? new Date(todayQuery.data.date) : new Date(),
-			-1
-		);
+
+		// Use dates from runs if available, otherwise fallback to previous day
+		const initialSecondaryDate = dates[1] || addDays(initialMainDate, -1);
+
+		// Use stored layout for table positions (default to secondary-left if not set)
+		const useMainLeft = layout === 'main-left';
+
+		const leftTable = useMainLeft
+			? { id: DASHBOARD_TABLE_ID.Main, initialDate: initialMainDate }
+			: { id: DASHBOARD_TABLE_ID.Secondary, initialDate: initialSecondaryDate };
+		const rightTable = useMainLeft
+			? { id: DASHBOARD_TABLE_ID.Secondary, initialDate: initialSecondaryDate }
+			: { id: DASHBOARD_TABLE_ID.Main, initialDate: initialMainDate };
 
 		return (
 			<div className="flex flex-grow gap-1 overflow-hidden h-full">
@@ -51,18 +100,18 @@ export const LayoutHandlerContainer = () => {
 					className={cn('overflow-auto w-full relative styled-scrollbar pr-1')}
 				>
 					<DashboardTableContainer
-						id={DASHBOARD_TABLE_ID.Secondary}
+						id={leftTable.id}
 						mode={modeSettings.mode}
-						initialDate={initialSecondaryDate}
+						initialDate={leftTable.initialDate}
 					/>
 				</div>
 				<div
 					className={cn('overflow-auto w-full relative styled-scrollbar pr-1')}
 				>
 					<DashboardTableContainer
-						id={DASHBOARD_TABLE_ID.Main}
+						id={rightTable.id}
 						mode={modeSettings.mode}
-						initialDate={initialMainDate}
+						initialDate={rightTable.initialDate}
 					/>
 				</div>
 			</div>

--- a/libs/bublik/features/dashboard-v2/src/lib/today-button/today-button.container.tsx
+++ b/libs/bublik/features/dashboard-v2/src/lib/today-button/today-button.container.tsx
@@ -10,7 +10,9 @@ import { DASHBOARD_MODE } from '@/shared/types';
 import {
 	DASHBOARD_TABLE_ID,
 	useDashboardDate,
-	useDashboardModeSearch
+	useDashboardLayout,
+	useDashboardModeSearch,
+	useRunDates
 } from '../hooks';
 
 export const TodayButtonContainer = () => {
@@ -21,13 +23,23 @@ export const TodayButtonContainer = () => {
 	const { setDate: setSecondDate } = useDashboardDate(
 		DASHBOARD_TABLE_ID.Secondary
 	);
+	const { dates } = useRunDates();
+	const { reset: resetLayout } = useDashboardLayout();
 
 	const handleTodayButtonClick = () => {
 		if (mode === DASHBOARD_MODE.Columns) {
 			if (!data) return;
 
-			setFirstDate(new Date(data.date));
-			setSecondDate(addDays(new Date(data.date), -1));
+			// Reset layout so it gets recalculated based on new dates
+			resetLayout();
+
+			// dates[0] = most recent date with runs
+			// dates[1] = second most recent date with runs (or fallback to dates[0] - 1)
+			const mainDate = dates[0] || new Date(data.date);
+			const secondaryDate = dates[1] || addDays(mainDate, -1);
+
+			setFirstDate(mainDate);
+			setSecondDate(secondaryDate);
 			return;
 		}
 


### PR DESCRIPTION
## Summary

Update the split dashboard (columns mode) to always display the **two most recent available runs**, ensuring the latest run appears on the right and the previous run appears on the left.

## Changes

* Updated columns mode logic to select the last two available run dates instead of using the previous calendar day
* Ensured the most recent run is displayed in the right pane
* Displayed the immediately preceding run in the left pane for accurate comparisons

## Context

Fixes issue #232, where columns mode showed the previous calendar day on the left even when no run existed for that date. The dashboard now consistently displays actual run data, improving clarity and comparison accuracy.

## TODO:
 - [] Show "no test runs" on dates x,y,z