### PR TITLE
fix(log): [preview] fix history link dropdown not visible

### DIFF
--- a/libs/shared/tailwind-ui/src/lib/split-button/split-button.component.tsx
+++ b/libs/shared/tailwind-ui/src/lib/split-button/split-button.component.tsx
@@ -97,7 +97,7 @@ const SplitButtonContent = React.forwardRef<
 		<DropdownMenu.Content
 			ref={ref}
 			className={cn(
-				'min-w-[220px] bg-white rounded-lg p-1 shadow-popover',
+				'z-[100] min-w-[220px] bg-white rounded-lg p-1 shadow-popover',
 				'rdx-state-open:rdx-side-top:animate-slide-down-fade',
 				'rdx-state-open:rdx-side-right:animate-slide-left-fade',
 				'rdx-state-open:rdx-side-bottom:animate-slide-up-fade',


### PR DESCRIPTION
The SplitButton dropdown content was appearing behind modals and drawers because it lacked an explicit z-index. Added z-[100] to ensure the dropdown appears above DialogOverlay (z-40) and DrawerContent (z-50).

Fixes issue where HistoryLinkContainer dropdown was invisible in LogPreviewDrawer.

## Before dropdown not visible
<img width="1379" height="348" alt="Screenshot 2026-01-29 at 00 21 05" src="https://github.com/user-attachments/assets/101c7c04-98b7-4217-b1d0-d0f8f4fe1697" />

## After dropdown now visible
<img width="1383" height="397" alt="Screenshot 2026-01-29 at 00 20 29" src="https://github.com/user-attachments/assets/f8ccbfeb-7686-4e07-86d2-b3fa4aebce0b" />
