### PR TITLE
Update error handling

### DIFF
--- a/apps/bublik/src/pages/configs/create-config-form/create-new-config.container.tsx
+++ b/apps/bublik/src/pages/configs/create-config-form/create-new-config.container.tsx
@@ -8,11 +8,7 @@ import { z } from 'zod';
 import { useForm, Controller } from 'react-hook-form';
 
 import { useConfirm } from '@/shared/hooks';
-import {
-	bublikAPI,
-	ConfigExistsError,
-	ConfigValidationErrorSchema
-} from '@/services/bublik-api';
+import { bublikAPI, ConfigExistsError } from '@/services/bublik-api';
 import {
 	Input,
 	cn,
@@ -29,6 +25,7 @@ import {
 	FormAlertError,
 	ConfirmDialog
 } from '@/shared/tailwind-ui';
+import { setErrorsOnForm } from '@/shared/utils';
 
 import { useConfigPageSearchParams, useSavedState } from '../hooks';
 import { getEditorValue, isValidJson, ValidJsonStringSchema } from '../utils';
@@ -108,28 +105,15 @@ function CreateNewConfigScreen() {
 
 				setConfigId(e.configId);
 			}
-			const result = ConfigValidationErrorSchema.safeParse(e);
-			if (!result.success) {
-				form?.setError('root', {
-					message: `Unknown error occured: ${String(e)}`
-				});
-				return;
-			}
 
-			if (typeof result.data.data.message === 'object') {
-				Object.entries(result?.data.data.message).forEach(([key, error]) => {
+			setErrorsOnForm(e, {
+				handle: form,
+				onSetError: (key, error, form) => {
 					if (key === 'content') {
-						form?.setError('root', { message: error.join('\n') });
-						return;
+						form.setError('root', error);
 					}
-
-					// @ts-expect-error mapped frontend form field names to frontend so should be fine
-					return form?.setError(key, { message: error.join('\n') });
-				});
-				return;
-			}
-
-			form?.setError('root', { message: result.data.data.message });
+				}
+			});
 		}
 	}
 

--- a/apps/bublik/src/pages/configs/update-config-form/update-config-form.container.tsx
+++ b/apps/bublik/src/pages/configs/update-config-form/update-config-form.container.tsx
@@ -5,13 +5,13 @@ import { UseFormReturn } from 'react-hook-form';
 
 import {
 	ConfigExistsError,
-	ConfigValidationErrorSchema,
 	ConfigWithSameNameErrorResponseSchema,
 	EditConfigBody
 } from '@/services/bublik-api';
 import { useConfirm } from '@/shared/hooks';
-import { ButtonTw, ConfirmDialog, Icon, Skeleton } from '@/shared/tailwind-ui';
+import { ConfirmDialog, Skeleton } from '@/shared/tailwind-ui';
 import { useAuth } from '@/bublik/features/auth';
+import { setErrorsOnForm } from '@/shared/utils';
 
 import { useConfigPageSearchParams, useConfigById } from '../hooks';
 import { ConfigEditorForm } from './update-config-form.component';
@@ -72,30 +72,16 @@ function ConfigsEditorContainer({ configId }: ConfigsEditorContainerProps) {
 				setConfigId(e.configId);
 			}
 
-			const validationError = ConfigValidationErrorSchema.safeParse(e);
-			if (!validationError.success) {
-				form?.setError('root', {
-					message: `Unknown error occured: ${String(e)}`
-				});
-				return;
-			}
-
-			if (typeof validationError.data.data.message === 'object') {
-				Object.entries(validationError?.data.data.message).forEach(
-					([key, error]) => {
+			if (form) {
+				setErrorsOnForm(e, {
+					handle: form,
+					onSetError: (key, error, form) => {
 						if (key === 'content') {
-							form?.setError('root', { message: error.join('\n') });
-							return;
+							form.setError('root', error);
 						}
-
-						// @ts-expect-error mapped frontend form field names to frontend so should be fine
-						return form?.setError(key, { message: error.join('\n') });
 					}
-				);
-				return;
+				});
 			}
-
-			form?.setError('root', { message: validationError.data.data.message });
 		}
 	};
 

