### PR TITLE
style(report,history): [stacked-chart] display legend with line breaks

### DIFF
--- a/libs/bublik/features/run-report/src/lib/run-report-stacked/run-report-stacked-chart.container.tsx
+++ b/libs/bublik/features/run-report/src/lib/run-report-stacked/run-report-stacked-chart.container.tsx
@@ -9,7 +9,13 @@ import {
 	cn
 } from '@/shared/tailwind-ui';
 import { ReportChart } from '@/shared/types';
-import { EChartsOption, Plot } from '@/shared/charts';
+import {
+	EChartsOption,
+	Plot,
+	estimateLegendTopOffset,
+	sanitizeLegendLabel
+} from '@/shared/charts';
+import { useMeasure } from '@/shared/hooks';
 
 import { useRunReportStacked } from './run-report-stacked.hooks';
 
@@ -65,7 +71,18 @@ function getRecordValue(record: unknown, key: string): unknown {
 	return (record as Record<string, unknown>)[key];
 }
 
-function createStackedOptions(records: ChartWithContext[]): EChartsOption {
+function createStackedOptions(
+	records: ChartWithContext[],
+	containerWidth?: number,
+	containerHeight?: number
+): EChartsOption {
+	const LEGEND_TOP = 8;
+	const LEGEND_LEFT_PADDING_RATIO = 0.07;
+	const LEGEND_RIGHT_PADDING_RATIO = 0.05;
+	const LEGEND_GRID_GAP = 18;
+	const LEGEND_SAFETY_ROWS = 2;
+	const LEGEND_SAFETY_PADDING = 12;
+	const MIN_PLOT_HEIGHT = 180;
 	const axisLabelStyles = {
 		fontFamily: 'Inter',
 		fontSize: 10,
@@ -101,6 +118,7 @@ function createStackedOptions(records: ChartWithContext[]): EChartsOption {
 	let datasetIdCounter = 0;
 	const datasets: EChartsOption['dataset'] = [];
 	const seriesConfigs: EChartsOption['series'] = [];
+	const legendLabels: string[] = [];
 
 	const measurementLabelCounts = new Map<string, number>();
 	records.forEach((record) => {
@@ -176,7 +194,38 @@ function createStackedOptions(records: ChartWithContext[]): EChartsOption {
 				showSymbol: true,
 				symbolSize: 6
 			});
+
+			legendLabels.push(sanitizeLegendLabel(seriesName));
 		});
+	});
+
+	const legendLeftPaddingPx = containerWidth
+		? containerWidth * LEGEND_LEFT_PADDING_RATIO
+		: 0;
+	const legendRightPaddingPx = containerWidth
+		? containerWidth * LEGEND_RIGHT_PADDING_RATIO
+		: 0;
+	const maxLegendTop = containerHeight
+		? Math.max(220, containerHeight - MIN_PLOT_HEIGHT)
+		: 320;
+	const topGridOffset = estimateLegendTopOffset({
+		labels: legendLabels,
+		containerWidth,
+		legendTop: LEGEND_TOP,
+		leftPaddingPx: legendLeftPaddingPx,
+		rightPaddingPx: legendRightPaddingPx,
+		fontFamily: axisLabelStyles.fontFamily,
+		fontSize: axisLabelStyles.fontSize,
+		fontWeight: axisLabelStyles.fontWeight,
+		itemHeight: 14,
+		lineHeight: 14,
+		rowGap: 8,
+		itemGap: 12,
+		gridGap: LEGEND_GRID_GAP,
+		safetyRows: LEGEND_SAFETY_ROWS,
+		safetyPaddingPx: LEGEND_SAFETY_PADDING,
+		minTop: 64,
+		maxTop: maxLegendTop
 	});
 
 	const options: EChartsOption = {
@@ -201,12 +250,10 @@ function createStackedOptions(records: ChartWithContext[]): EChartsOption {
 			{ type: 'slider', xAxisIndex: [0], bottom: 10 }
 		],
 		grid: {
-			top: '12%',
-			left: '5%',
+			top: topGridOffset,
+			left: '7%',
 			right:
-				yAxisConfigs.length > 1
-					? `${8 * (yAxisConfigs.length - 1) + 5}%`
-					: '5%',
+				yAxisConfigs.length > 1 ? `${8 * (yAxisConfigs.length - 1)}%` : '5%',
 			bottom: '9%'
 		},
 		tooltip: {
@@ -261,11 +308,24 @@ function createStackedOptions(records: ChartWithContext[]): EChartsOption {
 			}
 		},
 		legend: {
-			top: '1%',
-			left: 'left',
-			type: 'scroll',
-			animationDurationUpdate: 200,
-			pageButtonPosition: 'start'
+			type: 'plain',
+			top: LEGEND_TOP,
+			left: '7%',
+			right: '5%',
+			itemGap: 12,
+			formatter: (name: string) => sanitizeLegendLabel(name),
+			textStyle: {
+				fontFamily: axisLabelStyles.fontFamily,
+				fontSize: axisLabelStyles.fontSize,
+				fontWeight: axisLabelStyles.fontWeight,
+				overflow: 'break',
+				lineHeight: 14
+			},
+			tooltip: {
+				show: true,
+				formatter: (params: { name: string }) =>
+					sanitizeLegendLabel(params.name)
+			}
 		}
 	};
 
@@ -275,6 +335,10 @@ function createStackedOptions(records: ChartWithContext[]): EChartsOption {
 function RunReportStackedChartContainer() {
 	const { selectedRecords, isStackedOpen, toggleStacked } =
 		useRunReportStacked();
+	const [
+		plotContainerRef,
+		{ width: plotContainerWidth, height: plotContainerHeight }
+	] = useMeasure<HTMLDivElement>();
 
 	const charts = useMemo<ChartWithContext[]>(
 		() =>
@@ -291,7 +355,10 @@ function RunReportStackedChartContainer() {
 			}, []),
 		[selectedRecords]
 	);
-	const options = useMemo(() => createStackedOptions(charts), [charts]);
+	const options = useMemo(
+		() => createStackedOptions(charts, plotContainerWidth, plotContainerHeight),
+		[charts, plotContainerHeight, plotContainerWidth]
+	);
 
 	if (!charts.length) return null;
 
@@ -299,12 +366,14 @@ function RunReportStackedChartContainer() {
 		<DrawerRoot open={isStackedOpen} onOpenChange={toggleStacked}>
 			<DrawerContent
 				className={cn(
-					'bg-white shadow-popover flex flex-col overflow-hidden w-[80vw] max-w-[80vw]'
+					'bg-white shadow-popover flex flex-col overflow-hidden w-[80vw]'
 				)}
 			>
 				<CardHeader label="Stacked Chart" />
 				<div className="p-1 flex-1">
-					<Plot options={options} style={{ height: '100%', width: '100%' }} />
+					<div ref={plotContainerRef} className="h-full w-full">
+						<Plot options={options} style={{ height: '100%', width: '100%' }} />
+					</div>
 				</div>
 			</DrawerContent>
 		</DrawerRoot>

--- a/libs/shared/charts/src/lib/single-measurement-chart/measurement-chart.component.tsx
+++ b/libs/shared/charts/src/lib/single-measurement-chart/measurement-chart.component.tsx
@@ -15,7 +15,7 @@ import {
 	ToolbarToggleItem,
 	Tooltip
 } from '@/shared/tailwind-ui';
-import { usePlatformSpecificCtrl } from '@/shared/hooks';
+import { useMeasure, usePlatformSpecificCtrl } from '@/shared/hooks';
 
 import { Plot } from '../plot';
 import {
@@ -295,13 +295,34 @@ interface StackedMeasurementChartProps {
 
 function StackedMeasurementChart(props: StackedMeasurementChartProps) {
 	const ref = useRef<ReactEChartsCore>(null);
+	const [containerRef, { width: containerWidth, height: containerHeight }] =
+		useMeasure<HTMLDivElement>();
 	useChartClick({ ref, onChartPointClick: props.onPointClick });
 
-	const stackedOptions = resolveStackedOptions(props.charts, {
-		enableResultErrorHighlight: props.enableResultErrorHighlight
-	});
+	const stackedOptions = useMemo(
+		() =>
+			resolveStackedOptions(props.charts, {
+				enableResultErrorHighlight: props.enableResultErrorHighlight,
+				containerWidth,
+				containerHeight
+			}),
+		[
+			containerHeight,
+			containerWidth,
+			props.charts,
+			props.enableResultErrorHighlight
+		]
+	);
 
-	return <Plot options={stackedOptions} style={props.style} ref={ref} />;
+	return (
+		<div ref={containerRef} className="h-full w-full" style={props.style}>
+			<Plot
+				options={stackedOptions}
+				style={{ height: '100%', width: '100%' }}
+				ref={ref}
+			/>
+		</div>
+	);
 }
 
 export { MeasurementChart, StackedMeasurementChart, MeasurementChartToolbar };

--- a/libs/shared/charts/src/lib/single-measurement-chart/measurement-chart.component.utils.ts
+++ b/libs/shared/charts/src/lib/single-measurement-chart/measurement-chart.component.utils.ts
@@ -1,10 +1,17 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
 import { ComponentProps } from 'react';
 import { isDate } from 'date-fns';
 
 import { SingleMeasurementChart } from '@/services/bublik-api';
 
 import { Plot } from '../plot';
-import { getChartName, getColorByIdx } from '../utils';
+import {
+	estimateLegendTopOffset,
+	getChartName,
+	getColorByIdx,
+	sanitizeLegendLabel
+} from '../utils';
 import { EChartsOption } from '../echart';
 
 function resolveXAxisType(
@@ -179,6 +186,8 @@ function resolveOptions(
 
 interface ResolveStackedOptionsProps {
 	enableResultErrorHighlight?: boolean;
+	containerWidth?: number;
+	containerHeight?: number;
 }
 
 export type SingleMeasurementChartWithContext = SingleMeasurementChart & {
@@ -189,8 +198,18 @@ function resolveStackedOptions(
 	plots: SingleMeasurementChartWithContext[],
 	options: ResolveStackedOptionsProps = {}
 ): ComponentProps<typeof Plot>['options'] {
-	const { enableResultErrorHighlight = false } = options;
+	const {
+		enableResultErrorHighlight = false,
+		containerWidth,
+		containerHeight
+	} = options;
 	const Y_AXIS_SPACING = 120;
+	const LEGEND_TOP = 8;
+	const LEGEND_SIDE_PADDING_RATIO = 0.05;
+	const LEGEND_GRID_GAP = 18;
+	const LEGEND_SAFETY_ROWS = 2;
+	const LEGEND_SAFETY_PADDING = 8;
+	const MIN_PLOT_HEIGHT = 180;
 	const axisLabelStyles = {
 		fontFamily: 'Inter',
 		fontSize: 10,
@@ -236,6 +255,43 @@ function resolveStackedOptions(
 	};
 
 	const differingParams = getDifferingParams(plots.map((p) => p.parameters));
+	const seriesNames = plots.map((plot, idx) => {
+		const title = getChartName(plot);
+		const paramsSuffix = formatParamsForDisplay(
+			plot.parameters,
+			differingParams
+		);
+
+		return `${title.replace(/\u200B/g, '')}${paramsSuffix}${`\u200B`.repeat(
+			idx
+		)}`;
+	});
+	const legendLabels = seriesNames.map((name) => sanitizeLegendLabel(name));
+	const legendSidePaddingPx = containerWidth
+		? containerWidth * LEGEND_SIDE_PADDING_RATIO
+		: 0;
+	const maxLegendTop = containerHeight
+		? Math.max(220, containerHeight - MIN_PLOT_HEIGHT)
+		: 320;
+	const topGridOffset = estimateLegendTopOffset({
+		labels: legendLabels,
+		containerWidth,
+		legendTop: LEGEND_TOP,
+		leftPaddingPx: legendSidePaddingPx,
+		rightPaddingPx: legendSidePaddingPx,
+		fontFamily: axisLabelStyles.fontFamily,
+		fontSize: axisLabelStyles.fontSize,
+		fontWeight: axisLabelStyles.fontWeight,
+		itemHeight: 14,
+		lineHeight: 14,
+		rowGap: 8,
+		itemGap: 12,
+		gridGap: LEGEND_GRID_GAP,
+		safetyRows: LEGEND_SAFETY_ROWS,
+		safetyPaddingPx: LEGEND_SAFETY_PADDING,
+		minTop: 64,
+		maxTop: maxLegendTop
+	});
 
 	const yAxisGroups = new Map<string, number[]>();
 	const yAxisConfigs: EChartsOption['yAxis'] = [];
@@ -263,7 +319,10 @@ function resolveStackedOptions(
 				scale: true
 			});
 		} else {
-			yAxisGroups.get(yAxisLabel)!.push(idx);
+			const groupedPlotIndices = yAxisGroups.get(yAxisLabel);
+			if (!groupedPlotIndices) return;
+
+			groupedPlotIndices.push(idx);
 		}
 	});
 	const plotToYAxisIndex = new Map<number, number>();
@@ -297,18 +356,11 @@ function resolveStackedOptions(
 		},
 		yAxis: yAxisConfigs,
 		series: plots.map((plot, idx) => {
-			const title = getChartName(plot);
-			const yAxisIndex = plotToYAxisIndex.get(idx)!;
-			const paramsSuffix = formatParamsForDisplay(
-				plot.parameters,
-				differingParams
-			);
+			const yAxisIndex = plotToYAxisIndex.get(idx) ?? 0;
 
 			return {
 				type: 'line',
-				name: `${title.replace(/\u200B/g, '')}${paramsSuffix}${`\u200B`.repeat(
-					idx
-				)}`,
+				name: seriesNames[idx],
 				datasetId: `dataset_${idx}`,
 				yAxisIndex: yAxisIndex,
 				color: getColorByIdx(idx),
@@ -351,9 +403,9 @@ function resolveStackedOptions(
 			{ type: 'slider', xAxisIndex: [0], bottom: 10 }
 		],
 		grid: {
-			top: 80,
+			top: topGridOffset,
 			left: '5%',
-			right: `${7 * yAxisConfigs.length}%`,
+			right: yAxisConfigs.length > 2 ? `${7 * yAxisConfigs.length}%` : '5%',
 			bottom: '15%'
 		},
 		tooltip: {
@@ -362,7 +414,26 @@ function resolveStackedOptions(
 			extraCssText: 'shadow-popover rounded-lg',
 			axisPointer: { type: 'cross' }
 		},
-		legend: { left: 'left', type: 'scroll', pageButtonPosition: 'start' }
+		legend: {
+			type: 'plain',
+			top: LEGEND_TOP,
+			left: 'center',
+			right: '5%',
+			itemGap: 12,
+			formatter: (name: string) => sanitizeLegendLabel(name),
+			textStyle: {
+				fontFamily: axisLabelStyles.fontFamily,
+				fontSize: axisLabelStyles.fontSize,
+				fontWeight: axisLabelStyles.fontWeight,
+				overflow: 'break',
+				lineHeight: 14
+			},
+			tooltip: {
+				show: true,
+				formatter: (params: { name: string }) =>
+					sanitizeLegendLabel(params.name)
+			}
+		}
 	};
 }
 

--- a/libs/shared/charts/src/lib/utils/formatting.ts
+++ b/libs/shared/charts/src/lib/utils/formatting.ts
@@ -12,3 +12,7 @@ export const getChartName = (plot: SingleMeasurementChart): string => {
 		? `${plot.title} - ${plot.axis_y.label}`
 		: plot.subtitle ?? '';
 };
+
+export const sanitizeLegendLabel = (label: string): string => {
+	return label.replace(/\u200B/g, '');
+};

--- a/libs/shared/charts/src/lib/utils/index.ts
+++ b/libs/shared/charts/src/lib/utils/index.ts
@@ -4,3 +4,4 @@ export * from './actions';
 export * from './table-utils';
 export * from './colors';
 export * from './formatting';
+export * from './legend-layout';

--- a/libs/shared/charts/src/lib/utils/legend-layout.ts
+++ b/libs/shared/charts/src/lib/utils/legend-layout.ts
@@ -1,0 +1,113 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+
+interface EstimateLegendTopOffsetConfig {
+	labels: string[];
+	containerWidth?: number;
+	legendTop?: number;
+	leftPaddingPx?: number;
+	rightPaddingPx?: number;
+	itemGap?: number;
+	itemIconWidth?: number;
+	itemIconTextGap?: number;
+	itemHeight?: number;
+	lineHeight?: number;
+	rowGap?: number;
+	fontFamily?: string;
+	fontSize?: number;
+	fontWeight?: number;
+	gridGap?: number;
+	safetyRows?: number;
+	safetyPaddingPx?: number;
+	minTop?: number;
+	maxTop?: number;
+}
+
+let measurementContext: CanvasRenderingContext2D | null = null;
+
+function getMeasurementContext(): CanvasRenderingContext2D | null {
+	if (measurementContext) return measurementContext;
+	if (typeof document === 'undefined') return null;
+
+	const canvas = document.createElement('canvas');
+	measurementContext = canvas.getContext('2d');
+
+	return measurementContext;
+}
+
+function measureTextWidth(text: string, font: string): number {
+	const context = getMeasurementContext();
+
+	if (!context) return text.length * 7;
+
+	context.font = font;
+	return context.measureText(text).width;
+}
+
+function estimateLegendTopOffset(
+	config: EstimateLegendTopOffsetConfig
+): number {
+	const {
+		labels,
+		containerWidth,
+		legendTop = 8,
+		leftPaddingPx = 0,
+		rightPaddingPx = 0,
+		itemGap = 12,
+		itemIconWidth = 25,
+		itemIconTextGap = 8,
+		itemHeight = 14,
+		lineHeight = 14,
+		rowGap = 8,
+		fontFamily = 'Inter',
+		fontSize = 10,
+		fontWeight = 500,
+		gridGap = 12,
+		safetyRows = 0,
+		safetyPaddingPx = 0,
+		minTop = 64,
+		maxTop = 240
+	} = config;
+
+	if (!labels.length || !containerWidth || containerWidth <= 0) {
+		return minTop;
+	}
+
+	const legendContentWidth = Math.max(
+		containerWidth - leftPaddingPx - rightPaddingPx,
+		120
+	);
+	const font = `${fontWeight} ${fontSize}px ${fontFamily}`;
+
+	let rows = 1;
+	let rowWidth = 0;
+
+	labels.forEach((label) => {
+		const textWidth = measureTextWidth(label, font);
+		const legendItemWidth =
+			itemIconWidth + itemIconTextGap + textWidth + itemGap;
+
+		if (rowWidth === 0) {
+			rowWidth = legendItemWidth;
+			return;
+		}
+
+		if (rowWidth + legendItemWidth <= legendContentWidth) {
+			rowWidth += legendItemWidth;
+			return;
+		}
+
+		rows += 1;
+		rowWidth = legendItemWidth;
+	});
+
+	const effectiveRows = rows + safetyRows;
+	const rowHeight = Math.max(lineHeight, itemHeight);
+	const legendHeight =
+		effectiveRows * rowHeight + (effectiveRows - 1) * rowGap + safetyPaddingPx;
+	const topOffset = legendTop + legendHeight + gridGap;
+
+	return Math.max(minTop, Math.min(topOffset, maxTop));
+}
+
+export { estimateLegendTopOffset };


### PR DESCRIPTION
Display legend at the top with line breaks in case of long label for legend item. Currently we display in one line with buttons to scroll but it's inconvinient.

Before:
<img width="1285" height="866" alt="Screenshot 2026-03-03 at 00 58 26" src="https://github.com/user-attachments/assets/d3ae29d9-734a-4487-81a4-7098c17527c0" />

After:
<img width="1418" height="866" alt="Screenshot 2026-03-03 at 00 56 57" src="https://github.com/user-attachments/assets/27865d33-2ea0-4a9b-9fbe-aa330c49f0da" />


Fixes #487