### PR TITLE
fix(run-table): preserve runIds on /multiple reset

### DIFF
--- a/libs/bublik/features/run/src/lib/run-table/run-table.hooks.ts
+++ b/libs/bublik/features/run/src/lib/run-table/run-table.hooks.ts
@@ -85,7 +85,7 @@ function useColumnVisibility() {
 		const newState =
 			typeof state === 'function' ? state(columnVisibility) : state;
 
-		setQueryColumnVisibility(newState, 'replace');
+		setQueryColumnVisibility(newState, 'replaceIn');
 		setLocalColumnVisibility(newState);
 	};
 


### PR DESCRIPTION
## Summary
- switch column visibility query updates from `replace` to `replaceIn`
- preserve existing URL params on `/multiple` (including repeated `runIds`) when using Columns/Reset
- prevent selected runs from being dropped after reset actions

Fixes #511