--- a/libs/bublik/features/projects/src/create-project-modal/create-project-modal.container.tsx
+++ b/libs/bublik/features/projects/src/create-project-modal/create-project-modal.container.tsx
@@ -23,6 +23,7 @@ import {
 	DialogPortal,
 	Icon
 } from '@/shared/tailwind-ui';
+import { setErrorsOnForm } from '@/shared/utils';
 
 interface CreateProjectModalProps {
 	children: React.ReactNode;
@@ -79,28 +80,7 @@ function CreateProjectForm({ onSuccess, onCancel }: CreateProjectFormProps) {
 			form.reset();
 			onSuccess?.();
 		} catch (e) {
-			try {
-				const {
-					data: { message }
-				} = z
-					.object({
-						status: z.number(),
-						data: z.object({
-							type: z.string(),
-							message: z.record(z.array(z.string()))
-						})
-					})
-					.parse(e);
-				const errorMessage = Object.entries(message)
-					.map(([key, error]) => `${key}: ${error}`)
-					.flat()
-					.join('\n');
-
-				form.setError('root', { message: errorMessage });
-			} catch (parseError) {
-				console.error(parseError);
-				form.setError('root', { message: 'Unknown Error!' });
-			}
+			setErrorsOnForm(e, { handle: form });
 		}
 	};
 

