### PR TITLE
fix(run): make result table header cells visible when scrolling in safari

### DIFF
--- a/libs/bublik/features/run/src/lib/run-table/components/row/row.tsx
+++ b/libs/bublik/features/run/src/lib/run-table/components/row/row.tsx
@@ -25,7 +25,7 @@ export const RunRow = ({ row, runId, targetIterationId }: RowProps) => {
 		<Fragment>
 			<tr
 				className={cn(
-					'[&>*]:hover:bg-gray-50 h-full relative z-10',
+					'[&>*]:hover:bg-gray-50 h-full relative',
 					isExpandedTest &&
 						'[&>*]:bg-gray-50 h-full [&>*]:sticky [&>*]:top-[102px]'
 				)}
@@ -43,7 +43,7 @@ export const RunRow = ({ row, runId, targetIterationId }: RowProps) => {
 						<td
 							key={cell.id}
 							className={cn(
-								'px-2 py-0 bg-white',
+								'px-2 py-0 bg-white z-10',
 								isLast && 'border-r',
 								cell.column.columnDef.meta?.className
 							)}


### PR DESCRIPTION
Not visible:
<img width="1647" height="351" alt="Screenshot 2026-02-05 at 21 02 20" src="https://github.com/user-attachments/assets/50582dce-466b-43fa-8c1a-7c8d7a00e56c" />

After fix:
<img width="1659" height="364" alt="Screenshot 2026-02-05 at 21 02 51" src="https://github.com/user-attachments/assets/2802da51-191a-4a10-b882-541df5749967" />

Issue: https://github.com/ts-factory/bublik-ui/issues/489#issue-3902034677