### PR TITLE
style(dashboard): separate refresh button from clock widget

### DIFF
--- a/libs/bublik/features/dashboard-v2/src/lib/clock/clock.container.tsx
+++ b/libs/bublik/features/dashboard-v2/src/lib/clock/clock.container.tsx
@@ -1,15 +1,36 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { Clock, Tooltip } from '@/shared/tailwind-ui';
+import { useMemo } from 'react';
+import { format } from 'date-fns';
+
+import { Clock, cn, Icon, Tooltip } from '@/shared/tailwind-ui';
 
 import { useDashboardClock } from '../hooks';
 
 export const ClockContainer = () => {
 	const { latestTimestamp, refetch } = useDashboardClock();
 
+	const formattedTime = useMemo(
+		() => format(latestTimestamp, 'kk:mm:ss'),
+		[latestTimestamp]
+	);
+
 	return (
-		<Tooltip content="Click to refetch">
-			<Clock time={latestTimestamp} onClick={refetch} />
-		</Tooltip>
+		<div className="flex">
+			<Tooltip content={`Current dashboard is fetched at: ${formattedTime}`}>
+				<Clock time={latestTimestamp} disabled className="rounded-r-none" />
+			</Tooltip>
+			<Tooltip content="Click to refresh dashboard">
+				<button
+					className={cn(
+						'flex items-center justify-center border border-border-primary border-l rounded-r-md px-3 transition-colors',
+						'hover:bg-primary-wash hover:border-primary'
+					)}
+					onClick={refetch}
+				>
+					<Icon name="Refresh" className="text-primary" />
+				</button>
+			</Tooltip>
+		</div>
 	);
 };

--- a/libs/shared/tailwind-ui/src/lib/clock/clock.tsx
+++ b/libs/shared/tailwind-ui/src/lib/clock/clock.tsx
@@ -20,7 +20,7 @@ export const Clock = forwardRef<HTMLButtonElement, ClockProps>(
 		return (
 			<button
 				className={cn(
-					'flex items-center justify-center gap-1 border border-border-primary rounded-md px-3 py-[7px] hover:bg-gray-50 transition-colors w-28',
+					'flex items-center justify-center gap-1 border-y border-l border-border-primary rounded-md px-3 py-[7px] transition-colors w-28',
 					className
 				)}
 				{...props}


### PR DESCRIPTION
Previously, the clock widget was clickable to refresh the dashboard data, but this wasn't obvious to users. There was no visual indication that clicking the clock would trigger a refresh action.

This change:
- Adds a dedicated refresh button next to the clock
- Makes the clock non-clickable (disabled state)
- Adds tooltips: clock shows fetch time, refresh button shows 'Click to refresh'
- Improves UX by clearly separating display (clock) from action (refresh)

Before:
<img width="1054" height="126" alt="image" src="https://github.com/user-attachments/assets/72c815c8-bf8d-400b-aa8c-667337e757c1" />

After:
<img width="1164" height="148" alt="image" src="https://github.com/user-attachments/assets/34b9b64e-bc15-4f4a-81ef-0239a7914c38" />
