### PR TITLE
feat(run): change run ID copy method to clickable value

### DIFF
--- a/apps/bublik/src/pages/run-page/run-page.tsx
+++ b/apps/bublik/src/pages/run-page/run-page.tsx
@@ -14,15 +14,12 @@ import { DiffFormContainer } from '@/bublik/features/run-diff';
 import { CopyShortUrlButtonContainer } from '@/bublik/features/copy-url';
 import { routes } from '@/router';
 import { usePrefetchLogPage } from '@/services/bublik-api';
-import { useCopyToClipboard } from '@/shared/hooks';
 import {
 	ButtonTw,
 	CardHeader,
 	Icon,
 	RunModeToggle,
-	ScrollToTopPage,
-	toast,
-	Tooltip
+	ScrollToTopPage
 } from '@/shared/tailwind-ui';
 import { RunPageParams } from '@/shared/types';
 import { RunReportConfigsContainer } from '@/bublik/features/run-report';
@@ -35,14 +32,6 @@ export interface RunHeaderProps {
 
 const RunHeader = ({ runId }: RunHeaderProps) => {
 	const [isModeFull, setIsModeFull] = useState(false);
-	const [, copy] = useCopyToClipboard({
-		onSuccess: () =>
-			toast.success('Copied run ID to clipboard', { position: 'top-center' }),
-		onError: () =>
-			toast.error('Failed to copy run ID', { position: 'top-center' })
-	});
-
-	const handleCopyRunId = () => copy(runId);
 
 	const link = new URL(window.location.href);
 	link.searchParams.delete('rowState');
@@ -55,12 +44,6 @@ const RunHeader = ({ runId }: RunHeaderProps) => {
 						isFullMode={isModeFull}
 						onToggleClick={() => setIsModeFull(!isModeFull)}
 					/>
-					<Tooltip content="Copy identifier for comparison">
-						<ButtonTw variant="secondary" size="xss" onClick={handleCopyRunId}>
-							<Icon name="PaperStack" size={16} className="mr-1 text-primary" />
-							Copy ID
-						</ButtonTw>
-					</Tooltip>
 					<DefineCompromiseContainer runId={runId} />
 					<DiffFormContainer defaultValues={{ leftRunId: runId }} />
 					<RunReportConfigsContainer runId={runId} />

--- a/libs/bublik/features/run-details/src/lib/detail-item/detail-item.tsx
+++ b/libs/bublik/features/run-details/src/lib/detail-item/detail-item.tsx
@@ -2,19 +2,60 @@
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
 import { ReactNode } from 'react';
 
+import { useCopyToClipboard } from '@/shared/hooks';
+import { cn, Icon, toast } from '@/shared/tailwind-ui';
+
 export interface RunDetailsLabelProps {
 	label: string;
 	value?: string | number | ReactNode | null;
+	isCopyable?: boolean;
 }
 
-export const DetailItem = ({ label, value }: RunDetailsLabelProps) => {
+export const DetailItem = ({
+	label,
+	value,
+	isCopyable
+}: RunDetailsLabelProps) => {
+	const [, copy] = useCopyToClipboard();
+	const displayValue = value === null ? '-' : value;
+
+	const canCopy =
+		isCopyable &&
+		value !== null &&
+		value !== undefined &&
+		(typeof value === 'string' || typeof value === 'number');
+
+	const handleCopy = () => {
+		if (!canCopy) return;
+		copy(String(value)).then((success) => {
+			if (success) {
+				toast.success('Copied to clipboard');
+			} else {
+				toast.error('Failed to copy to clipboard');
+			}
+		});
+	};
+
 	return (
 		<>
 			<dt className="text-[0.6875rem] font-medium leading-[0.875rem] text-text-menu">
 				{label}
 			</dt>
-			<dd className="text-[0.6875rem] font-medium leading-[0.875rem]">
-				{value === null ? '-' : value}
+			<dd
+				className={cn(
+					'text-[0.6875rem] font-medium leading-[0.875rem] flex items-center gap-1 group',
+					canCopy && 'cursor-pointer hover:text-primary'
+				)}
+				onClick={handleCopy}
+			>
+				{displayValue}
+				{canCopy && (
+					<Icon
+						name="PaperStack"
+						size={14}
+						className="opacity-0 group-hover:opacity-100 transition-opacity text-primary"
+					/>
+				)}
 			</dd>
 		</>
 	);

--- a/libs/bublik/features/run-details/src/lib/run-details.component.tsx
+++ b/libs/bublik/features/run-details/src/lib/run-details.component.tsx
@@ -88,6 +88,7 @@ const RunDetailsMainInfo = (props: RunDetailsMainInfoProps) => {
 	if (!isFullMode) {
 		return (
 			<dl className="grid items-center grid-cols-[max-content,max-content] gap-y-2 gap-x-4">
+				<DetailItem label="Id" value={runId} isCopyable />
 				<DetailItem label="Start" value={runStartDate} />
 				<DetailItem
 					label="Conclusion"
@@ -99,7 +100,7 @@ const RunDetailsMainInfo = (props: RunDetailsMainInfoProps) => {
 
 	return (
 		<dl className="grid items-center grid-cols-[max-content,max-content] gap-y-2 gap-x-4">
-			<DetailItem label="Identifier" value={runId} />
+			<DetailItem label="Id" value={runId} isCopyable />
 			<DetailItem label="Main package" value={mainPackage} />
 			<DetailItem label="Start" value={runStartDate} />
 			<DetailItem label="Finish" value={runFinishDate} />


### PR DESCRIPTION
## Summary
This PR changes the way the run ID is copied. Instead of a separate 'Copy ID' button, the run ID is now displayed as a clickable value in both collapsed and expanded views.

## Screenshots
- Run ID is now clickable in both collapsed and expanded views
- Hovering shows the PaperStack copy icon
- Clicking copies the ID to clipboard

When hover over id:
<img width="298" height="151" alt="Screenshot 2026-02-05 at 20 44 44" src="https://github.com/user-attachments/assets/98a4d2e9-c040-4e9b-9536-f31a5424a8cc" />

Fixes #486