--- a/libs/bublik/features/projects/src/update-project-modal/update-project-modal.container.tsx
+++ b/libs/bublik/features/projects/src/update-project-modal/update-project-modal.container.tsx
@@ -6,8 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import {
 	bublikAPI,
 	CreateProject,
-	CreateProjectSchema,
-	getErrorMessage
+	CreateProjectSchema
 } from '@/services/bublik-api';
 import {
 	ButtonTw,
@@ -22,6 +21,7 @@ import {
 	FormAlertError,
 	DialogPortal
 } from '@/shared/tailwind-ui';
+import { setErrorsOnForm } from '@/shared/utils';
 
 interface UpdateProjectModalProps {
 	children: React.ReactNode;
@@ -85,14 +85,14 @@ function UpdateProjectForm({
 			toast.promise(promise, {
 				loading: 'Updating project...',
 				success: 'Project updated successfully',
-				error: (e) => getErrorMessage(e).description
+				error: 'Failed to update project'
 			});
 
 			await promise;
 			form.reset({ name: data.name });
 			onSuccess?.();
 		} catch (e) {
-			return form.setError('root', { message: getErrorMessage(e).description });
+			setErrorsOnForm(e, { handle: form });
 		}
 	}
 

--- a/libs/bublik/features/run-import/src/lib/import-run-form/import-run-form.container.tsx
+++ b/libs/bublik/features/run-import/src/lib/import-run-form/import-run-form.container.tsx
@@ -5,6 +5,7 @@ import { z } from 'zod';
 
 import { ImportEventResponse, ImportRunsFormValues } from '@/shared/types';
 import { bublikAPI, useImportRunsMutation } from '@/services/bublik-api';
+import { setErrorsOnForm } from '@/shared/utils';
 
 import {
 	ImportRunForm,
@@ -42,12 +43,7 @@ export const useImportTasks = () => {
 			setStep('result');
 			setCeleryTasks(results);
 		} catch (e: unknown) {
-			if (e instanceof Error) {
-				form.setError('root', { message: String(e.message) });
-				return;
-			}
-
-			form.setError('root', { message: 'Unknown error' });
+			setErrorsOnForm(e, { handle: form });
 		}
 	};
 

--- a/libs/services/bublik-api/src/lib/error-handling/index.spec.ts
+++ b/libs/services/bublik-api/src/lib/error-handling/index.spec.ts
@@ -1,0 +1,113 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+import { describe, it, expect } from 'vitest';
+import { getErrorMessage, isUnifiedError } from './index';
+
+describe('Unified Error Handling', () => {
+	describe('isUnifiedError', () => {
+		it('should recognize unified error format with array messages', () => {
+			const error = {
+				status: 400,
+				data: { messages: ['Error 1', 'Error 2'] }
+			};
+			expect(isUnifiedError(error)).toBe(true);
+		});
+
+		it('should recognize unified error format with string messages', () => {
+			const error = {
+				status: 500,
+				data: { messages: 'Server error occurred' }
+			};
+			expect(isUnifiedError(error)).toBe(true);
+		});
+
+		it('should recognize unified error format with object messages', () => {
+			const error = {
+				status: 422,
+				data: {
+					messages: { name: ['Name required'], email: ['Invalid email'] }
+				}
+			};
+			expect(isUnifiedError(error)).toBe(true);
+		});
+
+		it('should not recognize old error formats', () => {
+			const oldError = {
+				status: 400,
+				data: { type: 'ValidationError', message: { name: ['error'] } }
+			};
+			expect(isUnifiedError(oldError)).toBe(false);
+		});
+	});
+
+	describe('getErrorMessage', () => {
+		it('should handle unified error with array messages', () => {
+			const error = {
+				status: 400,
+				data: { messages: ['Error 1', 'Error 2'] }
+			};
+			const result = getErrorMessage(error);
+			expect(result).toEqual({
+				status: 400,
+				title: 'Error',
+				description: 'Error 1, Error 2'
+			});
+		});
+
+		it('should handle unified error with string messages', () => {
+			const error = {
+				status: 500,
+				data: { messages: 'Server error occurred' }
+			};
+			const result = getErrorMessage(error);
+			expect(result).toEqual({
+				status: 500,
+				title: 'Error',
+				description: 'Server error occurred'
+			});
+		});
+
+		it('should handle unified error with object messages (validation)', () => {
+			const error = {
+				status: 422,
+				data: {
+					messages: { name: ['Name required'], email: ['Invalid email'] }
+				}
+			};
+			const result = getErrorMessage(error);
+			expect(result).toEqual({
+				status: 422,
+				title: 'Validation error',
+				description: 'name: Name required\nemail: Invalid email'
+			});
+		});
+
+		it('should still handle old error formats', () => {
+			const oldError = {
+				status: 400,
+				data: { type: 'ValidationError', message: { name: ['error'] } }
+			};
+			const result = getErrorMessage(oldError);
+			expect(result.status).toBe(400);
+			expect(result.title).toBe('ValidationError');
+		});
+
+		it('should handle unexpected server error', () => {
+			const unexpectedError = {
+				status: 500,
+				data: {
+					messages: [
+						'Unexpected server error. Try refreshing and let us know if it keeps happening.'
+					]
+				}
+			};
+			const result = getErrorMessage(unexpectedError);
+			expect(result).toEqual({
+				status: 500,
+				title: 'Error',
+				description:
+					'Unexpected server error. Try refreshing and let us know if it keeps happening.'
+			});
+		});
+	});
+});

--- a/libs/services/bublik-api/src/lib/error-handling/validation.ts
+++ b/libs/services/bublik-api/src/lib/error-handling/validation.ts
@@ -88,7 +88,21 @@ const HistoryParsingErrorSchema = z.object({
 	})
 });
 
