### PR TITLE
fix(runs): filter runs by clicked conclusion in bar chart modal

### DIFF
--- a/libs/bublik/features/runs/src/lib/runs-stats/components/conclusion-section.component.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-stats/components/conclusion-section.component.tsx
@@ -47,13 +47,28 @@ export const ConclusionSection = ({ stats }: ConclusionSectionProps) => {
 		[stats]
 	);
 
-	const handleBarChartClick = useCallback((params: ECElementEvent) => {
-		const { ids: rawIds } = GroupedStatsSchema.parse(params.data);
-		const ids = rawIds.split(',');
+	const handleBarChartClick = useCallback(
+		(params: ECElementEvent) => {
+			if (!params.seriesName) return;
 
-		setIsModalOpen(true);
-		setRunIds(ids);
-	}, []);
+			const { ids: rawIds } = GroupedStatsSchema.parse(params.data);
+			const allIdsInGroup = rawIds.split(',');
+
+			const clickedStatus =
+				`run-${params.seriesName.toLowerCase()}` as RUN_STATUS;
+
+			const filteredIds = stats
+				.filter(
+					(s) =>
+						s.runStatus === clickedStatus && allIdsInGroup.includes(s.runId)
+				)
+				.map((s) => s.runId);
+
+			setIsModalOpen(true);
+			setRunIds(filteredIds);
+		},
+		[stats]
+	);
 
 	useEffect(() => {
 		pieRef.current?.getEchartsInstance()?.on('click', handlePieChartClick);


### PR DESCRIPTION
## Problem

When clicking on a specific bar section in the conclusion bar chart (e.g., "run-error"), the modal was showing **all** runs from that time period instead of filtering by the clicked conclusion.

## Solution

Modified the  function in  to:

1. Extract the clicked status from  (e.g., "OK" → "run-ok")
2. Filter the stats array to only include runs where:
   -  matches the clicked conclusion
   -  is in the clicked date group's ID list
3. Added a guard clause to handle undefined 

## Changes

- Updated  callback to filter runs by clicked conclusion
- Added dependency on  array for proper filtering
- Added null check for 

<img width="253" height="300" alt="Screenshot 2026-02-05 at 22 55 59" src="https://github.com/user-attachments/assets/cbb6721d-9e1a-4f55-820a-55f5168d7675" />

Before if user clicked on error:
<img width="705" height="420" alt="Screenshot 2026-02-05 at 22 54 56" src="https://github.com/user-attachments/assets/ce254979-1a22-4b78-94cc-82ee912a1868" />

After when user clicked on error:
<img width="735" height="192" alt="Screenshot 2026-02-05 at 22 55 35" src="https://github.com/user-attachments/assets/4e028066-9bb9-4b56-b384-ab6d80d8f413" />
