### PR TITLE
perf: improve initial loading for application

### DIFF
--- a/apps/bublik/src/app/router.tsx
+++ b/apps/bublik/src/app/router.tsx
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import { lazy, useEffect, useState, Suspense } from 'react';
 import {
 	Navigate,
 	Outlet,
@@ -14,34 +15,29 @@ import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 import { config } from '@/bublik/config';
 import { ErrorBoundary } from '@/shared/tailwind-ui';
 
-import {
-	DevelopersLayout,
-	FlowerFeature,
-	ImportPage,
-	NoMatchFeature,
-	LogPage,
-	RunPage,
-	MeasurementsPage,
-	HelpPage,
-	RunsPage,
-	RunDiffPage,
-	HistoryPageV2,
-	LoginPage,
-	ForgotPage,
-	AuthLayout,
-	ResetPasswordPage,
-	AdminUsersPage,
-	DashboardPageV2,
-	EmailActivationPage,
-	RunReportPage,
-	ConfigsPage,
-	RunMultiplePage,
-	NetPacketAnalyzerPage
-} from '../pages';
+import { AuthLayout } from '../pages/auth/auth.layout';
 import { Layout } from './layout';
 import { RedirectToLogPage } from './redirects';
 
-import { useEffect, useState } from 'react';
+import { AdminUsersPage } from '../pages/admin-users/admin-users.page';
+import { ConfigsPage } from '../pages/configs/configs.page';
+import { DashboardPageV2 } from '../pages/dashboard-page/dashboard-page-v2';
+import {
+	DevelopersLayout,
+	FlowerFeature
+} from '../pages/developers-page/developers-page';
+import { EmailActivationPage } from '../pages/auth/email-activation.page';
+import { ForgotPage } from '../pages/auth/forgot.page';
+import { HelpPage } from '../pages/help-page/help-page';
+import { LoginPage } from '../pages/auth/login.page';
+import { LogPage } from '../pages/log-page/log-page';
+import { NoMatchFeature } from '../pages/not-found-page/not-found-page';
+import { ResetPasswordPage } from '../pages/auth/reset-password.page';
+import { RunDiffPage } from '../pages/run-diff-page/run-diff-page';
+import { RunMultiplePage } from '../pages/run-multiple';
+import { RunPage } from '../pages/run-page/run-page';
+import { HistoryPageV2 } from '../pages/history-page/history-page';
+
 import { CopyShortUrlCommandItemContainer } from '@/bublik/features/copy-url';
 import {
 	Command,
@@ -52,8 +48,36 @@ import {
 	CommandItem,
 	CommandList,
 	CommandSeparator,
-	Icon
+	Icon,
+	Spinner
 } from '@/shared/tailwind-ui';
+import { RunsPage } from '../pages/runs-page';
+
+const ImportPage = lazy(() =>
+	import('../pages/import-page/import-page').then((module) => ({
+		default: module.ImportPage
+	}))
+);
+
+const MeasurementsPage = lazy(() =>
+	import('../pages/measurements-page/measurements-page').then((module) => ({
+		default: module.MeasurementsPage
+	}))
+);
+
+const NetPacketAnalyzerPage = lazy(() =>
+	import('../pages/net-packet-analyzer/net-packet-analyzer.page').then(
+		(module) => ({
+			default: module.NetPacketAnalyzerPage
+		})
+	)
+);
+
+const RunReportPage = lazy(() =>
+	import('../pages/run-report/run-report.page').then((module) => ({
+		default: module.RunReportPage
+	}))
+);
 
 function BublikCommand() {
 	const [open, setOpen] = useState(false);
@@ -138,6 +162,12 @@ function BublikCommand() {
 	);
 }
 
+function LazyRoute({ children }: { children: React.ReactNode }) {
+	return (
+		<Suspense fallback={<Spinner className="h-48" />}>{children}</Suspense>
+	);
+}
+
 const router = createBrowserRouter(
 	[
 		{
@@ -184,21 +214,42 @@ const router = createBrowserRouter(
 						{ path: '/dashboard', element: <DashboardPageV2 /> },
 						{
 							path: '/tools/packet-viewer',
-							element: <NetPacketAnalyzerPage />
+							element: (
+								<LazyRoute>
+									<NetPacketAnalyzerPage />
+								</LazyRoute>
+							)
 						},
-						{ path: '/history', element: <HistoryPageV2 /> },
-						{ path: '/history/v2', element: <HistoryPageV2 /> },
+						{
+							path: '/history',
+							element: <HistoryPageV2 />
+						},
+						{
+							path: '/history/v2',
+							element: <HistoryPageV2 />
+						},
 						{ path: '/log/:runId/:old', element: <RedirectToLogPage /> },
 						{ path: '/log/:runId', element: <LogPage /> },
 						{
 							path: '/runs/:runId/report',
-							element: <RunReportPage />
+							element: (
+								<LazyRoute>
+									<RunReportPage />
+								</LazyRoute>
+							)
 						},
 						{
 							path: '/runs/:runId/results/:resultId/measurements',
-							element: <MeasurementsPage />
+							element: (
+								<LazyRoute>
+									<MeasurementsPage />
+								</LazyRoute>
+							)
 						},
-						{ path: '/runs', element: <RunsPage /> },
+						{
+							path: '/runs',
+							element: <RunsPage />
+						},
 						{ path: '/compare', element: <RunDiffPage /> },
 						{ path: '/multiple', element: <RunMultiplePage /> },
 						{
@@ -209,10 +260,31 @@ const router = createBrowserRouter(
 							path: '/admin',
 							element: <DevelopersLayout />,
 							children: [
-								{ path: 'import', element: <ImportPage /> },
+								{
+									path: 'import',
+									element: (
+										<LazyRoute>
+											<ImportPage />
+										</LazyRoute>
+									)
+								},
 								{ path: 'flower', element: <FlowerFeature /> },
-								{ path: 'users', element: <AdminUsersPage /> },
-								{ path: 'config', element: <ConfigsPage /> },
+								{
+									path: 'users',
+									element: (
+										<LazyRoute>
+											<AdminUsersPage />
+										</LazyRoute>
+									)
+								},
+								{
+									path: 'config',
+									element: (
+										<LazyRoute>
+											<ConfigsPage />
+										</LazyRoute>
+									)
+								},
 								{ element: <NoMatchFeature /> }
 							]
 						},

--- a/apps/bublik/src/pages/auth/auth.layout.tsx
+++ b/apps/bublik/src/pages/auth/auth.layout.tsx
@@ -1,11 +1,15 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, Suspense } from 'react';
+
+import { Spinner } from '@/shared/tailwind-ui';
 
 export const AuthLayout = (props: PropsWithChildren) => {
 	return (
 		<div className="relative grid h-screen place-items-center">
-			{props.children}
+			<Suspense fallback={<Spinner className="h-screen" />}>
+				{props.children}
+			</Suspense>
 		</div>
 	);
 };

--- a/apps/bublik/vite.config.mts
+++ b/apps/bublik/vite.config.mts
@@ -99,7 +99,11 @@ export default defineConfig(({ mode }) => {
 				output: {
 					manualChunks: {
 						echarts: ['echarts'],
-						react: ['react', 'react-dom', 'react-router-dom']
+						react: ['react', 'react-dom', 'react-router-dom'],
+						monaco: ['monaco-editor', '@monaco-editor/react'],
+						shiki: ['react-shiki'],
+						prettier: ['prettier', 'prettier/parser-babel'],
+						reactJsonView: ['react-json-view']
 					}
 				}
 			}

--- a/libs/bublik/features/history/src/lib/history-mode-picker/history-mode-picker.container.tsx
+++ b/libs/bublik/features/history/src/lib/history-mode-picker/history-mode-picker.container.tsx
@@ -1,17 +1,32 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import { lazy, Suspense } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
+import { Spinner } from '@/shared/tailwind-ui';
 import { useUnmount } from '@/shared/hooks';
 
 import { useHistoryActions, useSyncHistoryQueryToState } from '../slice';
 import { HistoryLinearContainer } from '../history-linear';
 import { HistoryAggregationContainer } from '../history-aggregation';
-import {
-	PlotListContainer,
-	PlotListContainerByResult
-} from '../history-measurements';
-import { HistoryMeasurementsCombinedContainer } from '../history-measurements-combined';
+
+const PlotListContainer = lazy(() =>
+	import('../history-measurements').then((module) => ({
+		default: module.PlotListContainer
+	}))
+);
+
+const PlotListContainerByResult = lazy(() =>
+	import('../history-measurements').then((module) => ({
+		default: module.PlotListContainerByResult
+	}))
+);
+
+const HistoryMeasurementsCombinedContainer = lazy(() =>
+	import('../history-measurements-combined').then((module) => ({
+		default: module.HistoryMeasurementsCombinedContainer
+	}))
+);
 
 export const HistoryPageModePickerContainer = () => {
 	const actions = useHistoryActions();
@@ -25,14 +40,28 @@ export const HistoryPageModePickerContainer = () => {
 
 	if (mode === 'aggregation') return <HistoryAggregationContainer />;
 
-	if (mode === 'measurements') return <PlotListContainer />;
+	if (mode === 'measurements') {
+		return (
+			<Suspense fallback={<Spinner className="h-48" />}>
+				<PlotListContainer />
+			</Suspense>
+		);
+	}
 
 	if (mode === 'measurements-by-iteration') {
-		return <PlotListContainerByResult />;
+		return (
+			<Suspense fallback={<Spinner className="h-48" />}>
+				<PlotListContainerByResult />
+			</Suspense>
+		);
 	}
 
 	if (mode === 'measurements-combined') {
-		return <HistoryMeasurementsCombinedContainer />;
+		return (
+			<Suspense fallback={<Spinner className="h-48" />}>
+				<HistoryMeasurementsCombinedContainer />
+			</Suspense>
+		);
 	}
 
 	return <HistoryLinearContainer />;

--- a/libs/bublik/features/runs/src/lib/runs-mode-picker/runs-mode-picker.container.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-mode-picker/runs-mode-picker.container.tsx
@@ -1,16 +1,30 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import { lazy, Suspense } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
+import { Spinner } from '@/shared/tailwind-ui';
+
 import { RunsTableContainer } from '../runs-table';
-import { RunsStatsContainer } from '../runs-stats';
+
+const RunsStatsContainer = lazy(() =>
+	import('../runs-stats').then((module) => ({
+		default: module.RunsStatsContainer
+	}))
+);
 
 export const RunsModePickerContainer = () => {
 	const [searchParams] = useSearchParams();
 
 	if (searchParams.get('mode') === 'table') return <RunsTableContainer />;
 
-	if (searchParams.get('mode') === 'charts') return <RunsStatsContainer />;
+	if (searchParams.get('mode') === 'charts') {
+		return (
+			<Suspense fallback={<Spinner className="h-48" />}>
+				<RunsStatsContainer />
+			</Suspense>
+		);
+	}
 
 	return <RunsTableContainer />;
 };

--- a/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/blocks/log-content-mi/log-content-mi.tsx
+++ b/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/blocks/log-content-mi/log-content-mi.tsx
@@ -1,16 +1,25 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import { lazy, Suspense } from 'react';
+
 import { LogContentMiBlock, LogContentMiChartSchema } from '@/shared/types';
-
 import { checkSchema } from '@/shared/utils';
-import { JsonViewer } from '@/shared/tailwind-ui';
+import { JsonViewer, Spinner } from '@/shared/tailwind-ui';
 
-import { LogMiChart } from './blocks';
+const LogMiChart = lazy(() =>
+	import('./blocks/log-mi-chart').then((module) => ({
+		default: module.LogMiChart
+	}))
+);
 
 export const BlockLogContentChart = (props: LogContentMiBlock) => {
 	if (!checkSchema(LogContentMiChartSchema, props.content)) {
 		return <JsonViewer src={props.content} />;
 	}
 
-	return <LogMiChart {...props.content} />;
+	return (
+		<Suspense fallback={<Spinner className="h-48" />}>
+			<LogMiChart {...props.content} />
+		</Suspense>
+	);
 };


### PR DESCRIPTION
### 🚀 Improve initial load performance via lazy loading & vendor chunk splitting

This PR significantly improves initial page load performance by reducing the amount of JavaScript shipped on first render.

#### ✅ What changed
- Lazy-loaded non-critical pages to defer loading until needed
- Split vendor chunks so shared dependencies are cached and loaded independently
- Reduced work performed during initial render

#### 📊 Results (Fast 4G preset)
| Metric | Before | After |
|------|--------|-------|
| Initial page load | ~8.0s | **~2.47s** |
| Initial JS bundle size | ~6120 KB | **~466 KB** |

This results in an **~70% faster initial load** and a **>90% reduction in initial bundle size**.

Screenshots below show before/after comparisons under identical network conditions.

Before:
<img width="1029" height="43" alt="Screenshot 2026-02-10 at 00 33 39" src="https://github.com/user-attachments/assets/a23a8adc-7aab-4b73-85ab-e7cec08fd34d" />

After:
<img width="1028" height="41" alt="Screenshot 2026-02-10 at 00 38 36" src="https://github.com/user-attachments/assets/96abc133-8b6e-4e58-8918-4851b6ffbce8" />

Related: https://github.com/ts-factory/bublik-docker/pull/48
