### PR TITLE
Align header items gap with the rest of the ui

### DIFF
--- a/apps/bublik/src/pages/dashboard-page/dashboard-page-v2.tsx
+++ b/apps/bublik/src/pages/dashboard-page/dashboard-page-v2.tsx
@@ -75,13 +75,13 @@ export const DashboardPageV2 = () => {
 	return (
 		<div className="flex flex-col h-full gap-1 p-2">
 			<header className="flex flex-col px-6 py-4 bg-white rounded-t-xl">
-				<div className="flex flex-wrap justify-between">
-					<div className="flex flex-wrap items-stretch justify-center gap-6">
+				<div className="flex flex-wrap gap-4 justify-between">
+					<div className="flex flex-wrap items-stretch justify-center gap-4">
 						<SearchBarContainer />
 						<TodayButtonContainer />
 						<ModePickerContainer />
 					</div>
-					<div className="flex flex-wrap items-stretch justify-center gap-6">
+					<div className="flex flex-wrap items-stretch justify-center gap-4">
 						<TvModeContainer />
 						<AutoReloadContainer />
 						<ClockContainer />


### PR DESCRIPTION
On all other pages we use 16px gap, dashboard uses 24px. It's better to be consistent so change gap between header items to 16px so it's the same throughout ui.