+const UnifiedErrorSchema = z.object({
+	status: z.union([z.string(), z.number()]),
+	data: z.object({
+		messages: z.union([
+			z.string(),
+			z.array(z.string()),
+			z.record(z.union([z.string(), z.array(z.string())]))
+		])
+	})
+});
+
+export type UnifiedError = z.infer<typeof UnifiedErrorSchema>;
+
 export const BublikParsableErrorSchema = z.union([
+	UnifiedErrorSchema,
 	HttpErrorSchema,
 	FetchErrorSchema,
 	ParsingErrorSchema,
@@ -111,6 +125,12 @@ export const isValidationError = (
 	error: unknown
 ): error is z.infer<typeof ValidationErrorSchema> => {
 	return ValidationErrorSchema.safeParse(error).success;
+};
+
+export const isUnifiedError = (
+	error: unknown
+): error is z.infer<typeof UnifiedErrorSchema> => {
+	return UnifiedErrorSchema.safeParse(error).success;
 };
 
 export const isBublikAuthError = (

--- a/libs/shared/utils/src/lib/form.spec.ts
+++ b/libs/shared/utils/src/lib/form.spec.ts
@@ -1,0 +1,415 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+import { it, describe, expect, vi } from 'vitest';
+import { UseFormReturn } from 'react-hook-form';
+
+import { setErrorsOnForm } from './form';
+
+type TestFormData = {
+	name: string;
+	email: string;
+	password: string;
+};
+
+describe('setErrorsOnForm', () => {
+	const createMockFormHandle = () => {
+		const setError = vi.fn();
+		const onSetError = vi.fn();
+		const handle = {
+			setError,
+			formState: { errors: {} }
+		} as unknown as UseFormReturn<TestFormData>;
+
+		return { setError, onSetError, handle };
+	};
+
+	describe('String Error Format', () => {
+		it('should set root error for string data', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(
+				{ status: 400, data: 'This is a string error' },
+				{ handle, onSetError }
+			);
+
+			expect(setError).toHaveBeenCalledWith('root', {
+				type: 'custom',
+				message: 'This is a string error'
+			});
+			expect(onSetError).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('Just Error Format', () => {
+		it('should set root error for simple message object', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(
+				{ status: 400, data: { message: 'Simple error message' } },
+				{ handle, onSetError }
+			);
+
+			expect(setError).toHaveBeenCalledWith('root', {
+				type: 'custom',
+				message: 'Simple error message'
+			});
+			expect(onSetError).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('New Error - Array Format', () => {
+		it('should set root error with first message from array', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(
+				{
+					status: 500,
+					data: {
+						messages: [
+							'Unexpected server error. Try refreshing and let us know if it keeps happening.'
+						]
+					}
+				},
+				{ handle, onSetError }
+			);
+
+			expect(setError).toHaveBeenCalledWith('root', {
+				type: 'custom',
+				message:
+					'Unexpected server error. Try refreshing and let us know if it keeps happening.'
+			});
+			expect(onSetError).not.toHaveBeenCalled();
+		});
+
+		it('should use fallback if messages array is empty', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(
+				{ status: 500, data: { messages: [] } },
+				{ handle, onSetError }
+			);
+
+			expect(setError).toHaveBeenCalledWith('root', {
+				type: 'custom',
+				message: 'Unknown error!'
+			});
+		});
+
+		it('should use first message if array has multiple items', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(
+				{
+					status: 500,
+					data: { messages: ['First error', 'Second error', 'Third error'] }
+				},
+				{ handle, onSetError }
+			);
+
+			expect(setError).toHaveBeenCalledWith('root', {
+				type: 'custom',
+				message: 'First error'
+			});
+		});
+	});
+
+	describe('New Error - Object Format', () => {
+		it('should set field-level errors for each field', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(
+				{
+					status: 400,
+					data: {
+						messages: {
+							name: ['Name is required'],
+							email: ['Email is invalid'],
+							password: ['Password too short']
+						}
+					}
+				},
+				{ handle, onSetError }
+			);
+
+			expect(setError).toHaveBeenCalledWith('name', {
+				type: 'custom',
+				message: 'Name is required'
+			});
+			expect(setError).toHaveBeenCalledWith('email', {
+				type: 'custom',
+				message: 'Email is invalid'
+			});
+			expect(setError).toHaveBeenCalledWith('password', {
+				type: 'custom',
+				message: 'Password too short'
+			});
+			expect(onSetError).toHaveBeenCalledTimes(3);
+		});
+
+		it('should handle string values in messages object', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(
+				{
+					status: 400,
+					data: {
+						messages: {
+							name: 'Single error string',
+							email: 'Another string'
+						}
+					}
+				},
+				{ handle, onSetError }
+			);
+
+			expect(setError).toHaveBeenCalledWith('name', {
+				type: 'custom',
+				message: 'Single error string'
+			});
+			expect(setError).toHaveBeenCalledWith('email', {
+				type: 'custom',
+				message: 'Another string'
+			});
+		});
+
+		it('should use first error from array', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(
+				{
+					status: 400,
+					data: {
+						messages: {
+							name: ['First error', 'Second error', 'Third error']
+						}
+					}
+				},
+				{ handle, onSetError }
+			);
+
+			expect(setError).toHaveBeenCalledWith('name', {
+				type: 'custom',
+				message: 'First error'
+			});
+		});
+
+		it('should call onSetError callback for each field error', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(
+				{
+					status: 400,
+					data: {
+						messages: {
+							name: ['Error 1'],
+							email: ['Error 2']
+						}
+					}
+				},
+				{ handle, onSetError }
+			);
+
+			expect(setError).toHaveBeenCalledWith('name', {
+				type: 'custom',
+				message: 'Error 1'
+			});
+			expect(setError).toHaveBeenCalledWith('email', {
+				type: 'custom',
+				message: 'Error 2'
+			});
+			expect(onSetError).toHaveBeenCalledWith(
+				'name',
+				{ type: 'custom', message: 'Error 1' },
+				handle
+			);
+			expect(onSetError).toHaveBeenCalledWith(
+				'email',
+				{ type: 'custom', message: 'Error 2' },
+				handle
+			);
+		});
+	});
+
+	describe('Old Error Schema - Message Object', () => {
+		it('should set field-level errors for old format with type and message object', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(
+				{
+					status: 400,
+					data: {
+						type: 'ValidationError',
+						message: {
+							name: ['Name is required'],
+							email: ['Invalid email format']
+						}
+					}
+				},
+				{ handle, onSetError }
+			);
+
+			expect(setError).toHaveBeenCalledWith('name', {
+				type: 'custom',
+				message: 'Name is required'
+			});
+			expect(setError).toHaveBeenCalledWith('email', {
+				type: 'custom',
+				message: 'Invalid email format'
+			});
+			expect(onSetError).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('500 Error Fallback', () => {
+		it('should JSON stringify 500 errors that do not match schemas', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			const error = {
+				status: 500,
+				data: { unexpected: 'data structure' },
+				extra: 'field'
+			};
+
+			setErrorsOnForm<TestFormData>(error, { handle, onSetError });
+
+			const errorMessage = JSON.stringify(error, null, 2);
+			expect(setError).toHaveBeenCalledWith('root', {
+				type: 'json',
+				message: errorMessage
+			});
+		});
+
+		it('should handle JSON stringify errors gracefully', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			const circularError = { status: 500, data: {} } as {
+				status: number;
+				data: { self?: unknown };
+			};
+			circularError.data.self = circularError;
+
+			setErrorsOnForm<TestFormData>(circularError, { handle, onSetError });
+
+			expect(setError).toHaveBeenCalledWith('root', {
+				message: 'Unknown error!'
+			});
+		});
+	});
+
+	describe('Unknown Error', () => {
+		it('should set Unknown error for unrecognised error format', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(
+				{ random: 'object structure' },
+				{ handle, onSetError }
+			);
+
+			expect(setError).toHaveBeenCalledWith('root', {
+				message: 'Unknown error!'
+			});
+		});
+
+		it('should handle null error', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(null, { handle, onSetError });
+
+			expect(setError).toHaveBeenCalledWith('root', {
+				message: 'Unknown error!'
+			});
+		});
+
+		it('should handle undefined error', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(undefined, { handle, onSetError });
+
+			expect(setError).toHaveBeenCalledWith('root', {
+				message: 'Unknown error!'
+			});
+		});
+
+		it('should work without onSetError callback', () => {
+			const { onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(
+				{
+					status: 400,
+					data: { messages: { name: ['Error'] } }
+				},
+				{ handle }
+			);
+
+			expect(handle.setError).toHaveBeenCalledWith('name', {
+				type: 'custom',
+				message: 'Error'
+			});
+			expect(onSetError).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('Real-world API Error Examples', () => {
+		it('should handle config validation error with messages object', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(
+				{
+					status: 400,
+					data: {
+						messages: {
+							name: ["Report configuration 'report' already exist for default"]
+						}
+					}
+				},
+				{ handle, onSetError }
+			);
+
+			expect(setError).toHaveBeenCalledWith('name', {
+				type: 'custom',
+				message: "Report configuration 'report' already exist for default"
+			});
+		});
+
+		it('should handle password validation error with messages object', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(
+				{
+					status: 400,
+					data: { messages: { current_password: ['Invalid password'] } }
+				},
+				{ handle, onSetError }
+			);
+
+			expect(setError).toHaveBeenCalledWith('current_password', {
+				type: 'custom',
+				message: 'Invalid password'
+			});
+		});
+
+		it('should handle global config name validation', () => {
+			const { setError, onSetError, handle } = createMockFormHandle();
+
+			setErrorsOnForm<TestFormData>(
+				{
+					status: 400,
+					data: {
+						messages: {
+							name: [
+								"Unsupported global configuration name. Possible are: ['per_conf', 'references', 'meta']."
+							]
+						}
+					}
+				},
+				{ handle, onSetError }
+			);
+
+			expect(setError).toHaveBeenCalledWith('name', {
+				type: 'custom',
+				message:
+					"Unsupported global configuration name. Possible are: ['per_conf', 'references', 'meta']."
+			});
+		});
+	});
+});

--- a/libs/shared/utils/src/lib/form.ts
+++ b/libs/shared/utils/src/lib/form.ts
@@ -11,10 +11,23 @@ const ErrorSchema = z.object({
 
 const JustError = z.object({ message: z.string() });
 
-const FormResponseSchema = z.object({
-	status: z.string().or(z.number()),
-	data: z.union([ErrorSchema, JustError])
+const NewErrorSchema = z.object({
+	messages: z.union([
+		z.array(z.string()),
+		z.record(z.array(z.string()).or(z.string()))
+	])
 });
+
+const FormResponseSchema = z.union([
+	z.object({
+		status: z.string().or(z.number()),
+		data: z.union([ErrorSchema, JustError])
+	}),
+	z.object({
+		status: z.string().or(z.number()),
+		data: NewErrorSchema
+	})
+]);
 
 const StringErrorSchema = z.object({
 	status: z.string().or(z.number()),
@@ -40,43 +53,66 @@ export const setErrorsOnForm = <TFieldValues extends FieldValues = FieldValues>(
 	error: unknown,
 	config: SetErrorsOnFormConfig<TFieldValues>
 ) => {
-	if (
-		typeof error === 'object' &&
-		error &&
-		'status' in error &&
-		Number(error.status) >= 500
-	) {
-		try {
-			const jsonString = JSON.stringify(error, null, 2);
-			config.handle.setError('root', { type: 'json', message: jsonString });
-		} catch (e) {
-			config.handle.setError('root', { message: 'Unknown error!' });
+	const stringResult = StringErrorSchema.safeParse(error);
+	if (stringResult.success) {
+		config.handle.setError('root', getError(stringResult.data.data));
+		return;
+	}
+
+	const formResult = FormResponseSchema.safeParse(error);
+	if (!formResult.success) {
+		if (
+			typeof error === 'object' &&
+			error &&
+			'status' in error &&
+			typeof error.status === 'number' &&
+			error.status >= 500
+		) {
+			try {
+				const jsonString = JSON.stringify(error, null, 2);
+				config.handle.setError('root', { type: 'json', message: jsonString });
+			} catch (e) {
+				config.handle.setError('root', { message: 'Unknown error!' });
+			}
+			return;
 		}
+		config.handle.setError('root', { message: 'Unknown error!' });
 		return;
 	}
 
-	if (StringErrorSchema.safeParse(error).success) {
-		const parsedError = error as z.infer<typeof StringErrorSchema>;
+	const parsed = formResult.data;
 
-		config.handle.setError('root', getError(parsedError.data));
+	if ('message' in parsed.data && typeof parsed.data.message === 'string') {
+		config.handle.setError('root', getError(parsed.data.message));
 		return;
 	}
 
-	try {
-		const parsed = FormResponseSchema.parse(error);
+	if ('messages' in parsed.data) {
+		const messages = parsed.data.messages;
 
-		if (typeof parsed.data.message === 'string') {
-			config.handle.setError('root', { message: parsed.data.message });
+		if (Array.isArray(messages)) {
+			config.handle.setError('root', getError(messages[0] || 'Unknown error!'));
 			return;
 		}
 
-		Object.entries(parsed.data.message).forEach(([key, error]) => {
-			const formError = getError(error);
+		Object.entries(messages).forEach(([key, error]) => {
+			const formError = getError(error as string | string[]);
 
 			config.handle.setError(key as Path<TFieldValues>, formError);
 			config.onSetError?.(key as Path<TFieldValues>, formError, config.handle);
 		});
-	} catch (e: unknown) {
-		config.handle.setError('root', { message: 'Unknown error!' });
+		return;
 	}
+
+	if ('message' in parsed.data && typeof parsed.data.message === 'object') {
+		Object.entries(parsed.data.message).forEach(([key, error]) => {
+			const formError = getError(error as string | string[]);
+
+			config.handle.setError(key as Path<TFieldValues>, formError);
+			config.onSetError?.(key as Path<TFieldValues>, formError, config.handle);
+		});
+		return;
+	}
+
+	config.handle.setError('root', { message: 'Unknown error!' });
 };


### PR DESCRIPTION
This PR updates the UI to align with the unified error response format introduced in [bublik #253](https://github.com/ts-factory/bublik/pull/253). The backend now returns all errors in a standardized format with a `messages` field, replacing the previous inconsistent error structures.

### Key Changes

**New Error Format Support**
- Backend now returns errors with a `messages` field that can be:
  - A list of strings for general errors: `{"messages": ["Error message"]}`
  - An object with field-specific errors: `{"messages": {"fieldName": ["Error"]}}`
- Replaces the old format that used `message` field with different structures

**New `setErrorsOnForm` Utility**
- Centralized error handling for react-hook-form across all forms
- Automatically detects and parses both new and old error formats for backward compatibility
- Supports field-level error mapping with optional `onSetError` callback for custom field transformations
- Handles 500 errors by displaying JSON-formatted error details for debugging

**Updated Forms**
- Create config form: Simplified error handling using `setErrorsOnForm`
- Update config form: Unified error handling with `onSetError` callback to map `content` field to root errors
- Create project modal: Removed manual Zod validation, now uses `setErrorsOnForm`
- Update project modal: Updated to use centralized error handler
- Import runs form: Simplified error handling

**Comprehensive Test Coverage**
- Added 415 lines of tests in `libs/shared/utils/src/lib/form.spec.ts`
- Tests cover all error formats: string messages, simple message objects, new messages array, new messages object, old schema format, 500 errors, and unknown errors
- Includes real-world API error examples from config validation and user management

### Breaking Changes

None - The implementation maintains backward compatibility with the old error format while supporting the new unified structure.

### Related

- Backend changes: [ts-factory/bublik#253](https://github.com/ts-factory/bublik/pull/253)