### PR TITLE
fix(run): [details] not showing skeleton while details loading

### DIFF
--- a/libs/bublik/features/run-details/src/lib/run-details.component.tsx
+++ b/libs/bublik/features/run-details/src/lib/run-details.component.tsx
@@ -22,7 +22,7 @@ import { RunCommentFormContainer } from './run-comment.container';
 
 export const RunDetailsLoading = () => {
 	return (
-		<div className="flex flex-grow h-full p-2">
+		<div className="flex flex-grow h-full p-2 min-h-52">
 			<Skeleton className="flex-grow rounded" />
 		</div>
 	);


### PR DESCRIPTION
This was caused by missing min height for run details skeleton so while details were loading we just shown empty space.
Loading state before the fix:
<img width="1670" height="62" alt="Screenshot 2026-01-30 at 04 32 52" src="https://github.com/user-attachments/assets/8f7a12da-63a8-49a7-9cd7-530c74fa3faa" />

Loading state after the fix:
<img width="1663" height="253" alt="Screenshot 2026-01-30 at 04 33 17" src="https://github.com/user-attachments/assets/fad9c1aa-0942-4563-a958-17891f4612f1" />

