### PR TITLE
fix(result): crash caused by incorrect import from react-router

### DIFF
--- a/libs/bublik/features/measurements/src/lib/components/mode-picker/index.tsx
+++ b/libs/bublik/features/measurements/src/lib/components/mode-picker/index.tsx
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
 import { skipToken } from '@reduxjs/toolkit/query';
-import { useParams } from 'react-router';
+import { useParams } from 'react-router-dom';
 
 import { useGetSingleMeasurementQuery } from '@/services/bublik-api';
 import { getColorByIdx, SelectedChartsPopover } from '@/shared/charts';

--- a/libs/bublik/features/measurements/src/lib/hooks/index.ts
+++ b/libs/bublik/features/measurements/src/lib/hooks/index.ts
@@ -1,5 +1,4 @@
-import { useNavigate } from 'react-router';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
 	useQueryParam,
 	NumericArrayParam,


### PR DESCRIPTION
Incorrect import from wrong package causes crash and mismatch for reading params from wrong context