### PR TITLE
fix(run): standardize Notes column header alignment

### DIFF
--- a/libs/bublik/features/run/src/lib/run-table/columns/index.tsx
+++ b/libs/bublik/features/run/src/lib/run-table/columns/index.tsx
@@ -203,7 +203,7 @@ function getColumns({ projectId, runIds }: GetColumnsOptions) {
 		}),
 		helper.accessor('comments', {
 			id: ColumnId.Comments,
-			header: () => <div className="px-2">Notes</div>,
+			header: () => <div className="px-2 text-left">Notes</div>,
 			cell: ({ cell, row }) => {
 				const comments = cell.getValue();
 


### PR DESCRIPTION
Left-align the Notes column header to ensure consistent alignment with all other column headers in the Run table.

Closes #490