### PR TITLE
fix(log): [new-bug] fix layout shift for "new bug" button

### DIFF
--- a/libs/bublik/features/log-preview-drawer/src/log-preview-new-bug.container.tsx
+++ b/libs/bublik/features/log-preview-drawer/src/log-preview-new-bug.container.tsx
@@ -6,8 +6,16 @@ import {
 	useGetTreeByRunIdQuery
 } from '@/services/bublik-api';
 import { RootBlock } from '@/shared/types';
+import { ButtonTw, Icon } from '@/shared/tailwind-ui';
 
 import { getBugProps, NewBugButton } from './new-bug.component';
+
+const LoadingState = () => (
+	<ButtonTw variant="secondary" size="xss" state="loading">
+		<Icon name="ProgressIndicator" className="size-5 mr-1.5 animate-spin" />
+		<span>New Bug</span>
+	</ButtonTw>
+);
 
 function getLogTablesFromLog(data?: RootBlock) {
 	if (!data) return [];
@@ -31,7 +39,7 @@ function NewBugContainer(props: NewBugProps) {
 	const { data: tree } = useGetTreeByRunIdQuery(String(props.runId));
 	const tables = getLogTablesFromLog(log);
 
-	if (!details || !tree || !log) return null;
+	if (!details || !tree || !log) return <LoadingState />;
 
 	return (
 		<NewBugButton


### PR DESCRIPTION
When opening page first time new bug button is now shown and appears once needed data is fetched add loading state to button so appearance does not cause layout shift.