### PR TITLE
feat(run): add interrupted run status handling

### DIFF
--- a/apps/bublik/src/styles/tailwind.css
+++ b/apps/bublik/src/styles/tailwind.css
@@ -69,6 +69,7 @@ body,
 	--colors-bg-compromised: 240 7% 70%;
 	--colors-bg-stopped: 0 74% 93%;
 	--colors-bg-busy: 47 100% 64%;
+	--colors-bg-interrupted: 354 80% 75%;
 	--colors-border-primary: 214 26% 89%;
 
 	/* BADGES */

--- a/apps/bublik/tailwind-bublik-preset.js
+++ b/apps/bublik/tailwind-bublik-preset.js
@@ -33,6 +33,7 @@ module.exports = {
 				'bg-compromised': 'hsl(var(--colors-bg-compromised) / <alpha-value>)',
 				'bg-stopped': 'hsl(var(--colors-bg-stopped) / <alpha-value>)',
 				'bg-busy': 'hsl(var(--colors-bg-busy) / <alpha-value>)',
+				'bg-interrupted': 'hsl(var(--colors-bg-interrupted) / <alpha-value>)',
 				'border-primary': 'hsl(var(--colors-border-primary) / <alpha-value>)',
 				'badge-0': 'hsl(var(--colors-badge-0) / <alpha-value>)',
 				'badge-1': 'hsl(var(--colors-badge-1) / <alpha-value>)',

--- a/libs/bublik/features/runs/src/lib/runs-stats/runs-stats.component.utils.ts
+++ b/libs/bublik/features/runs/src/lib/runs-stats/runs-stats.component.utils.ts
@@ -82,6 +82,7 @@ export const getRunStatus = (stats: RunStats[], group: 'day' | 'week') => {
 				[RUN_STATUS.Busy]: 0,
 				[RUN_STATUS.Compromised]: 0,
 				[RUN_STATUS.Error]: 0,
+				[RUN_STATUS.Interrupted]: 0,
 				[RUN_STATUS.Ok]: 0,
 				[RUN_STATUS.Running]: 0,
 				[RUN_STATUS.Stopped]: 0,

--- a/libs/bublik/features/runs/src/lib/runs-stats/runs-stats.types.ts
+++ b/libs/bublik/features/runs/src/lib/runs-stats/runs-stats.types.ts
@@ -24,6 +24,7 @@ export const GroupedStatsSchema = z.object({
 	[RUN_STATUS.Busy]: z.number(),
 	[RUN_STATUS.Compromised]: z.number(),
 	[RUN_STATUS.Error]: z.number(),
+	[RUN_STATUS.Interrupted]: z.number(),
 	[RUN_STATUS.Ok]: z.number(),
 	[RUN_STATUS.Running]: z.number(),
 	[RUN_STATUS.Stopped]: z.number(),

--- a/libs/shared/tailwind-ui/src/lib/utils/run-info-helpers.tsx
+++ b/libs/shared/tailwind-ui/src/lib/utils/run-info-helpers.tsx
@@ -14,6 +14,8 @@ export const getRunStatusIcon = (runStatus: RUN_STATUS) => {
 			return <Icon name="InformationCircleCrossMark" size={18} />;
 		case RUN_STATUS.Compromised:
 			return <Icon name="InformationCircleStop" size={18} />;
+		case RUN_STATUS.Interrupted:
+			return <Icon name="InformationCircleStop" size={18} />;
 		case RUN_STATUS.Running:
 			return <Icon name="InformationCircleProgress" size={18} />;
 		case RUN_STATUS.Busy:
@@ -35,6 +37,8 @@ export const getRunStatusBgColor = (runStatus: RUN_STATUS): string => {
 			return 'bg-bg-error';
 		case RUN_STATUS.Compromised:
 			return 'bg-bg-compromised';
+		case RUN_STATUS.Interrupted:
+			return 'bg-bg-interrupted';
 		case RUN_STATUS.Running:
 			return 'bg-bg-running';
 		case RUN_STATUS.Busy:
@@ -56,6 +60,8 @@ export const getRunStatusBgColorRaw = (runStatus: RUN_STATUS): string => {
 			return '#f95c78';
 		case RUN_STATUS.Compromised:
 			return '#aeaeb9';
+		case RUN_STATUS.Interrupted:
+			return '#f0a0a6';
 		case RUN_STATUS.Running:
 			return '#7283e2';
 		case RUN_STATUS.Busy:

--- a/libs/shared/types/src/lib/run.ts
+++ b/libs/shared/types/src/lib/run.ts
@@ -46,7 +46,8 @@ export enum RUN_STATUS {
 	Running = 'run-running',
 	Compromised = 'run-compromised',
 	Busy = 'run-busy',
-	Stopped = 'run-stopped'
+	Stopped = 'run-stopped',
+	Interrupted = 'run-interrupted'
 }
 
 export type RunResult = {


### PR DESCRIPTION
Changes:
- Add handling for run with conclusion `run-interrupted`
<img width="1459" height="175" alt="Screenshot 2026-01-26 at 15 43 25" src="https://github.com/user-attachments/assets/653d3caa-2afd-4d27-ae89-c606da07b679" />
<img width="1470" height="247" alt="Screenshot 2026-01-26 at 15 43 39" src="https://github.com/user-attachments/assets/382608bc-1f3d-4456-9364-e52d913c4f86" />
<img width="732" height="130" alt="Screenshot 2026-01-26 at 15 43 51" src="https://github.com/user-attachments/assets/f866a51e-08dc-4fe3-a656-00d1d8549cb6" />

UI for https://github.com/ts-factory/bublik/pull/271
