### PR TITLE
Remove history legend empty items and fix labels capitalization

### DIFF
--- a/libs/bublik/features/history/src/lib/history-filter-legend/history-filter-legend.component.tsx
+++ b/libs/bublik/features/history/src/lib/history-filter-legend/history-filter-legend.component.tsx
@@ -3,15 +3,7 @@
 import { Badge, BadgeVariants, Icon, IconProps } from '@/shared/tailwind-ui';
 
 const LegendItemValue = ({ value }: { value?: LegendItemProps['value'] }) => {
-	if (!value || !value.length) {
-		return (
-			<Badge variant={BadgeVariants.Primary} className="bg-primary-wash">
-				<span className="text-[0.6875rem] leading-[0.875rem] text-text-secondary">
-					&#8212;
-				</span>
-			</Badge>
-		);
-	}
+	if (!value) return null;
 
 	if (!Array.isArray(value)) {
 		return (
@@ -22,6 +14,8 @@ const LegendItemValue = ({ value }: { value?: LegendItemProps['value'] }) => {
 			</Badge>
 		);
 	}
+
+	if (!value.length) return null;
 
 	return (
 		<>

--- a/libs/bublik/features/history/src/lib/history-filter-legend/history-filter-legend.container.utils.spec.ts
+++ b/libs/bublik/features/history/src/lib/history-filter-legend/history-filter-legend.container.utils.spec.ts
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+
+import { describe, expect, it } from 'vitest';
+
+import { HistoryAPIQuery, VERDICT_TYPE } from '@/shared/types';
+
+import { getLegendItems } from './history-filter-legend.container.utils';
+
+describe('getLegendItems', () => {
+	it('filters out legend items with empty values', () => {
+		const query: HistoryAPIQuery = {
+			testName: '   ',
+			hash: 'abc123',
+			branches: '  ;   ',
+			verdictLookup: VERDICT_TYPE.None,
+			verdict: '  '
+		};
+
+		const legendItems = getLegendItems(query);
+
+		expect(legendItems.some((item) => item.label === 'Test Name')).toBe(false);
+		expect(legendItems.some((item) => item.label === 'Branches')).toBe(false);
+		expect(legendItems.some((item) => item.label === 'Verdict Value')).toBe(
+			false
+		);
+		expect(legendItems.some((item) => item.label === 'Hash')).toBe(true);
+		expect(legendItems.some((item) => item.label === 'Date')).toBe(true);
+	});
+
+	it('keeps non-empty array values and removes empty array entries', () => {
+		const query: HistoryAPIQuery = {
+			branches: 'main; ;dev;  '
+		};
+
+		const legendItems = getLegendItems(query);
+		const branchesItem = legendItems.find((item) => item.label === 'Branches');
+
+		expect(branchesItem).toBeDefined();
+		expect(Array.isArray(branchesItem?.value)).toBe(true);
+		expect(branchesItem?.value).toEqual(['main', 'dev']);
+	});
+});

--- a/libs/bublik/features/history/src/lib/history-filter-legend/history-filter-legend.container.utils.ts
+++ b/libs/bublik/features/history/src/lib/history-filter-legend/history-filter-legend.container.utils.ts
@@ -6,6 +6,28 @@ import { formatTimeToDot } from '@/shared/utils';
 import { LegendItem } from './history-filter-legend.component';
 import { queryToHistorySearchState } from '../slice/history-slice.utils';
 
+const normalizeLegendItemValue = (
+	value?: LegendItem['value']
+): LegendItem['value'] => {
+	if (!value) return null;
+
+	if (!Array.isArray(value)) {
+		const trimmedValue = value.trim();
+
+		return trimmedValue.length ? trimmedValue : null;
+	}
+
+	const normalizedArray = value
+		.map((item) => item.trim())
+		.filter((item) => item.length > 0);
+
+	return normalizedArray.length ? normalizedArray : null;
+};
+
+const hasLegendItemValue = (item: LegendItem): boolean => {
+	return normalizeLegendItemValue(item.value) !== null;
+};
+
 export const getLegendItems = (search: HistoryAPIQuery): LegendItem[] => {
 	const state = queryToHistorySearchState(search);
 
@@ -13,11 +35,11 @@ export const getLegendItems = (search: HistoryAPIQuery): LegendItem[] => {
 		state.startDate.toISOString()
 	)} — ${formatTimeToDot(state.finishDate.toISOString())}`;
 
-	return [
+	const items: LegendItem[] = [
 		{
 			iconName: 'Paper',
 			iconSize: 24,
-			label: 'Test name',
+			label: 'Test Name',
 			value: state.testName
 		},
 		{
@@ -35,7 +57,7 @@ export const getLegendItems = (search: HistoryAPIQuery): LegendItem[] => {
 		{
 			iconName: 'BoxCheckmark',
 			iconSize: 24,
-			label: 'Obtained result',
+			label: 'Obtained Result',
 			value: state.results
 		},
 		{
@@ -47,7 +69,7 @@ export const getLegendItems = (search: HistoryAPIQuery): LegendItem[] => {
 		{
 			iconName: 'PaperShort',
 			iconSize: 24,
-			label: 'Branches expression',
+			label: 'Branches Expression',
 			value: state.branchExpr
 		},
 		{
@@ -59,13 +81,13 @@ export const getLegendItems = (search: HistoryAPIQuery): LegendItem[] => {
 		{
 			iconName: 'PaperShort',
 			iconSize: 24,
-			label: 'Revision expressions',
+			label: 'Revision Expression',
 			value: state.revisionExpr
 		},
 		{
 			iconName: 'PaperShort',
 			iconSize: 24,
-			label: 'Tags expressions',
+			label: 'Tags Expression',
 			value: state.tagExpr
 		},
 		{
@@ -77,25 +99,25 @@ export const getLegendItems = (search: HistoryAPIQuery): LegendItem[] => {
 		{
 			iconName: 'PaperShort',
 			iconSize: 24,
-			label: 'Result type classification',
+			label: 'Result Type Classification',
 			value: state.resultProperties
 		},
 		{
 			iconName: 'PaperShort',
 			iconSize: 24,
-			label: 'Verdict mode',
+			label: 'Verdict Mode',
 			value: state.verdictLookup
 		},
 		{
 			iconName: 'PaperShort',
 			iconSize: 24,
-			label: 'Verdict value',
+			label: 'Verdict Value',
 			value: state.verdict
 		},
 		{
 			iconName: 'PaperShort',
 			iconSize: 24,
-			label: 'Verdict expressions',
+			label: 'Verdict Expression',
 			value: state.verdictExpr
 		},
 		{
@@ -107,8 +129,15 @@ export const getLegendItems = (search: HistoryAPIQuery): LegendItem[] => {
 		{
 			iconName: 'PaperShort',
 			iconSize: 24,
-			label: 'Parameters expression',
+			label: 'Parameters Expression',
 			value: state.testArgExpr
 		}
 	];
+
+	return items
+		.map((item) => ({
+			...item,
+			value: normalizeLegendItemValue(item.value)
+		}))
+		.filter(hasLegendItemValue);
 };

--- a/libs/bublik/features/history/src/lib/history-legend-count/history-legend-count.component.tsx
+++ b/libs/bublik/features/history/src/lib/history-legend-count/history-legend-count.component.tsx
@@ -84,13 +84,13 @@ export const HistoryLegendCountLoading = () => {
 		<div className="flex flex-wrap gap-14">
 			<HistoryLegendCountItemLoading label="Runs" />
 			<HistoryLegendCountItemLoading label="Iterations" />
-			<HistoryLegendCountItemLoading label="Test results" />
+			<HistoryLegendCountItemLoading label="Test Results" />
 			<HistoryLegendCountItemLoading
-				label="Expected results"
+				label="Expected Results"
 				resultType="expected"
 			/>
 			<HistoryLegendCountItemLoading
-				label="Unexpected results"
+				label="Unexpected Results"
 				resultType="unexpected"
 			/>
 		</div>
@@ -118,14 +118,14 @@ export const HistoryLegendCount = (props: HeaderStatsProps) => {
 		<div className="flex flex-wrap gap-14">
 			<HistoryLegendCountItem label="Runs" count={runs} />
 			<HistoryLegendCountItem label="Iterations" count={iterations} />
-			<HistoryLegendCountItem label="Test results" count={results} />
+			<HistoryLegendCountItem label="Test Results" count={results} />
 			<HistoryLegendCountItem
-				label="Expected results"
+				label="Expected Results"
 				count={expected}
 				resultType="expected"
 			/>
 			<HistoryLegendCountItem
-				label="Unexpected results"
+				label="Unexpected Results"
 				count={unexpected}
 				resultType="unexpected"
 			/>


### PR DESCRIPTION
Currently we have a lot of history legend items that don't serve any purpose since they just display empty values. It's hard to see current search on a quick glance since current values for search are among empty values so it's better to remove them. Also fixed capitalization for all labels in legend. 

Before:
<img width="1643" height="241" alt="Screenshot 2026-02-18 at 00 42 08" src="https://github.com/user-attachments/assets/baea2d5f-62b3-447c-9f26-350e897d531d" />

After:
<img width="1641" height="191" alt="Screenshot 2026-02-18 at 00 41 16" src="https://github.com/user-attachments/assets/a7ebddc4-3ca8-418b-b418-12dff73adc7c" />
