### PR TITLE
fix(run): show timezone offset in GMT format for dates column header

### DIFF
--- a/libs/bublik/features/runs/src/lib/runs-table/columns/dates-header.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-table/columns/dates-header.tsx
@@ -1,13 +1,14 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { FC } from 'react';
-
 import { Icon, Tooltip } from '@/shared/tailwind-ui';
+import { formatTimezoneOffset } from '@/shared/utils';
 
-export const DatesHeader: FC = () => {
+function DatesHeader() {
+	const timeZone = formatTimezoneOffset();
+
 	return (
 		<div className="flex items-center gap-1">
-			<Tooltip content="Time zone: UTC">
+			<Tooltip content={`Time zone: ${timeZone}`}>
 				<Icon
 					name="InformationCircleQuestionMark"
 					size={16}
@@ -17,4 +18,6 @@ export const DatesHeader: FC = () => {
 			<span>Dates</span>
 		</div>
 	);
-};
+}
+
+export { DatesHeader };

--- a/libs/shared/utils/src/lib/time.ts
+++ b/libs/shared/utils/src/lib/time.ts
@@ -18,6 +18,22 @@ export const formatTimeToDot = (date?: string): string => {
 	return format(parseISO(date), TIME_DOT_FORMAT);
 };
 
+export function formatTimezoneOffset(): string {
+	const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+
+	const offsetFormatter = new Intl.DateTimeFormat('en-US', {
+		timeZone,
+		timeZoneName: 'shortOffset'
+	});
+
+	const gmtOffset =
+		offsetFormatter
+			.formatToParts(new Date())
+			.find((part) => part.type === 'timeZoneName')?.value || 'GMT';
+
+	return gmtOffset;
+}
+
 export const parseDetailDate = (dateString?: string) => {
 	if (!dateString) return null;
 


### PR DESCRIPTION
## Summary

This PR fixes the timezone display in the Dates column header to show the offset in GMT format (e.g., "GMT+3") instead of the hardcoded UTC timezone

## Changes

- **Added `formatTimezoneOffset()` function** in `libs/shared/utils/src/lib/time.ts`
  - Returns timezone offset in "GMT±N" format using `Intl.DateTimeFormat` with `timeZoneName: 'shortOffset'`
  - Consistent with existing timezone formatting in `parseDetailDate` and `formatTimestampToFull`

- **Updated `DatesHeader` component** in `libs/bublik/features/runs/src/lib/runs-table/columns/dates-header.tsx`
  - Now uses `formatTimezoneOffset()` for the timezone tooltip
  - Tooltip shows "Time zone: GMT+3" instead of "Time zone: Europe/Moscow"

## Before / After

**Before:** Tooltip showed hardcoded incorrect UTC timezone
<img width="658" height="280" alt="Screenshot 2026-02-03 at 20 52 29" src="https://github.com/user-attachments/assets/6da6b29d-488f-4695-bb8e-24b35c7674f5" />

**After:** Tooltip shows GMT offset like "GMT+3"
<img width="649" height="276" alt="Screenshot 2026-02-03 at 20 47 25" src="https://github.com/user-attachments/assets/718f13d0-36da-467d-94be-f7a963fe29d2"/>