### PR TITLE
style: change default delimeter to be ": " instead of "="

### DIFF
--- a/libs/bublik/config/src/lib/environment.ts
+++ b/libs/bublik/config/src/lib/environment.ts
@@ -26,5 +26,7 @@ export const config = {
 	isProd: env.PROD,
 	isSsr: env.SSR,
 	mode: env.MODE,
-	queryDelimiter: ';'
+	queryDelimiter: ';',
+	keyValueSubmitDelimiter: '=',
+	keyValueDisplayDelimiter: ': '
 } satisfies BublikConfig;

--- a/libs/bublik/config/src/lib/types.ts
+++ b/libs/bublik/config/src/lib/types.ts
@@ -20,7 +20,9 @@ export const BublikConfigSchema = z.object({
 	isDev: z.boolean(),
 	isSsr: z.boolean(),
 	mode: z.string(),
-	queryDelimiter: z.string()
+	queryDelimiter: z.string(),
+	keyValueSubmitDelimiter: z.string(),
+	keyValueDisplayDelimiter: z.string()
 });
 
 export type BublikEnv = z.infer<typeof BublikEnvSchema>;

--- a/libs/bublik/features/history/src/lib/history-aggregation/column-components/aggregation-tooltip/aggregation-tooltip.tsx
+++ b/libs/bublik/features/history/src/lib/history-aggregation/column-components/aggregation-tooltip/aggregation-tooltip.tsx
@@ -12,6 +12,7 @@ import {
 	hoverCardContentStyles,
 	cn
 } from '@/shared/tailwind-ui';
+import { config } from '@/bublik/config';
 
 interface BadgesCardListProps {
 	startDate: string;
@@ -36,7 +37,11 @@ function BadgesCardList(props: BadgesCardListProps) {
 				</p>
 			</div>
 			<div className="min-h-0 overflow-auto styled-scrollbar px-4 pb-4">
-				<BadgeList badges={badges} />
+				<BadgeList
+					keyValueDisplayDelimiter={config.keyValueDisplayDelimiter}
+					keyValueSubmitDelimiter={config.keyValueSubmitDelimiter}
+					badges={badges}
+				/>
 			</div>
 		</div>
 	);

--- a/libs/bublik/features/history/src/lib/history-aggregation/history-aggregation.columns.tsx
+++ b/libs/bublik/features/history/src/lib/history-aggregation/history-aggregation.columns.tsx
@@ -3,6 +3,7 @@
 import { ColumnDef } from '@tanstack/react-table';
 
 import { HistoryDataAggregation, ResultData } from '@/shared/types';
+import { config } from '@/bublik/config';
 import { HistoryAggregationColumns } from './history-aggregation.constantst';
 import { Badge, BadgeList } from '@/shared/tailwind-ui';
 
@@ -36,6 +37,8 @@ export const columns: ColumnDef<HistoryDataAggregation>[] = [
 					<div className="flex flex-col gap-1">
 						<BadgeList
 							badges={parameters}
+							keyValueDisplayDelimiter={config.keyValueDisplayDelimiter}
+							keyValueSubmitDelimiter={config.keyValueSubmitDelimiter}
 							onBadgeClick={onBadgeCellClick(cell, 'parameters')}
 							selectedBadges={globalFilter.parameters}
 							className="bg-badge-1"

--- a/libs/bublik/features/history/src/lib/history-filter-legend/history-filter-legend.component.tsx
+++ b/libs/bublik/features/history/src/lib/history-filter-legend/history-filter-legend.component.tsx
@@ -1,15 +1,22 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import { config } from '@/bublik/config';
 import { Badge, BadgeVariants, Icon, IconProps } from '@/shared/tailwind-ui';
+import { formatKeyValueForDisplay } from '@/shared/utils';
 
 const LegendItemValue = ({ value }: { value?: LegendItemProps['value'] }) => {
 	if (!value) return null;
 
 	if (!Array.isArray(value)) {
+		const displayValue = formatKeyValueForDisplay(value, {
+			displayDelimiter: config.keyValueDisplayDelimiter,
+			submitDelimiter: config.keyValueSubmitDelimiter
+		});
+
 		return (
 			<Badge variant={BadgeVariants.Primary} className="bg-primary-wash">
 				<span className="text-[0.6875rem] leading-[0.875rem] text-text-secondary">
-					{value}
+					{displayValue}
 				</span>
 			</Badge>
 		);
@@ -19,17 +26,24 @@ const LegendItemValue = ({ value }: { value?: LegendItemProps['value'] }) => {
 
 	return (
 		<>
-			{value.map((value) => (
-				<Badge
-					key={value}
-					variant={BadgeVariants.Primary}
-					className="bg-primary-wash"
-				>
-					<span className="text-[0.6875rem] leading-[0.875rem] text-text-secondary">
-						{value}
-					</span>
-				</Badge>
-			))}
+			{value.map((value) => {
+				const displayValue = formatKeyValueForDisplay(value, {
+					displayDelimiter: config.keyValueDisplayDelimiter,
+					submitDelimiter: config.keyValueSubmitDelimiter
+				});
+
+				return (
+					<Badge
+						key={value}
+						variant={BadgeVariants.Primary}
+						className="bg-primary-wash"
+					>
+						<span className="text-[0.6875rem] leading-[0.875rem] text-text-secondary">
+							{displayValue}
+						</span>
+					</Badge>
+				);
+			})}
 		</>
 	);
 };

--- a/libs/bublik/features/history/src/lib/history-filter-legend/history-filter-legend.component.tsx
+++ b/libs/bublik/features/history/src/lib/history-filter-legend/history-filter-legend.component.tsx
@@ -4,14 +4,17 @@ import { config } from '@/bublik/config';
 import { Badge, BadgeVariants, Icon, IconProps } from '@/shared/tailwind-ui';
 import { formatKeyValueForDisplay } from '@/shared/utils';
 
+const formatLegendValue = (value: string) =>
+	formatKeyValueForDisplay(value, {
+		displayDelimiter: config.keyValueDisplayDelimiter,
+		submitDelimiter: config.keyValueSubmitDelimiter
+	});
+
 const LegendItemValue = ({ value }: { value?: LegendItemProps['value'] }) => {
 	if (!value) return null;
 
 	if (!Array.isArray(value)) {
-		const displayValue = formatKeyValueForDisplay(value, {
-			displayDelimiter: config.keyValueDisplayDelimiter,
-			submitDelimiter: config.keyValueSubmitDelimiter
-		});
+		const displayValue = formatLegendValue(value);
 
 		return (
 			<Badge variant={BadgeVariants.Primary} className="bg-primary-wash">
@@ -27,10 +30,7 @@ const LegendItemValue = ({ value }: { value?: LegendItemProps['value'] }) => {
 	return (
 		<>
 			{value.map((value) => {
-				const displayValue = formatKeyValueForDisplay(value, {
-					displayDelimiter: config.keyValueDisplayDelimiter,
-					submitDelimiter: config.keyValueSubmitDelimiter
-				});
+				const displayValue = formatLegendValue(value);
 
 				return (
 					<Badge

--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/run-section.tsx
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/run-section.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
+import { config } from '@/bublik/config';
 import {
 	TextField,
 	BadgeField,

--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/run-section.tsx
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/run-section.tsx
@@ -80,6 +80,8 @@ export const RunSection = (props: RunSectionProps) => {
 							label="Labels"
 							placeholder="label"
 							control={control}
+							keyValueDisplayDelimiter={config.keyValueDisplayDelimiter}
+							keyValueSubmitDelimiter={config.keyValueSubmitDelimiter}
 							labelTrailingContent={
 								<FieldResetButton
 									helpMessage="Clear labels"
@@ -115,6 +117,8 @@ export const RunSection = (props: RunSectionProps) => {
 							label="Branches"
 							placeholder="master"
 							control={control}
+							keyValueDisplayDelimiter={config.keyValueDisplayDelimiter}
+							keyValueSubmitDelimiter={config.keyValueSubmitDelimiter}
 							labelTrailingContent={
 								<FieldResetButton
 									helpMessage="Clear branches"
@@ -152,6 +156,8 @@ export const RunSection = (props: RunSectionProps) => {
 							label="Revisions"
 							placeholder="8af383125f20cc5ecdb8393bf"
 							control={control}
+							keyValueDisplayDelimiter={config.keyValueDisplayDelimiter}
+							keyValueSubmitDelimiter={config.keyValueSubmitDelimiter}
 							labelTrailingContent={
 								<FieldResetButton
 									helpMessage="Clear revisions"
@@ -189,6 +195,8 @@ export const RunSection = (props: RunSectionProps) => {
 							name="runData"
 							placeholder="medford"
 							control={control}
+							keyValueDisplayDelimiter={config.keyValueDisplayDelimiter}
+							keyValueSubmitDelimiter={config.keyValueSubmitDelimiter}
 							labelTrailingContent={
 								<FieldResetButton
 									helpMessage="Clear tags"

--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/test-section.tsx
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/test-section.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
+import { config } from '@/bublik/config';
 import { TextField, BadgeField } from '@/shared/tailwind-ui';
 
 import {

--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/test-section.tsx
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/test-section.tsx
@@ -63,6 +63,8 @@ export const TestSection = (props: TestSectionProps) => {
 							label="Parameters"
 							placeholder="time_limit:30"
 							control={control}
+							keyValueDisplayDelimiter={config.keyValueDisplayDelimiter}
+							keyValueSubmitDelimiter={config.keyValueSubmitDelimiter}
 							labelTrailingContent={
 								<FieldResetButton
 									helpMessage="Clear parameters"

--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/verdict-section.tsx
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/verdict-section.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
+import { config } from '@/bublik/config';
 import { VERDICT_TYPE } from '@/shared/types';
 import { BadgeField, TextField, cn } from '@/shared/tailwind-ui';
 

--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/verdict-section.tsx
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/verdict-section.tsx
@@ -117,6 +117,8 @@ export const VerdictSection = (props: VerdictSectionProps) => {
 							}
 							disabled={verdictLookup === VERDICT_TYPE.None}
 							control={control}
+							keyValueDisplayDelimiter={config.keyValueDisplayDelimiter}
+							keyValueSubmitDelimiter={config.keyValueSubmitDelimiter}
 							labelTrailingContent={lookupControls}
 						/>
 					</div>

--- a/libs/bublik/features/history/src/lib/history-linear/history-linear.columns.tsx
+++ b/libs/bublik/features/history/src/lib/history-linear/history-linear.columns.tsx
@@ -3,6 +3,7 @@
 import { ColumnDef } from '@tanstack/react-table';
 
 import { HistoryDataLinear, RunResult } from '@/shared/types';
+import { config } from '@/bublik/config';
 import {
 	BadgeList,
 	BadgeListItem,
@@ -72,6 +73,8 @@ export const columns: ColumnDef<HistoryDataLinear>[] = [
 				>
 					<BadgeList
 						badges={metadataBadges}
+						keyValueDisplayDelimiter={config.keyValueDisplayDelimiter}
+						keyValueSubmitDelimiter={config.keyValueSubmitDelimiter}
 						selectedBadges={cell.table.getState().globalFilter['tags']}
 						onBadgeClick={onBadgeClick(cell, 'tags')}
 						className="bg-badge-4"
@@ -95,6 +98,8 @@ export const columns: ColumnDef<HistoryDataLinear>[] = [
 				>
 					<BadgeList
 						badges={tags}
+						keyValueDisplayDelimiter={config.keyValueDisplayDelimiter}
+						keyValueSubmitDelimiter={config.keyValueSubmitDelimiter}
 						selectedBadges={cell.table.getState().globalFilter['tags']}
 						onBadgeClick={onBadgeClick(cell, 'tags')}
 					/>
@@ -176,6 +181,8 @@ export const columns: ColumnDef<HistoryDataLinear>[] = [
 				>
 					<BadgeList
 						badges={parameters}
+						keyValueDisplayDelimiter={config.keyValueDisplayDelimiter}
+						keyValueSubmitDelimiter={config.keyValueSubmitDelimiter}
 						selectedBadges={cell.table.getState().globalFilter['parameters']}
 						onBadgeClick={onBadgeClick(cell, 'parameters')}
 						className="bg-badge-1"

--- a/libs/bublik/features/history/src/lib/history-measurements/plot-list.container.tsx
+++ b/libs/bublik/features/history/src/lib/history-measurements/plot-list.container.tsx
@@ -6,6 +6,7 @@ import { ArrayParam, useQueryParam, withDefault } from 'use-query-params';
 import { LinkWithProject } from '@/bublik/features/projects';
 import { routes } from '@/router';
 import { HistoryMeasurementResult } from '@/services/bublik-api';
+import { config } from '@/bublik/config';
 import { InfoBlock, SelectedChartsPopover } from '@/shared/charts';
 import {
 	ButtonTw,
@@ -302,6 +303,7 @@ function MeasurementsList(
 								name={m.test_name}
 								start={m.start}
 								parameters={m.parameters_list}
+								separator={config.keyValueSubmitDelimiter}
 							/>
 						</div>
 						{m.measurement_series_charts.length ? (

--- a/libs/bublik/features/measurements/src/lib/containers/measurement-statistics/measurement-statistics.container.tsx
+++ b/libs/bublik/features/measurements/src/lib/containers/measurement-statistics/measurement-statistics.container.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom';
 import { skipToken } from '@reduxjs/toolkit/query';
 
 import { MeasurementsRouterParams } from '@/shared/types';
+import { config } from '@/bublik/config';
 
 import {
 	useGetResultInfoQuery,
@@ -141,6 +142,7 @@ export const MeasurementStatisticsContainer: FC = () => {
 					obtainedResult={result_type}
 					parameters={parameters}
 					isError={has_error}
+					separator={config.keyValueSubmitDelimiter}
 				/>
 			</div>
 		</div>

--- a/libs/bublik/features/run-details/src/lib/info-list/utils.ts
+++ b/libs/bublik/features/run-details/src/lib/info-list/utils.ts
@@ -1,30 +1,36 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { isRevision, REVISION_POSTFIX } from '@/shared/utils';
+import { config } from '@/bublik/config';
+import { isRevision, joinKeyValue, REVISION_POSTFIX } from '@/shared/utils';
 
 const createRawString = (name?: string, value?: string) => {
 	const key = name ?? '';
 	const strValue = value ?? '';
-	let rawString = '';
 
-	if (key && strValue) rawString = `${key}: ${strValue}`;
-	if (!key && strValue) rawString = strValue;
-	if (key && !strValue) rawString = key;
+	const rawString = joinKeyValue(name, value, config.keyValueDisplayDelimiter);
+	const submitString = joinKeyValue(
+		name,
+		value,
+		config.keyValueSubmitDelimiter
+	);
 
-	return [rawString, key, strValue] as const;
+	return [rawString, submitString, key, strValue] as const;
 };
 
 export const getDisplayText = (name?: string, value?: string) => {
-	const [rawStr, key, rawValue] = createRawString(name, value);
-	const isRevisionValue = isRevision(rawStr);
+	const [rawStr, submitString, key, rawValue] = createRawString(name, value);
+	const isRevisionValue = isRevision(submitString);
 
-	const copyValue = rawStr.replace(': ', '=');
 	const displayValue = isRevisionValue
-		? `${key.replace(REVISION_POSTFIX, '')}: ${rawValue.slice(0, 8)}`
+		? joinKeyValue(
+				key.replace(REVISION_POSTFIX, ''),
+				rawValue.slice(0, 8),
+				config.keyValueDisplayDelimiter
+		  )
 		: rawStr;
 
 	return {
 		displayValue,
-		copyValue
+		copyValue: submitString
 	};
 };

--- a/libs/bublik/features/run-details/src/lib/utils.ts
+++ b/libs/bublik/features/run-details/src/lib/utils.ts
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
 import { DetailsItem } from '@/shared/types';
+import { config } from '@/bublik/config';
+import { formatKeyValueForDisplay, getKeyValueParts } from '@/shared/utils';
 
 import { InfoListItem } from './info-list/list-item';
 
@@ -43,7 +45,10 @@ export const prepareDuration = (dateString?: string) => {
 };
 
 export const formatSeparator = (value: string) => {
-	return value.replace('=', ': ');
+	return formatKeyValueForDisplay(value, {
+		displayDelimiter: config.keyValueDisplayDelimiter,
+		submitDelimiter: config.keyValueSubmitDelimiter
+	});
 };
 
 export const prepareRevisions = (
@@ -69,11 +74,9 @@ export const prepareInfoListItems =
 	};
 
 export const extractUrlFromLabel = (item: string): string | undefined => {
-	const parts = item.split('=');
+	const [, value] = getKeyValueParts(item, config.keyValueSubmitDelimiter);
 
-	if (parts.length >= 2) {
-		const value = parts.slice(1).join('=');
-
+	if (typeof value !== 'undefined') {
 		if (value.startsWith('https://') || value.startsWith('http://')) {
 			const urlMatch = value.match(/https?:\/\/[^\s,)\]}>]+/);
 			return urlMatch ? urlMatch[0] : undefined;

--- a/libs/bublik/features/run-diff/src/lib/parameters-diff/parameters-diff.tsx
+++ b/libs/bublik/features/run-diff/src/lib/parameters-diff/parameters-diff.tsx
@@ -4,6 +4,8 @@ import { FC, useMemo } from 'react';
 import { diffArrays } from 'diff';
 
 import { Badge, cn } from '@/shared/tailwind-ui';
+import { config } from '@/bublik/config';
+import { formatKeyValueForDisplay } from '@/shared/utils';
 
 export interface ParameterDiffProps {
 	side: 'left' | 'right';
@@ -36,18 +38,25 @@ export const ParametersDiff: FC<ParameterDiffProps> = (props) => {
 		<div className="flex flex-col flex-wrap gap-1">
 			{diff.map((change, idx) => (
 				<div key={idx} className="flex flex-col flex-wrap gap-1">
-					{change.value.map((value) => (
-						<Badge
-							key={value}
-							className={cn(
-								'bg-badge-1',
-								change.added && 'bg-green-300 text-black',
-								change.removed && 'bg-red-300 text-black'
-							)}
-						>
-							{value}
-						</Badge>
-					))}
+					{change.value.map((value) => {
+						const displayValue = formatKeyValueForDisplay(value, {
+							displayDelimiter: config.keyValueDisplayDelimiter,
+							submitDelimiter: config.keyValueSubmitDelimiter
+						});
+
+						return (
+							<Badge
+								key={value}
+								className={cn(
+									'bg-badge-1',
+									change.added && 'bg-green-300 text-black',
+									change.removed && 'bg-red-300 text-black'
+								)}
+							>
+								{displayValue}
+							</Badge>
+						);
+					})}
 				</div>
 			))}
 		</div>

--- a/libs/bublik/features/run-diff/src/lib/run-details-diff/run-details-diff.tsx
+++ b/libs/bublik/features/run-diff/src/lib/run-details-diff/run-details-diff.tsx
@@ -6,6 +6,12 @@ import { ArrayChange, diffArrays, diffWords } from 'diff';
 import { useGetRunDetailsQuery } from '@/services/bublik-api';
 import { cn, infoListItemStyles, Skeleton } from '@/shared/tailwind-ui';
 import { BublikEmptyState, BublikErrorState } from '@/bublik/features/ui-state';
+import { config } from '@/bublik/config';
+import {
+	formatKeyValueForDisplay,
+	getKeyValueParts,
+	hasSubmitDelimiter
+} from '@/shared/utils';
 
 import { getDiffProps } from './run-details-diff.utils';
 import { MetadataValue, MetaDiff } from './run-details-diff.types';
@@ -102,6 +108,21 @@ export interface TagDiffProps {
 	right?: MetadataValue;
 }
 
+const formatDiffValue = (value: string) => {
+	return formatKeyValueForDisplay(value, {
+		displayDelimiter: config.keyValueDisplayDelimiter,
+		submitDelimiter: config.keyValueSubmitDelimiter
+	});
+};
+
+const isKeyValueEntry = (value: string) => {
+	return hasSubmitDelimiter(value, config.keyValueSubmitDelimiter);
+};
+
+const getEntryKey = (value: string) => {
+	return getKeyValueParts(value, config.keyValueSubmitDelimiter)[0];
+};
+
 const TagDiff = ({ left, right }: TagDiffProps) => {
 	if (!left || !right) return null;
 
@@ -129,7 +150,7 @@ const TagDiff = ({ left, right }: TagDiffProps) => {
 									change.removed && 'bg-red-300 text-black border-transparent'
 								)}
 							>
-								{change.value.replace('=', ': ')}
+								{formatDiffValue(change.value)}
 							</span>
 						))}
 				</a>
@@ -149,7 +170,7 @@ const TagDiff = ({ left, right }: TagDiffProps) => {
 									change.removed && 'bg-red-300 text-black border-transparent'
 								)}
 							>
-								{change.value.replace('=', ': ')}
+								{formatDiffValue(change.value)}
 							</span>
 						))}
 				</div>
@@ -174,7 +195,7 @@ const TagDiff = ({ left, right }: TagDiffProps) => {
 									change.removed && 'bg-red-300 text-black border-transparent'
 								)}
 							>
-								{change.value.replace('=', ': ')}
+								{formatDiffValue(change.value)}
 							</span>
 						))}
 				</a>
@@ -194,7 +215,7 @@ const TagDiff = ({ left, right }: TagDiffProps) => {
 									change.removed && 'bg-red-300 text-black border-transparent'
 								)}
 							>
-								{change.value.replace('=', ': ')}
+								{formatDiffValue(change.value)}
 							</span>
 						))}
 				</div>
@@ -230,7 +251,7 @@ const MultipleDiff = (props: MultipleDiffProps) => {
 								target="_blank"
 								rel="noreferrer"
 							>
-								{meta.value.replace('=', ': ')}
+								{formatDiffValue(meta.value)}
 							</a>
 						);
 					}
@@ -247,7 +268,7 @@ const MultipleDiff = (props: MultipleDiffProps) => {
 									'bg-red-300 text-black border-transparent'
 							)}
 						>
-							{meta.value.replace('=', ': ')}
+							{formatDiffValue(meta.value)}
 						</div>
 					);
 				})}
@@ -272,15 +293,23 @@ export const MetadataDiff = (props: MetadataDiffProps) => {
 	);
 
 	const { allValuesWithDiff, diffWithChangedKeys } = useMemo(() => {
+		const getItemByKey = (items: MetadataValue[], key: string) => {
+			return items.find((item) => {
+				if (!isKeyValueEntry(item.value)) return false;
+
+				return getEntryKey(item.value) === key;
+			});
+		};
+
 		const leftKeys = new Set(
 			props.left
-				.filter((item) => item.value.includes('='))
-				.map((item) => item.value.split('=')[0])
+				.filter((item) => isKeyValueEntry(item.value))
+				.map((item) => getEntryKey(item.value))
 		);
 		const rightKeys = new Set(
 			props.right
-				.filter((item) => item.value.includes('='))
-				.map((item) => item.value.split('=')[0])
+				.filter((item) => isKeyValueEntry(item.value))
+				.map((item) => getEntryKey(item.value))
 		);
 		const allKeys = new Set([
 			...Array.from(leftKeys),
@@ -292,13 +321,9 @@ export const MetadataDiff = (props: MetadataDiffProps) => {
 		);
 
 		const keysWithDiff = keysPresentInBoth.filter((key) => {
-			const leftValue = props.left.find((item) =>
-				item.value.includes(key)
-			)?.value;
+			const leftValue = getItemByKey(props.left, key)?.value;
 
-			const rightValue = props.right.find((item) =>
-				item.value.includes(key)
-			)?.value;
+			const rightValue = getItemByKey(props.right, key)?.value;
 
 			return leftValue && rightValue && leftValue !== rightValue;
 		});
@@ -306,8 +331,8 @@ export const MetadataDiff = (props: MetadataDiffProps) => {
 		const diffWithChangedKeys = keysWithDiff
 			.map((key) => {
 				return {
-					left: props.left.find((item) => item.value.includes(key)),
-					right: props.right.find((item) => item.value.includes(key))
+					left: getItemByKey(props.left, key),
+					right: getItemByKey(props.right, key)
 				};
 			})
 			// Should ignore when key is repeated more than once so no clashes occur

--- a/libs/bublik/features/run-diff/src/lib/run-details-diff/run-details-diff.utils.ts
+++ b/libs/bublik/features/run-diff/src/lib/run-details-diff/run-details-diff.utils.ts
@@ -3,6 +3,7 @@
 import { RunDetailsDiffProps } from './run-details-diff';
 
 import { RunDetailsAPIResponse } from '@/shared/types';
+import { config } from '@/bublik/config';
 
 export const getDiffProps = ({
 	leftData,
@@ -34,12 +35,12 @@ export const getDiffProps = ({
 			label: 'Revisions',
 			left: leftData.revisions.map((revision) => ({
 				className: 'bg-badge-2',
-				value: `${revision.name}=${revision.value}`,
+				value: `${revision.name}${config.keyValueSubmitDelimiter}${revision.value}`,
 				url: revision.url
 			})),
 			right: rightData.revisions.map((revision) => ({
 				className: 'bg-badge-2',
-				value: `${revision.name}=${revision.value}`,
+				value: `${revision.name}${config.keyValueSubmitDelimiter}${revision.value}`,
 				url: revision.url
 			}))
 		},

--- a/libs/bublik/features/run/src/lib/result-table/matcher.ts
+++ b/libs/bublik/features/run/src/lib/result-table/matcher.ts
@@ -1,18 +1,36 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+
+import { config } from '@/bublik/config';
+import { getKeyValueParts } from '@/shared/utils';
+
+const toKeyValueMap = (items: string[], delimiter: string) => {
+	const entries = items
+		.map((item) => getKeyValueParts(item, delimiter))
+		.filter(
+			(entry): entry is [string, string] => typeof entry[1] !== 'undefined'
+		);
+
+	return new Map(entries);
+};
+
 export function calculateGroupSize(
 	dataset: string[][],
 	maxMismatchCount: number
 ) {
 	const referenceSet = dataset[0];
-	const referenceMap = new Map(
-		Array.from(referenceSet, (item) => item.split('=')) as [string, string][]
+	const referenceMap = toKeyValueMap(
+		referenceSet,
+		config.keyValueSubmitDelimiter
 	);
 
 	let groupSize = 1;
 
 	for (let i = 1; i < dataset.length; i++) {
 		const currentSet = dataset[i];
-		const currentSetMap = new Map(
-			Array.from(currentSet, (item) => item.split('=')) as [string, string][]
+		const currentSetMap = toKeyValueMap(
+			currentSet,
+			config.keyValueSubmitDelimiter
 		);
 
 		let mismatchCount = 0;
@@ -67,17 +85,17 @@ export type DiffValue = {
 export function highlightDifferences(
 	current: string[],
 	reference: string[],
-	delimeter = '='
+	delimeter = config.keyValueSubmitDelimiter
 ): DiffValue[] {
-	const referenceMap = new Map<string, string>(
-		Array.from(reference, (item) => item.split(delimeter)) as [string, string][]
-	);
+	const referenceMap = toKeyValueMap(reference, delimeter);
 
 	return current.map((item) => {
-		const currentKey = item.split(delimeter)?.[0];
-		const currentValue = item.split(delimeter)?.[1];
+		const [currentKey, currentValue] = getKeyValueParts(item, delimeter);
 		const referenceValue = referenceMap.get(currentKey);
-		if (!referenceValue) return { value: item };
+
+		if (typeof currentValue === 'undefined') return { value: item };
+		if (typeof referenceValue === 'undefined') return { value: item };
+
 		if (currentValue !== referenceValue) {
 			return { value: item, isDifferent: true };
 		}

--- a/libs/bublik/features/run/src/lib/result-table/result-table.columns.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.columns.tsx
@@ -10,6 +10,7 @@ import {
 import { createNextState } from '@reduxjs/toolkit';
 
 import { RESULT_PROPERTIES, RESULT_TYPE, RunDataResults } from '@/shared/types';
+import { config } from '@/bublik/config';
 import { ResultLinksContainer } from '@/bublik/features/result-links';
 import {
 	Badge,
@@ -19,6 +20,7 @@ import {
 	cn,
 	Tooltip
 } from '@/shared/tailwind-ui';
+import { formatKeyValueForDisplay } from '@/shared/utils';
 
 import { KeyList } from './key-list';
 import { getCommonParameters } from './matcher';
@@ -465,6 +467,10 @@ function Parameters(props: ParametersProps) {
 	return (
 		<ul className="flex gap-1 flex-wrap">
 			{parameters.map((value, index) => {
+				const displayValue = formatKeyValueForDisplay(value, {
+					displayDelimiter: config.keyValueDisplayDelimiter,
+					submitDelimiter: config.keyValueSubmitDelimiter
+				});
 				const isSelected = filterValue.includes(value);
 				const shouldDim = hasReferenceRow
 					? referenceSet.has(value)
@@ -480,7 +486,7 @@ function Parameters(props: ParametersProps) {
 						)}
 						onClick={() => onParameterClick(value)}
 					>
-						{value}
+						{displayValue}
 					</button>
 				);
 			})}

--- a/libs/bublik/features/run/src/lib/result-table/result-table.component.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.component.tsx
@@ -26,6 +26,7 @@ import { JsonParam, useQueryParam, withDefault } from 'use-query-params';
 import { analyticsEventNames, trackEvent } from '@/bublik/features/analytics';
 import { useIsSticky, useMount } from '@/shared/hooks';
 import { RESULT_PROPERTIES, RESULT_TYPE, RunDataResults } from '@/shared/types';
+import { config } from '@/bublik/config';
 import {
 	cn,
 	Skeleton,
@@ -35,6 +36,7 @@ import {
 	DataTableFacetedFilter,
 	Tooltip
 } from '@/shared/tailwind-ui';
+import { formatKeyValueForDisplay } from '@/shared/utils';
 import { BublikEmptyState, BublikErrorState } from '@/bublik/features/ui-state';
 
 import { getColumns } from './result-table.columns';
@@ -596,7 +598,10 @@ function useDataTableFilters(rowId: string, data: RunDataResults[]) {
 			.filter(Boolean)
 			.filter((parameter) => !parameter.includes('\n')) // Filter out formatted parameters
 			.map((parameter) => ({
-				label: parameter,
+				label: formatKeyValueForDisplay(parameter, {
+					displayDelimiter: config.keyValueDisplayDelimiter,
+					submitDelimiter: config.keyValueSubmitDelimiter
+				}),
 				value: parameter
 			}));
 	}, [filteredData]);

--- a/libs/bublik/features/runs/src/lib/hooks.ts
+++ b/libs/bublik/features/runs/src/lib/hooks.ts
@@ -7,8 +7,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import { OnChangeFn, PaginationState } from '@tanstack/react-table';
 
 import { RunsAPIQuery } from '@/shared/types';
-import { formatTimeToAPI, parseISODuration } from '@/shared/utils';
+import {
+	formatTimeToAPI,
+	normalizeKeyValueForSubmit,
+	parseISODuration
+} from '@/shared/utils';
 import { useProjectSearch } from '@/bublik/features/projects';
+import { config } from '@/bublik/config';
 
 import {
 	addToSelection,
@@ -21,6 +26,22 @@ import {
 	selectCompareIds,
 	selectRowSelection
 } from './runs-slice.selectors';
+
+const normalizeRunDataValue = (value: string) => {
+	return normalizeKeyValueForSubmit(value, {
+		displayDelimiter: config.keyValueDisplayDelimiter,
+		submitDelimiter: config.keyValueSubmitDelimiter
+	});
+};
+
+const normalizeRunDataQuery = (queryValue: string) => {
+	return queryValue
+		.split(';')
+		.filter(Boolean)
+		.map(normalizeRunDataValue)
+		.filter(Boolean)
+		.join(';');
+};
 
 export const useRunsGlobalFilter = () => {
 	const dispatch = useDispatch();
@@ -108,25 +129,28 @@ export const useRunsQuery = () => {
 		};
 	}, [searchParams]);
 
-	const query = useMemo<RunsAPIQuery>(
-		() => ({
+	const query = useMemo<RunsAPIQuery>(() => {
+		const normalizedRunData = normalizeRunDataQuery(
+			searchParams.get('runData') || ''
+		);
+
+		return {
 			startDate: dates.startDate,
 			finishDate: dates.finishDate,
 			page: (pagination.pageIndex + 1).toString() || '1',
 			pageSize: pagination.pageSize.toString() || '25',
-			runData: searchParams.get('runData') || '',
+			runData: normalizedRunData,
 			tagExpr: searchParams.get('tagExpr') || '',
 			projects: projectIds
-		}),
-		[
-			dates.finishDate,
-			dates.startDate,
-			pagination.pageIndex,
-			pagination.pageSize,
-			projectIds,
-			searchParams
-		]
-	);
+		};
+	}, [
+		dates.finishDate,
+		dates.startDate,
+		pagination.pageIndex,
+		pagination.pageSize,
+		projectIds,
+		searchParams
+	]);
 
 	return { query };
 };

--- a/libs/bublik/features/runs/src/lib/hooks.ts
+++ b/libs/bublik/features/runs/src/lib/hooks.ts
@@ -7,13 +7,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { OnChangeFn, PaginationState } from '@tanstack/react-table';
 
 import { RunsAPIQuery } from '@/shared/types';
-import {
-	formatTimeToAPI,
-	normalizeKeyValueForSubmit,
-	parseISODuration
-} from '@/shared/utils';
+import { formatTimeToAPI, parseISODuration } from '@/shared/utils';
 import { useProjectSearch } from '@/bublik/features/projects';
-import { config } from '@/bublik/config';
 
 import {
 	addToSelection,
@@ -26,22 +21,7 @@ import {
 	selectCompareIds,
 	selectRowSelection
 } from './runs-slice.selectors';
-
-const normalizeRunDataValue = (value: string) => {
-	return normalizeKeyValueForSubmit(value, {
-		displayDelimiter: config.keyValueDisplayDelimiter,
-		submitDelimiter: config.keyValueSubmitDelimiter
-	});
-};
-
-const normalizeRunDataQuery = (queryValue: string) => {
-	return queryValue
-		.split(';')
-		.filter(Boolean)
-		.map(normalizeRunDataValue)
-		.filter(Boolean)
-		.join(';');
-};
+import { normalizeRunDataQuery } from './runs-key-value';
 
 export const useRunsGlobalFilter = () => {
 	const dispatch = useDispatch();

--- a/libs/bublik/features/runs/src/lib/runs-form/runs-form.component.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-form/runs-form.component.tsx
@@ -13,6 +13,7 @@ import {
 	TagsBoxInput,
 	BoxValue
 } from '@/shared/tailwind-ui';
+import { config } from '@/bublik/config';
 
 import {
 	areRunsFiltersSnapshotsEqual,
@@ -155,6 +156,8 @@ export const RunsForm = forwardRef<HTMLFormElement, RunsFormProps>(
 									});
 									field.onChange(nextValues);
 								}}
+								keyValueDisplayDelimiter={config.keyValueDisplayDelimiter}
+								keyValueSubmitDelimiter={config.keyValueSubmitDelimiter}
 							/>
 						)}
 						name="runData"

--- a/libs/bublik/features/runs/src/lib/runs-form/runs-form.container.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-form/runs-form.container.tsx
@@ -7,10 +7,15 @@ import { getLocalTimeZone, parseDate } from '@internationalized/date';
 import { formatISODuration, intervalToDuration, sub } from 'date-fns';
 
 import { analyticsEventNames, trackEvent } from '@/bublik/features/analytics';
-import { formatTimeToAPI, parseISODuration } from '@/shared/utils';
+import {
+	formatTimeToAPI,
+	normalizeKeyValueForSubmit,
+	parseISODuration
+} from '@/shared/utils';
 import { BUBLIK_TAG, bublikAPI } from '@/services/bublik-api';
 import { BoxValue } from '@/shared/tailwind-ui';
 import { useMount } from '@/shared/hooks';
+import { config } from '@/bublik/config';
 
 import { RunsForm, RunsFormValues } from './runs-form.component';
 import {
@@ -21,6 +26,19 @@ import {
 import { updateGlobalFilter } from '../runs-slice';
 import { selectAllTags, selectGlobalFilter } from '../runs-slice.selectors';
 
+const normalizeRunDataValue = (value: string) => {
+	return normalizeKeyValueForSubmit(value, {
+		displayDelimiter: config.keyValueDisplayDelimiter,
+		submitDelimiter: config.keyValueSubmitDelimiter
+	});
+};
+
+const normalizeRunDataList = (runData: string[]) => {
+	return Array.from(
+		new Set(runData.map(normalizeRunDataValue).filter(Boolean))
+	);
+};
+
 function RunsFormContainer() {
 	const dispatch = useDispatch();
 	const location = useLocation();
@@ -29,8 +47,9 @@ function RunsFormContainer() {
 	const allTags = useSelector(selectAllTags);
 
 	useMount(() => {
-		const initialGlobalFilter =
-			searchParams.get('runData')?.split(';')?.filter(Boolean) || [];
+		const initialGlobalFilter = normalizeRunDataList(
+			searchParams.get('runData')?.split(';')?.filter(Boolean) || []
+		);
 
 		dispatch(updateGlobalFilter(initialGlobalFilter));
 	});
@@ -45,7 +64,9 @@ function RunsFormContainer() {
 	);
 
 	function handleFormSubmit(newForm: RunsFormValues) {
-		const selectedRunData = getSelectedRunData(newForm.runData);
+		const selectedRunData = normalizeRunDataList(
+			getSelectedRunData(newForm.runData)
+		);
 
 		trackEvent(analyticsEventNames.runsFormSubmit, {
 			calendarMode: newForm.calendarMode,
@@ -95,6 +116,16 @@ function searchParamsToForm(
 	searchParams: URLSearchParams,
 	allTags: BoxValue[]
 ): RunsFormValues {
+	const normalizedAllTags = allTags.map((tag) => {
+		const normalizedValue = normalizeRunDataValue(tag.value);
+
+		return {
+			...tag,
+			value: normalizedValue,
+			label: normalizedValue
+		};
+	});
+
 	const rawStart = searchParams.get('startDate');
 	const rawEnd = searchParams.get('finishDate');
 	const calendarMode = (searchParams.get('calendarMode') ??
@@ -104,7 +135,7 @@ function searchParamsToForm(
 
 	const defaultValues: RunsFormValues = {
 		calendarMode,
-		runData: allTags,
+		runData: normalizedAllTags,
 		tagExpr,
 		dates: null
 	};
@@ -172,7 +203,7 @@ function formToSearchParams(
 		);
 	}
 
-	const selectedRunData = getSelectedRunData(runData);
+	const selectedRunData = normalizeRunDataList(getSelectedRunData(runData));
 
 	tagExpr ? params.set('tagExpr', tagExpr) : params.delete('tagExpr');
 

--- a/libs/bublik/features/runs/src/lib/runs-form/runs-form.container.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-form/runs-form.container.tsx
@@ -7,15 +7,10 @@ import { getLocalTimeZone, parseDate } from '@internationalized/date';
 import { formatISODuration, intervalToDuration, sub } from 'date-fns';
 
 import { analyticsEventNames, trackEvent } from '@/bublik/features/analytics';
-import {
-	formatTimeToAPI,
-	normalizeKeyValueForSubmit,
-	parseISODuration
-} from '@/shared/utils';
+import { formatTimeToAPI, parseISODuration } from '@/shared/utils';
 import { BUBLIK_TAG, bublikAPI } from '@/services/bublik-api';
 import { BoxValue } from '@/shared/tailwind-ui';
 import { useMount } from '@/shared/hooks';
-import { config } from '@/bublik/config';
 
 import { RunsForm, RunsFormValues } from './runs-form.component';
 import {
@@ -25,19 +20,7 @@ import {
 } from './runs-form.utils';
 import { updateGlobalFilter } from '../runs-slice';
 import { selectAllTags, selectGlobalFilter } from '../runs-slice.selectors';
-
-const normalizeRunDataValue = (value: string) => {
-	return normalizeKeyValueForSubmit(value, {
-		displayDelimiter: config.keyValueDisplayDelimiter,
-		submitDelimiter: config.keyValueSubmitDelimiter
-	});
-};
-
-const normalizeRunDataList = (runData: string[]) => {
-	return Array.from(
-		new Set(runData.map(normalizeRunDataValue).filter(Boolean))
-	);
-};
+import { normalizeRunDataList, normalizeRunDataValue } from '../runs-key-value';
 
 function RunsFormContainer() {
 	const dispatch = useDispatch();

--- a/libs/bublik/features/runs/src/lib/runs-key-value.ts
+++ b/libs/bublik/features/runs/src/lib/runs-key-value.ts
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+import { config } from '@/bublik/config';
+import { normalizeKeyValueForSubmit } from '@/shared/utils';
+
+/** Normalize a single runData/tag value into its submit form (e.g. `key: v` -> `key=v`). */
+export const normalizeRunDataValue = (value: string) => {
+	return normalizeKeyValueForSubmit(value, {
+		displayDelimiter: config.keyValueDisplayDelimiter,
+		submitDelimiter: config.keyValueSubmitDelimiter
+	});
+};
+
+/** Normalize and deduplicate a list of runData/tag values. */
+export const normalizeRunDataList = (values: string[]) => {
+	return Array.from(new Set(values.map(normalizeRunDataValue).filter(Boolean)));
+};
+
+/** Normalize a delimited runData query string, preserving the query delimiter. */
+export const normalizeRunDataQuery = (queryValue: string) => {
+	return queryValue
+		.split(config.queryDelimiter)
+		.filter(Boolean)
+		.map(normalizeRunDataValue)
+		.filter(Boolean)
+		.join(config.queryDelimiter);
+};

--- a/libs/bublik/features/runs/src/lib/runs-slice.selectors.ts
+++ b/libs/bublik/features/runs/src/lib/runs-slice.selectors.ts
@@ -2,7 +2,9 @@
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
 import { createSelector } from '@reduxjs/toolkit';
 
+import { config } from '@/bublik/config';
 import type { BoxValue } from '@/shared/tailwind-ui';
+import { normalizeKeyValueForSubmit } from '@/shared/utils';
 
 import {
 	type AppStateWithRunsSlice,
@@ -12,6 +14,13 @@ import {
 
 const getRunsPageState = (state: AppStateWithRunsSlice) =>
 	state[RUNS_PAGE_SLICE];
+
+const normalizeRunDataValue = (value: string) => {
+	return normalizeKeyValueForSubmit(value, {
+		displayDelimiter: config.keyValueDisplayDelimiter,
+		submitDelimiter: config.keyValueSubmitDelimiter
+	});
+};
 
 export const selectGlobalFilter = createSelector(
 	getRunsPageState,
@@ -60,6 +69,10 @@ export const selectAllTags = createSelector(
 			return META_GROUP;
 		};
 
+		const normalizedGlobalFilter = Array.from(
+			new Set(globalFilter.map(normalizeRunDataValue).filter(Boolean))
+		);
+
 		const getClassName = (value: string) => {
 			if (importantSet.has(value)) return IMPORTANT_BG;
 			if (metaSet.has(value)) return META_BG;
@@ -80,7 +93,7 @@ export const selectAllTags = createSelector(
 			});
 		};
 
-		globalFilter.forEach((value) => upsertBox(value, true));
+		normalizedGlobalFilter.forEach((value) => upsertBox(value, true));
 		Array.from(importantSet).forEach((value) => upsertBox(value));
 		Array.from(metaSet).forEach((value) => upsertBox(value));
 		Array.from(tagsSet).forEach((value) => upsertBox(value));

--- a/libs/bublik/features/runs/src/lib/runs-slice.selectors.ts
+++ b/libs/bublik/features/runs/src/lib/runs-slice.selectors.ts
@@ -2,9 +2,7 @@
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
 import { createSelector } from '@reduxjs/toolkit';
 
-import { config } from '@/bublik/config';
 import type { BoxValue } from '@/shared/tailwind-ui';
-import { normalizeKeyValueForSubmit } from '@/shared/utils';
 
 import {
 	type AppStateWithRunsSlice,
@@ -14,13 +12,6 @@ import {
 
 const getRunsPageState = (state: AppStateWithRunsSlice) =>
 	state[RUNS_PAGE_SLICE];
-
-const normalizeRunDataValue = (value: string) => {
-	return normalizeKeyValueForSubmit(value, {
-		displayDelimiter: config.keyValueDisplayDelimiter,
-		submitDelimiter: config.keyValueSubmitDelimiter
-	});
-};
 
 export const selectGlobalFilter = createSelector(
 	getRunsPageState,
@@ -69,10 +60,6 @@ export const selectAllTags = createSelector(
 			return META_GROUP;
 		};
 
-		const normalizedGlobalFilter = Array.from(
-			new Set(globalFilter.map(normalizeRunDataValue).filter(Boolean))
-		);
-
 		const getClassName = (value: string) => {
 			if (importantSet.has(value)) return IMPORTANT_BG;
 			if (metaSet.has(value)) return META_BG;
@@ -93,7 +80,7 @@ export const selectAllTags = createSelector(
 			});
 		};
 
-		normalizedGlobalFilter.forEach((value) => upsertBox(value, true));
+		globalFilter.forEach((value) => upsertBox(value, true));
 		Array.from(importantSet).forEach((value) => upsertBox(value));
 		Array.from(metaSet).forEach((value) => upsertBox(value));
 		Array.from(tagsSet).forEach((value) => upsertBox(value));

--- a/libs/bublik/features/runs/src/lib/runs-slice.ts
+++ b/libs/bublik/features/runs/src/lib/runs-slice.ts
@@ -9,26 +9,13 @@ import {
 } from '@reduxjs/toolkit';
 
 import { bublikAPI } from '@/services/bublik-api';
-import { config } from '@/bublik/config';
 import { RunsData } from '@/shared/types';
-import { normalizeKeyValueForSubmit } from '@/shared/utils';
+
+import { normalizeRunDataList } from './runs-key-value';
 
 export const runsAdapter = createEntityAdapter<RunsData, EntityId>({
 	selectId: (run) => run.id.toString()
 });
-
-const normalizeGlobalFilterValue = (value: string) => {
-	return normalizeKeyValueForSubmit(value, {
-		displayDelimiter: config.keyValueDisplayDelimiter,
-		submitDelimiter: config.keyValueSubmitDelimiter
-	});
-};
-
-const normalizeGlobalFilter = (values: string[]) => {
-	return Array.from(
-		new Set(values.map(normalizeGlobalFilterValue).filter(Boolean))
-	);
-};
 
 export const RUNS_PAGE_SLICE = 'runsPage';
 
@@ -53,7 +40,7 @@ export const runsPageSlice = createSlice({
 	initialState: initialRunsPageState,
 	reducers: {
 		updateGlobalFilter: (state, action: PayloadAction<string[]>) => {
-			state.globalFilter = normalizeGlobalFilter(action.payload);
+			state.globalFilter = normalizeRunDataList(action.payload);
 		},
 		resetSelection: (state) => {
 			state.rowSelection = [];

--- a/libs/bublik/features/runs/src/lib/runs-slice.ts
+++ b/libs/bublik/features/runs/src/lib/runs-slice.ts
@@ -9,11 +9,26 @@ import {
 } from '@reduxjs/toolkit';
 
 import { bublikAPI } from '@/services/bublik-api';
+import { config } from '@/bublik/config';
 import { RunsData } from '@/shared/types';
+import { normalizeKeyValueForSubmit } from '@/shared/utils';
 
 export const runsAdapter = createEntityAdapter<RunsData, EntityId>({
 	selectId: (run) => run.id.toString()
 });
+
+const normalizeGlobalFilterValue = (value: string) => {
+	return normalizeKeyValueForSubmit(value, {
+		displayDelimiter: config.keyValueDisplayDelimiter,
+		submitDelimiter: config.keyValueSubmitDelimiter
+	});
+};
+
+const normalizeGlobalFilter = (values: string[]) => {
+	return Array.from(
+		new Set(values.map(normalizeGlobalFilterValue).filter(Boolean))
+	);
+};
 
 export const RUNS_PAGE_SLICE = 'runsPage';
 
@@ -38,7 +53,7 @@ export const runsPageSlice = createSlice({
 	initialState: initialRunsPageState,
 	reducers: {
 		updateGlobalFilter: (state, action: PayloadAction<string[]>) => {
-			state.globalFilter = action.payload;
+			state.globalFilter = normalizeGlobalFilter(action.payload);
 		},
 		resetSelection: (state) => {
 			state.rowSelection = [];

--- a/libs/bublik/features/runs/src/lib/runs-table/runs-table.columns.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-table/runs-table.columns.tsx
@@ -11,6 +11,7 @@ import {
 	TableSort,
 	cn
 } from '@/shared/tailwind-ui';
+import { config } from '@/bublik/config';
 import { RunsData, RunsStatisticData, RUN_STATUS } from '@/shared/types';
 
 import { DatesHeader, ColumnDates, RunLinks, ColumnSummary } from './columns';
@@ -139,6 +140,8 @@ export const columns: ColumnDef<RunsData>[] = [
 				<BadgeList
 					badges={cell.getValue<BadgeListItem[]>()}
 					className="bg-badge-6"
+					keyValueDisplayDelimiter={config.keyValueDisplayDelimiter}
+					keyValueSubmitDelimiter={config.keyValueSubmitDelimiter}
 					selectedBadges={cell.table.getState().globalFilter}
 					onBadgeClick={onGlobalFilter(cell)}
 				/>
@@ -155,6 +158,8 @@ export const columns: ColumnDef<RunsData>[] = [
 				<BadgeList
 					badges={cell.getValue<BadgeListItem[]>()}
 					className="bg-badge-4 whitespace-nowrap"
+					keyValueDisplayDelimiter={config.keyValueDisplayDelimiter}
+					keyValueSubmitDelimiter={config.keyValueSubmitDelimiter}
 					selectedBadges={cell.table.getState().globalFilter}
 					onBadgeClick={onGlobalFilter(cell)}
 				/>
@@ -170,6 +175,8 @@ export const columns: ColumnDef<RunsData>[] = [
 			return (
 				<BadgeList
 					badges={cell.getValue<BadgeListItem[]>()}
+					keyValueDisplayDelimiter={config.keyValueDisplayDelimiter}
+					keyValueSubmitDelimiter={config.keyValueSubmitDelimiter}
 					selectedBadges={cell.table.getState().globalFilter}
 					onBadgeClick={onGlobalFilter(cell)}
 				/>

--- a/libs/shared/charts/src/lib/info-block/info-block.tsx
+++ b/libs/shared/charts/src/lib/info-block/info-block.tsx
@@ -3,7 +3,7 @@
 import { FC, SVGProps } from 'react';
 import { format, isValid, parseISO } from 'date-fns';
 
-import { TIME_DOT_FORMAT_FULL } from '@/shared/utils';
+import { getKeyValueParts, TIME_DOT_FORMAT_FULL } from '@/shared/utils';
 import { Icon } from '@/shared/tailwind-ui';
 
 import { InfoItem } from './info-item';
@@ -79,9 +79,9 @@ export function InfoBlock(props: InfoBlockProps) {
 			</div>
 			<div className="flex flex-wrap items-center gap-4">
 				{parameters.map((param) => {
-					const [label, value] = param.split(separator);
+					const [label, value] = getKeyValueParts(param, separator);
 
-					return <InfoItem key={param} label={label} value={value} />;
+					return <InfoItem key={param} label={label} value={value ?? ''} />;
 				})}
 			</div>
 		</div>

--- a/libs/shared/tailwind-ui/src/lib/badge-box/badge-box.tsx
+++ b/libs/shared/tailwind-ui/src/lib/badge-box/badge-box.tsx
@@ -10,6 +10,11 @@ import {
 } from 'react';
 import { CheckIcon } from '@radix-ui/react-icons';
 
+import {
+	formatKeyValueForDisplay,
+	normalizeKeyValueForSubmit
+} from '@/shared/utils';
+
 import { Badge } from '../badge';
 import { ButtonTw } from '../button';
 import {
@@ -34,8 +39,25 @@ export type BoxValue = {
 	groupLabel?: string;
 };
 
+export interface KeyValueDelimiterProps {
+	keyValueDisplayDelimiter?: string;
+	keyValueSubmitDelimiter?: string;
+}
+
 const normalizeInputValue = (value: string) =>
 	value.trim().replace(/\s+/g, ' ');
+
+const normalizeBoxValue = (rawValue: string, props: KeyValueDelimiterProps) =>
+	normalizeKeyValueForSubmit(normalizeInputValue(rawValue), {
+		displayDelimiter: props.keyValueDisplayDelimiter,
+		submitDelimiter: props.keyValueSubmitDelimiter
+	});
+
+const formatBoxValue = (value: string, props: KeyValueDelimiterProps) =>
+	formatKeyValueForDisplay(value, {
+		displayDelimiter: props.keyValueDisplayDelimiter,
+		submitDelimiter: props.keyValueSubmitDelimiter
+	});
 
 const normalizeForMatch = (value: string) =>
 	normalizeInputValue(value).toLowerCase();
@@ -43,11 +65,20 @@ const normalizeForMatch = (value: string) =>
 const updateSelection = <T extends BoxValue>(
 	values: T[],
 	targetValue: string,
-	isSelected: boolean
-): T[] =>
-	values.map((box) =>
-		box.value === targetValue ? ({ ...box, isSelected } as T) : box
+	isSelected: boolean,
+	props: KeyValueDelimiterProps
+): T[] => {
+	const normalizedTargetValue = normalizeForMatch(
+		normalizeBoxValue(targetValue, props)
 	);
+
+	return values.map((box) =>
+		normalizeForMatch(normalizeBoxValue(box.value, props)) ===
+		normalizedTargetValue
+			? ({ ...box, isSelected } as T)
+			: box
+	);
+};
 
 const clearSelection = <T extends BoxValue>(values: T[]): T[] =>
 	values.map((box) =>
@@ -99,6 +130,8 @@ export interface FancyBoxProps {
 	startIcon?: ReactNode;
 	/** End icon for trigger button */
 	endIcon?: ReactNode;
+	keyValueDisplayDelimiter?: string;
+	keyValueSubmitDelimiter?: string;
 	/** Button size */
 	size?: 'xss' | 'xs/2' | 'md';
 	/** Group label for newly created values */
@@ -118,10 +151,16 @@ export const TagsBoxInput = ({
 	valueLabel,
 	values,
 	onChange,
+	keyValueDisplayDelimiter,
+	keyValueSubmitDelimiter,
 	size = 'md',
 	createdGroupLabel,
 	groupOrder
 }: FancyBoxProps) => {
+	const delimiterProps: KeyValueDelimiterProps = {
+		keyValueDisplayDelimiter,
+		keyValueSubmitDelimiter
+	};
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [openCombobox, setOpenCombobox] = useState(false);
 	const [inputValue, setInputValue] = useState('');
@@ -161,13 +200,18 @@ export const TagsBoxInput = ({
 			return 0;
 		});
 	}, [groupOrder, values]);
-	const normalizedInputValue = normalizeInputValue(inputValue);
+	const normalizedInputValue = normalizeBoxValue(
+		inputValue,
+		delimiterProps
+	).trim();
 	const normalizedValueLabel = (valueLabel || label).toLowerCase();
+	const normalizedInputMatch = normalizeForMatch(normalizedInputValue);
 	const hasNormalizedMatch = values.some(
 		(box) =>
-			normalizeForMatch(box.value) ===
-				normalizeForMatch(normalizedInputValue) ||
-			normalizeForMatch(box.label) === normalizeForMatch(normalizedInputValue)
+			normalizeForMatch(normalizeBoxValue(box.value, delimiterProps)) ===
+				normalizedInputMatch ||
+			normalizeForMatch(normalizeBoxValue(box.label, delimiterProps)) ===
+				normalizedInputMatch
 	);
 	const canCreate = normalizedInputValue.length > 0 && !hasNormalizedMatch;
 
@@ -183,12 +227,14 @@ export const TagsBoxInput = ({
 	};
 
 	const handleToggle = (box: BoxValue) => {
-		handleChange(updateSelection(values, box.value, !box.isSelected));
+		handleChange(
+			updateSelection(values, box.value, !box.isSelected, delimiterProps)
+		);
 		focusInput();
 	};
 
 	const handleRemove = (box: BoxValue) => {
-		handleChange(updateSelection(values, box.value, false));
+		handleChange(updateSelection(values, box.value, false, delimiterProps));
 		focusInput();
 	};
 
@@ -199,7 +245,7 @@ export const TagsBoxInput = ({
 			...values,
 			{
 				value: normalizedInputValue,
-				label: normalizedInputValue,
+				label: formatBoxValue(normalizedInputValue, delimiterProps),
 				isSelected: true,
 				groupLabel: createdGroupLabel || valueLabel || label
 			}
@@ -277,7 +323,9 @@ export const TagsBoxInput = ({
 												box.className
 											)}
 										>
-											<span className="truncate">{box.label}</span>
+											<span className="truncate">
+												{formatBoxValue(box.label, delimiterProps)}
+											</span>
 										</Badge>
 									))
 								)}
@@ -340,13 +388,16 @@ export const TagsBoxInput = ({
 										box.className
 									)}
 								>
-									<span>{box.label}</span>
+									<span>{formatBoxValue(box.label, delimiterProps)}</span>
 									<button
 										type="button"
 										className="rounded text-text-menu hover:text-primary"
 										onMouseDown={keepPopoverOpen}
 										onClick={() => handleRemove(box)}
-										aria-label={`Remove ${box.label}`}
+										aria-label={`Remove ${formatBoxValue(
+											box.label,
+											delimiterProps
+										)}`}
 									>
 										<Icon name="CrossSimple" size={14} />
 									</button>
@@ -393,7 +444,7 @@ export const TagsBoxInput = ({
 													box.className
 												)}
 											>
-												{box.label}
+												{formatBoxValue(box.label, delimiterProps)}
 											</Badge>
 										</CommandItem>
 									);
@@ -413,8 +464,8 @@ export const TagsBoxInput = ({
 									<div className="mr-0 flex h-4 w-4 items-center justify-center rounded-sm border border-border-primary text-primary">
 										<Icon name="AddSymbol" size={10} />
 									</div>
-									Create new {normalizedValueLabel} &quot;{normalizedInputValue}
-									&quot;
+									Create new {normalizedValueLabel} &quot;
+									{formatBoxValue(normalizedInputValue, delimiterProps)}&quot;
 								</CommandItem>
 							</CommandGroup>
 						) : null}

--- a/libs/shared/tailwind-ui/src/lib/badge-input/badge-field.tsx
+++ b/libs/shared/tailwind-ui/src/lib/badge-input/badge-field.tsx
@@ -12,6 +12,8 @@ export type BadgeFieldProps<T extends FieldValues> = {
 	disabled?: BadgeInputProps['disabled'];
 	labelTrailingContent?: BadgeInputProps['labelTrailingContent'];
 	trailingContent?: BadgeInputProps['trailingContent'];
+	keyValueDisplayDelimiter?: BadgeInputProps['keyValueDisplayDelimiter'];
+	keyValueSubmitDelimiter?: BadgeInputProps['keyValueSubmitDelimiter'];
 };
 
 export const BadgeField = <T extends FieldValues>(

--- a/libs/shared/tailwind-ui/src/lib/badge-input/badge-input.tsx
+++ b/libs/shared/tailwind-ui/src/lib/badge-input/badge-input.tsx
@@ -16,6 +16,11 @@ import { nanoid } from '@reduxjs/toolkit';
 import { mergeRefs } from '@react-aria/utils';
 
 import { useClickOutside } from '@/shared/hooks';
+import {
+	DEFAULT_KEY_VALUE_DISPLAY_DELIMITER,
+	DEFAULT_KEY_VALUE_SUBMIT_DELIMITER,
+	formatKeyValueForDisplay
+} from '@/shared/utils';
 
 import { BadgeItem } from './types';
 import { parseBadgeString } from './utils';
@@ -34,20 +39,24 @@ export interface BadgeInputProps {
 	icon?: ReactNode;
 	trailingContent?: ReactNode;
 	name?: string;
+	keyValueDisplayDelimiter?: string;
+	keyValueSubmitDelimiter?: string;
 }
 
 export const BadgeInput = forwardRef<HTMLDivElement, BadgeInputProps>(
 	(
 		{
 			label,
-			labelTrailingContent,
 			onBadgesChange,
 			badges = [],
 			placeholder,
 			icon,
-			trailingContent,
 			disabled,
-			name
+			name,
+			keyValueDisplayDelimiter,
+			keyValueSubmitDelimiter,
+			labelTrailingContent,
+			trailingContent
 		},
 		ref
 	) => {
@@ -55,6 +64,14 @@ export const BadgeInput = forwardRef<HTMLDivElement, BadgeInputProps>(
 		const [isKeyReleased, setIsKeyReleased] = useState(false);
 		const [isFocused, setIsFocused] = useState(false);
 		const inputRef = useRef<HTMLInputElement>(null);
+		const formatBadgeValueForInput = useCallback(
+			(badgeValue: string) =>
+				formatKeyValueForDisplay(badgeValue, {
+					displayDelimiter: keyValueDisplayDelimiter,
+					submitDelimiter: keyValueSubmitDelimiter
+				}),
+			[keyValueDisplayDelimiter, keyValueSubmitDelimiter]
+		);
 
 		/**
     |--------------------------------------------------
@@ -73,14 +90,23 @@ export const BadgeInput = forwardRef<HTMLDivElement, BadgeInputProps>(
 			) {
 				e.preventDefault();
 
-				const parsedBadges: BadgeItem[] = parseBadgeString(input).map(
-					(value) => ({
-						id: nanoid(4),
-						value,
-						originalValue: value,
-						isExpression: false
-					})
-				);
+				const parsedConfig = {
+					separator: ',',
+					displayDelimiter:
+						keyValueDisplayDelimiter ?? DEFAULT_KEY_VALUE_DISPLAY_DELIMITER,
+					submitDelimiter:
+						keyValueSubmitDelimiter ?? DEFAULT_KEY_VALUE_SUBMIT_DELIMITER
+				};
+
+				const parsedBadges: BadgeItem[] = parseBadgeString(
+					input,
+					parsedConfig
+				).map((value) => ({
+					id: nanoid(4),
+					value,
+					originalValue: value,
+					isExpression: false
+				}));
 				const newBadgesValue = [...badges, ...parsedBadges];
 
 				setValue('');
@@ -98,7 +124,9 @@ export const BadgeInput = forwardRef<HTMLDivElement, BadgeInputProps>(
 				const badgesCopy = [...badges];
 				const poppedBadge = badgesCopy.pop();
 
-				setValue(poppedBadge?.value || '');
+				setValue(
+					poppedBadge ? formatBadgeValueForInput(poppedBadge.value) : ''
+				);
 				onBadgesChange?.(badgesCopy);
 			}
 
@@ -134,11 +162,11 @@ export const BadgeInput = forwardRef<HTMLDivElement, BadgeInputProps>(
 
 		const handleBadgeEdit = useCallback(
 			(badgeToEdit: BadgeItem) => {
-				setValue(badgeToEdit.value);
+				setValue(formatBadgeValueForInput(badgeToEdit.value));
 				onBadgesChange?.(badges.filter((badge) => badge.id !== badgeToEdit.id));
 				queueMicrotask(() => inputRef.current?.focus());
 			},
-			[onBadgesChange, badges]
+			[onBadgesChange, badges, formatBadgeValueForInput]
 		);
 
 		const handleBadgeDeleteClick = useCallback(
@@ -193,7 +221,14 @@ export const BadgeInput = forwardRef<HTMLDivElement, BadgeInputProps>(
 					) : null}
 
 					<div className="flex flex-wrap flex-grow h-full">
-						{!disabled ? <BadgeList label={label} badges={badges} /> : null}
+						{!disabled ? (
+							<BadgeList
+								label={label}
+								badges={badges}
+								keyValueDisplayDelimiter={keyValueDisplayDelimiter}
+								keyValueSubmitDelimiter={keyValueSubmitDelimiter}
+							/>
+						) : null}
 						<input
 							className="flex w-full outline-none placeholder:font-normal disabled:bg-bg-body pr-2 pl-4 py-2 cursor-[inherit] bg-transparent placeholder:text-text-menu border-none text-text-secondary leading-[1.5rem] font-medium text-[0.875rem] focus:ring-transparent"
 							value={value}

--- a/libs/shared/tailwind-ui/src/lib/badge-input/badge-list/badge-list.tsx
+++ b/libs/shared/tailwind-ui/src/lib/badge-input/badge-list/badge-list.tsx
@@ -5,13 +5,21 @@ import { useRef, RefObject } from 'react';
 import { BadgeItem } from '../types';
 import { EditPopover } from './edit-popover';
 import { cn } from '../../utils';
+import { formatKeyValueForDisplay } from '@/shared/utils';
 
 export interface BadgeListProps {
 	label?: string;
 	badges: BadgeItem[];
+	keyValueDisplayDelimiter?: string;
+	keyValueSubmitDelimiter?: string;
 }
 
-export const BadgeList = ({ label, badges }: BadgeListProps) => {
+export const BadgeList = ({
+	label,
+	badges,
+	keyValueDisplayDelimiter,
+	keyValueSubmitDelimiter
+}: BadgeListProps) => {
 	const listRef = useRef<HTMLUListElement>(null);
 
 	return (
@@ -25,7 +33,13 @@ export const BadgeList = ({ label, badges }: BadgeListProps) => {
 			ref={listRef}
 		>
 			{badges.map((badge) => (
-				<Badge key={badge.id} badge={badge} listRef={listRef} />
+				<Badge
+					key={badge.id}
+					badge={badge}
+					listRef={listRef}
+					keyValueDisplayDelimiter={keyValueDisplayDelimiter}
+					keyValueSubmitDelimiter={keyValueSubmitDelimiter}
+				/>
 			))}
 		</ul>
 	);
@@ -34,13 +48,25 @@ export const BadgeList = ({ label, badges }: BadgeListProps) => {
 export interface BadgeProps {
 	badge: BadgeItem;
 	listRef: RefObject<HTMLUListElement>;
+	keyValueDisplayDelimiter?: string;
+	keyValueSubmitDelimiter?: string;
 }
 
-export const Badge = ({ badge, listRef }: BadgeProps) => {
+export const Badge = ({
+	badge,
+	listRef,
+	keyValueDisplayDelimiter,
+	keyValueSubmitDelimiter
+}: BadgeProps) => {
+	const displayValue = formatKeyValueForDisplay(badge.value, {
+		displayDelimiter: keyValueDisplayDelimiter,
+		submitDelimiter: keyValueSubmitDelimiter
+	});
+
 	return (
 		<EditPopover badge={badge} listRef={listRef}>
 			<li className="relative inline-flex items-center py-0.5 px-1 rounded bg-badge-0 text-[0.7875rem] font-medium leading-[1.125rem]">
-				{badge.value}
+				{displayValue}
 			</li>
 		</EditPopover>
 	);

--- a/libs/shared/tailwind-ui/src/lib/badge-input/utils/index.ts
+++ b/libs/shared/tailwind-ui/src/lib/badge-input/utils/index.ts
@@ -1,9 +1,15 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import {
+	DEFAULT_KEY_VALUE_DISPLAY_DELIMITER,
+	DEFAULT_KEY_VALUE_SUBMIT_DELIMITER,
+	normalizeKeyValueForSubmit
+} from '@/shared/utils';
+
 export interface ParseBadgeStringOptions {
 	separator: string;
-	delimeter: string;
-	originalDelimeter: string;
+	submitDelimiter?: string;
+	displayDelimiter?: string;
 	quote?: string;
 }
 
@@ -11,8 +17,8 @@ const DEFAULT_QUOTE = '"';
 
 const PARSE_CONFIG: ParseBadgeStringOptions = {
 	separator: ',',
-	originalDelimeter: ':',
-	delimeter: '=',
+	displayDelimiter: DEFAULT_KEY_VALUE_DISPLAY_DELIMITER,
+	submitDelimiter: DEFAULT_KEY_VALUE_SUBMIT_DELIMITER,
 	quote: DEFAULT_QUOTE
 };
 
@@ -21,9 +27,32 @@ const normalizeBadgeValue = (
 	wasQuoted: boolean,
 	config: ParseBadgeStringOptions
 ): string => {
-	const normalizedValue = wasQuoted ? value : value.trim();
+	if (wasQuoted) {
+		const leadingWhitespaceLength = value.length - value.trimStart().length;
+		const trailingWhitespaceLength = value.length - value.trimEnd().length;
+		const leadingWhitespace = value.slice(0, leadingWhitespaceLength);
+		const trailingWhitespace = value.slice(
+			value.length - trailingWhitespaceLength
+		);
+		const coreValue = value.slice(
+			leadingWhitespaceLength,
+			value.length - trailingWhitespaceLength
+		);
 
-	return normalizedValue.replace(config.originalDelimeter, config.delimeter);
+		if (!coreValue.length) return value;
+
+		const normalizedCoreValue = normalizeKeyValueForSubmit(coreValue, {
+			displayDelimiter: config.displayDelimiter,
+			submitDelimiter: config.submitDelimiter
+		});
+
+		return `${leadingWhitespace}${normalizedCoreValue}${trailingWhitespace}`;
+	}
+
+	return normalizeKeyValueForSubmit(value, {
+		displayDelimiter: config.displayDelimiter,
+		submitDelimiter: config.submitDelimiter
+	});
 };
 
 export const parseBadgeString = (
@@ -39,7 +68,10 @@ export const parseBadgeString = (
 	let isAfterClosingQuote = false;
 
 	const pushCurrent = (): void => {
-		result.push(normalizeBadgeValue(current, wasQuoted, config));
+		const value = normalizeBadgeValue(current, wasQuoted, config);
+
+		if (value || wasQuoted) result.push(value);
+
 		current = '';
 		wasQuoted = false;
 		isAfterClosingQuote = false;

--- a/libs/shared/tailwind-ui/src/lib/badge-list/__snapshots__/badge-list.spec.tsx.snap
+++ b/libs/shared/tailwind-ui/src/lib/badge-list/__snapshots__/badge-list.spec.tsx.snap
@@ -125,7 +125,7 @@ exports[`components/BadgeList > should render env badges 1`] = `
         class="inline-flex items-center w-fit py-0.5 px-2 rounded border border-transparent text-[0.75rem] font-medium transition-colors overflow-wrap-anywhere bg-badge-1"
         data-testid="tw-badge"
       >
-        env=test-env
+        env: test-env
       </div>
     </div>
     <div

--- a/libs/shared/tailwind-ui/src/lib/badge-list/badge-list.tsx
+++ b/libs/shared/tailwind-ui/src/lib/badge-list/badge-list.tsx
@@ -2,12 +2,20 @@
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
 import { forwardRef, useMemo } from 'react';
 
-import { isBranch, isRevision, trimBranch, trimRevision } from '@/shared/utils';
+import {
+	DEFAULT_KEY_VALUE_SUBMIT_DELIMITER,
+	formatKeyValueForDisplay,
+	isBranch,
+	isRevision,
+	trimBranch,
+	trimRevision
+} from '@/shared/utils';
 
 import { Badge } from '../badge';
 import { EnvBadge } from '../env-badge';
 
-const isEnv = (value: string) => value.startsWith('env=');
+const isEnv = (value: string, delimiter = DEFAULT_KEY_VALUE_SUBMIT_DELIMITER) =>
+	value.startsWith(`env${delimiter}`);
 
 export type BadgeListItem = {
 	payload: string;
@@ -19,16 +27,34 @@ export interface BadgeListProps {
 	onBadgeClick?: (badge: BadgeListItem) => void;
 	selectedBadges?: string[];
 	className?: string;
+	keyValueDisplayDelimiter?: string;
+	keyValueSubmitDelimiter?: string;
 }
 
 export const BadgeList = forwardRef<HTMLDivElement, BadgeListProps>(
-	({ badges, selectedBadges, onBadgeClick, className }, ref) => {
+	(
+		{
+			badges,
+			selectedBadges,
+			onBadgeClick,
+			className,
+			keyValueDisplayDelimiter,
+			keyValueSubmitDelimiter
+		},
+		ref
+	) => {
 		const { filterBadges, envBadges } = useMemo(() => {
-			const filterBadges = badges.filter((badge) => !isEnv(badge.payload));
-			const envBadges = badges.filter((badge) => isEnv(badge.payload));
+			const submitDelimiter =
+				keyValueSubmitDelimiter ?? DEFAULT_KEY_VALUE_SUBMIT_DELIMITER;
+			const filterBadges = badges.filter(
+				(badge) => !isEnv(badge.payload, submitDelimiter)
+			);
+			const envBadges = badges.filter((badge) =>
+				isEnv(badge.payload, submitDelimiter)
+			);
 
 			return { filterBadges, envBadges };
-		}, [badges]);
+		}, [badges, keyValueSubmitDelimiter]);
 
 		const badgeNodes = filterBadges.map((badge, idx) => {
 			const isSelected = selectedBadges?.includes(badge.payload);
@@ -41,6 +67,10 @@ export const BadgeList = forwardRef<HTMLDivElement, BadgeListProps>(
 			let value = badge.payload;
 			if (isRevision(badge.payload)) value = trimRevision(badge.payload);
 			if (isBranch(badge.payload)) value = trimBranch(badge.payload);
+			value = formatKeyValueForDisplay(value, {
+				displayDelimiter: keyValueDisplayDelimiter,
+				submitDelimiter: keyValueSubmitDelimiter
+			});
 
 			return (
 				<Badge
@@ -59,6 +89,8 @@ export const BadgeList = forwardRef<HTMLDivElement, BadgeListProps>(
 			<EnvBadge
 				key={idx}
 				value={envBadge.payload}
+				keyValueDisplayDelimiter={keyValueDisplayDelimiter}
+				keyValueSubmitDelimiter={keyValueSubmitDelimiter}
 				onContentClick={
 					onBadgeClick ? () => onBadgeClick?.(envBadge) : undefined
 				}

--- a/libs/shared/tailwind-ui/src/lib/env-badge/env-badge.tsx
+++ b/libs/shared/tailwind-ui/src/lib/env-badge/env-badge.tsx
@@ -2,7 +2,7 @@
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
 import { FC, useState } from 'react';
 
-import { indentEnv } from '@/shared/utils';
+import { formatKeyValueForDisplay, indentEnv } from '@/shared/utils';
 
 import { cn } from '../utils';
 import { Badge } from '../badge';
@@ -14,12 +14,24 @@ export interface EnvBadgeProps {
 	value: string;
 	isSelected?: boolean;
 	onContentClick?: () => void;
+	keyValueDisplayDelimiter?: string;
+	keyValueSubmitDelimiter?: string;
 }
 
 export const EnvBadge: FC<EnvBadgeProps> = (props) => {
-	const { value, isSelected, onContentClick } = props;
+	const {
+		value,
+		isSelected,
+		onContentClick,
+		keyValueDisplayDelimiter,
+		keyValueSubmitDelimiter
+	} = props;
 	const indentedValue = indentEnv(value);
 	const [isOpen, setIsOpen] = useState(false);
+	const displayValue = formatKeyValueForDisplay(value, {
+		displayDelimiter: keyValueDisplayDelimiter,
+		submitDelimiter: keyValueSubmitDelimiter
+	});
 
 	if (value.length <= 30) {
 		return (
@@ -29,7 +41,7 @@ export const EnvBadge: FC<EnvBadgeProps> = (props) => {
 				onClick={onContentClick}
 				overflowWrap
 			>
-				{value}
+				{displayValue}
 			</Badge>
 		);
 	}

--- a/libs/shared/utils/src/index.ts
+++ b/libs/shared/utils/src/index.ts
@@ -8,6 +8,7 @@ export * from './lib/misc';
 export * from './lib/tree';
 export * from './lib/time';
 export * from './lib/format';
+export * from './lib/key-value';
 export * from './lib/compress-tests';
 export * from './lib/router';
 export * from './lib/form';

--- a/libs/shared/utils/src/lib/key-value.spec.ts
+++ b/libs/shared/utils/src/lib/key-value.spec.ts
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+	formatKeyValueForDisplay,
+	getKeyValueParts,
+	joinKeyValue,
+	normalizeKeyValueForSubmit
+} from './key-value';
+
+describe('key-value utils', () => {
+	it('formats submit key/value pair for display', () => {
+		expect(formatKeyValueForDisplay('time_limit=30')).toBe('time_limit: 30');
+	});
+
+	it('does not modify plain values without submit delimiter', () => {
+		expect(formatKeyValueForDisplay('linux-mm-612')).toBe('linux-mm-612');
+	});
+
+	it('splits only by first submit delimiter', () => {
+		expect(getKeyValueParts('foo=bar=baz')).toEqual(['foo', 'bar=baz']);
+	});
+
+	it('normalizes display key/value input to submit delimiter', () => {
+		expect(normalizeKeyValueForSubmit('time_limit:30')).toBe('time_limit=30');
+		expect(normalizeKeyValueForSubmit('time_limit: 30')).toBe('time_limit=30');
+	});
+
+	it('normalizes display key/value input with submit delimiter in value', () => {
+		expect(normalizeKeyValueForSubmit('url: https://host/path?a=b')).toBe(
+			'url=https://host/path?a=b'
+		);
+		expect(normalizeKeyValueForSubmit('expr: a=b')).toBe('expr=a=b');
+	});
+
+	it('does not normalize already submitted key/value input', () => {
+		expect(normalizeKeyValueForSubmit('expr=a=b: c')).toBe('expr=a=b: c');
+	});
+
+	it('does not normalize urls with ://', () => {
+		expect(normalizeKeyValueForSubmit('https://example.com')).toBe(
+			'https://example.com'
+		);
+	});
+
+	it('joins optional key/value preserving empty parts', () => {
+		expect(joinKeyValue('name', 'value')).toBe('name=value');
+		expect(joinKeyValue('name', undefined)).toBe('name');
+		expect(joinKeyValue(undefined, 'value')).toBe('value');
+	});
+});

--- a/libs/shared/utils/src/lib/key-value.ts
+++ b/libs/shared/utils/src/lib/key-value.ts
@@ -1,0 +1,111 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+
+export interface KeyValueDelimiterOptions {
+	submitDelimiter?: string;
+	displayDelimiter?: string;
+}
+
+export const DEFAULT_KEY_VALUE_SUBMIT_DELIMITER = '=';
+export const DEFAULT_KEY_VALUE_DISPLAY_DELIMITER = ': ';
+
+const normalizeDelimiters = (options: KeyValueDelimiterOptions = {}) => {
+	return {
+		submitDelimiter:
+			options.submitDelimiter ?? DEFAULT_KEY_VALUE_SUBMIT_DELIMITER,
+		displayDelimiter:
+			options.displayDelimiter ?? DEFAULT_KEY_VALUE_DISPLAY_DELIMITER
+	};
+};
+
+export const hasSubmitDelimiter = (
+	value: string,
+	submitDelimiter = DEFAULT_KEY_VALUE_SUBMIT_DELIMITER
+) => {
+	if (!submitDelimiter.length) return false;
+
+	return value.includes(submitDelimiter);
+};
+
+export const getKeyValueParts = (
+	value: string,
+	submitDelimiter = DEFAULT_KEY_VALUE_SUBMIT_DELIMITER
+): [string, string | undefined] => {
+	if (!submitDelimiter.length) return [value, undefined];
+
+	const delimiterIndex = value.indexOf(submitDelimiter);
+
+	if (delimiterIndex === -1) return [value, undefined];
+
+	const key = value.slice(0, delimiterIndex);
+	const parsedValue = value.slice(delimiterIndex + submitDelimiter.length);
+
+	return [key, parsedValue];
+};
+
+export const formatKeyValueForDisplay = (
+	value: string,
+	options: KeyValueDelimiterOptions = {}
+) => {
+	const { submitDelimiter, displayDelimiter } = normalizeDelimiters(options);
+	const [key, parsedValue] = getKeyValueParts(value, submitDelimiter);
+
+	if (typeof parsedValue === 'undefined') return value;
+
+	return `${key}${displayDelimiter}${parsedValue}`;
+};
+
+export const normalizeKeyValueForSubmit = (
+	rawValue: string,
+	options: KeyValueDelimiterOptions = {}
+) => {
+	const { submitDelimiter, displayDelimiter } = normalizeDelimiters(options);
+	const value = rawValue.trim();
+
+	if (!value.length) return value;
+	if (!submitDelimiter.length || !displayDelimiter.length) return value;
+
+	const displayDelimiters = Array.from(
+		new Set([
+			displayDelimiter,
+			displayDelimiter.trimEnd(),
+			displayDelimiter.trim()
+		])
+	).filter((delimiter) => delimiter.length > 0);
+	const submitDelimiterIndex = value.indexOf(submitDelimiter);
+
+	for (const delimiter of displayDelimiters) {
+		const delimiterIndex = value.indexOf(delimiter);
+
+		if (delimiterIndex <= 0) continue;
+		if (submitDelimiterIndex !== -1 && submitDelimiterIndex < delimiterIndex) {
+			return value;
+		}
+
+		const key = value.slice(0, delimiterIndex).trim();
+		const parsedValue = value
+			.slice(delimiterIndex + delimiter.length)
+			.trimStart();
+
+		if (!key.length || !parsedValue.length) continue;
+		if (delimiter === ':' && parsedValue.startsWith('//')) continue;
+
+		return `${key}${submitDelimiter}${parsedValue}`;
+	}
+
+	return value;
+};
+
+export const joinKeyValue = (
+	key?: string,
+	value?: string,
+	delimiter = DEFAULT_KEY_VALUE_SUBMIT_DELIMITER
+) => {
+	const finalKey = key ?? '';
+	const finalValue = value ?? '';
+
+	if (finalKey && finalValue) return `${finalKey}${delimiter}${finalValue}`;
+	if (finalKey) return finalKey;
+
+	return finalValue;
+};


### PR DESCRIPTION
Currently we use "=" as a delimeter for `<key>=<value>` pairs and use "=" also in API requests make this behaviour configurable via global app config and display in ": " as a default delimeter. This change is backward compatible with current usage of "=", so users can use both "=" and ": " when filling out forms.