### PR TITLE
Improve run page filters

### DIFF
--- a/libs/bublik/features/runs/src/lib/runs-form/runs-form.component.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-form/runs-form.component.tsx
@@ -2,6 +2,7 @@
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
 import { forwardRef } from 'react';
 import { useForm, Controller } from 'react-hook-form';
+import { DateValue } from '@internationalized/date';
 
 import { analyticsEventNames, trackEvent } from '@/bublik/features/analytics';
 import {
@@ -12,7 +13,8 @@ import {
 	TagsBoxInput,
 	BoxValue
 } from '@/shared/tailwind-ui';
-import { DateValue } from '@internationalized/date';
+
+import { RUN_DATA_GROUP_ORDER } from '../runs-slice.selectors';
 
 export interface RunsFormValues {
 	calendarMode: 'default' | 'duration';
@@ -78,7 +80,10 @@ export const RunsForm = forwardRef<HTMLFormElement, RunsFormProps>(
 							<TagsBoxInput
 								label="Metas"
 								valueLabel="Meta"
+								createdGroupLabel="Metadata"
+								groupOrder={RUN_DATA_GROUP_ORDER}
 								placeholder="Metas"
+								size="md"
 								startIcon={
 									<Icon
 										name="Filter"
@@ -86,7 +91,9 @@ export const RunsForm = forwardRef<HTMLFormElement, RunsFormProps>(
 										className="mr-2 text-text-menu"
 									/>
 								}
-								endIcon={<Icon name="AddSymbol" size={20} className="ml-2" />}
+								endIcon={
+									<Icon name="AddSymbol" size={20} className="text-text-menu" />
+								}
 								values={field.value}
 								onChange={(nextValues) => {
 									trackEvent(analyticsEventNames.runsFormTagsEdit, {

--- a/libs/bublik/features/runs/src/lib/runs-form/runs-form.component.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-form/runs-form.component.tsx
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { forwardRef } from 'react';
-import { useForm, Controller } from 'react-hook-form';
+import { forwardRef, useMemo } from 'react';
+import { useForm, Controller, useWatch } from 'react-hook-form';
 import { DateValue } from '@internationalized/date';
 
 import { analyticsEventNames, trackEvent } from '@/bublik/features/analytics';
@@ -14,6 +14,11 @@ import {
 	BoxValue
 } from '@/shared/tailwind-ui';
 
+import {
+	areRunsFiltersSnapshotsEqual,
+	createRunsFormFiltersSnapshot,
+	type RunsFormFiltersSnapshot
+} from './runs-form.utils';
 import { RUN_DATA_GROUP_ORDER } from '../runs-slice.selectors';
 
 export interface RunsFormValues {
@@ -25,21 +30,68 @@ export interface RunsFormValues {
 
 export interface RunsFormProps {
 	defaultValues: RunsFormValues;
+	appliedFilters: RunsFormFiltersSnapshot;
 	onRunsFormSubmit: (newForm: RunsFormValues) => void;
 	onResetFormClick: (resettedForm: RunsFormValues) => void;
 }
 
 export const RunsForm = forwardRef<HTMLFormElement, RunsFormProps>(
-	({ defaultValues, onRunsFormSubmit, onResetFormClick }, ref) => {
-		const {
-			control,
-			register,
-			handleSubmit,
-			reset,
-			getValues,
-			watch,
-			setValue
-		} = useForm<RunsFormValues>({ defaultValues });
+	(
+		{ defaultValues, appliedFilters, onRunsFormSubmit, onResetFormClick },
+		ref
+	) => {
+		const { control, register, handleSubmit, reset, getValues, setValue } =
+			useForm<RunsFormValues>({ defaultValues });
+		const watchedValues = useWatch({ control });
+
+		const currentDates: RunsFormValues['dates'] = useMemo(
+			() =>
+				watchedValues.dates?.start && watchedValues.dates?.end
+					? {
+							start: watchedValues.dates.start as DateValue,
+							end: watchedValues.dates.end as DateValue
+					  }
+					: defaultValues.dates,
+			[
+				defaultValues.dates,
+				watchedValues?.dates?.end,
+				watchedValues?.dates?.start
+			]
+		);
+
+		const currentRunData: RunsFormValues['runData'] =
+			watchedValues.runData?.every(
+				(value): value is BoxValue =>
+					typeof value?.label === 'string' && typeof value?.value === 'string'
+			)
+				? watchedValues.runData
+				: defaultValues.runData;
+
+		const currentFormValues = useMemo<RunsFormValues>(
+			() => ({
+				calendarMode: watchedValues.calendarMode ?? defaultValues.calendarMode,
+				dates: currentDates,
+				runData: currentRunData,
+				tagExpr: watchedValues.tagExpr ?? defaultValues.tagExpr
+			}),
+			[
+				currentDates,
+				currentRunData,
+				defaultValues.calendarMode,
+				defaultValues.tagExpr,
+				watchedValues.calendarMode,
+				watchedValues.tagExpr
+			]
+		);
+
+		const hasPendingFilterMismatch = useMemo(
+			() =>
+				!areRunsFiltersSnapshotsEqual(
+					createRunsFormFiltersSnapshot(currentFormValues),
+					appliedFilters
+				),
+			[appliedFilters, currentFormValues]
+		);
 
 		const handleResetClick = () => {
 			const resettedForm: RunsFormValues = {
@@ -65,7 +117,7 @@ export const RunsForm = forwardRef<HTMLFormElement, RunsFormProps>(
 						control={control}
 						render={({ field }) => (
 							<AriaDateRangePicker
-								mode={watch('calendarMode')}
+								mode={currentFormValues.calendarMode}
 								onModeChange={(mode) => setValue('calendarMode', mode)}
 								label="Runs Range"
 								enabledModes={['default', 'duration']}
@@ -111,7 +163,12 @@ export const RunsForm = forwardRef<HTMLFormElement, RunsFormProps>(
 					<SearchBar {...register('tagExpr')} placeholder="Tag expression" />
 				</div>
 				<div className="flex gap-4">
-					<ButtonTw size="md" rounded="lg" type="submit" variant="primary">
+					<ButtonTw
+						size="md"
+						rounded="lg"
+						type="submit"
+						variant={hasPendingFilterMismatch ? 'primary' : 'outline'}
+					>
 						<Icon name="Refresh" size={24} className="mr-1.5" />
 						<span>Submit</span>
 					</ButtonTw>

--- a/libs/bublik/features/runs/src/lib/runs-form/runs-form.container.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-form/runs-form.container.tsx
@@ -13,6 +13,10 @@ import { BoxValue } from '@/shared/tailwind-ui';
 import { useMount } from '@/shared/hooks';
 
 import { RunsForm, RunsFormValues } from './runs-form.component';
+import {
+	createRunsSearchParamsFiltersSnapshot,
+	getSelectedRunData
+} from './runs-form.utils';
 import { updateGlobalFilter } from '../runs-slice';
 import { selectAllTags, selectGlobalFilter } from '../runs-slice.selectors';
 
@@ -34,11 +38,13 @@ function RunsFormContainer() {
 		() => searchParamsToForm(searchParams, allTags),
 		[allTags, searchParams]
 	);
+	const appliedFilters = useMemo(
+		() => createRunsSearchParamsFiltersSnapshot(searchParams),
+		[searchParams]
+	);
 
 	function handleFormSubmit(newForm: RunsFormValues) {
-		const selectedRunData = newForm.runData
-			.filter((value) => value.isSelected)
-			.map((value) => value.value);
+		const selectedRunData = getSelectedRunData(newForm.runData);
 
 		trackEvent(analyticsEventNames.runsFormSubmit, {
 			calendarMode: newForm.calendarMode,
@@ -77,6 +83,7 @@ function RunsFormContainer() {
 		<RunsForm
 			key={`${localGlobalFilter.length}_${defaultValues.runData.length}`}
 			defaultValues={defaultValues}
+			appliedFilters={appliedFilters}
 			onRunsFormSubmit={handleFormSubmit}
 			onResetFormClick={handleResetFormClick}
 		/>
@@ -164,9 +171,7 @@ function formToSearchParams(
 		);
 	}
 
-	const selectedRunData = runData
-		.filter((v) => v.isSelected)
-		.map((v) => v.value);
+	const selectedRunData = getSelectedRunData(runData);
 
 	selectedRunData.length
 		? params.set('runData', selectedRunData.join(';'))

--- a/libs/bublik/features/runs/src/lib/runs-form/runs-form.container.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-form/runs-form.container.tsx
@@ -14,6 +14,7 @@ import { useMount } from '@/shared/hooks';
 
 import { RunsForm, RunsFormValues } from './runs-form.component';
 import {
+	applyRunDataToSearchParams,
 	createRunsSearchParamsFiltersSnapshot,
 	getSelectedRunData
 } from './runs-form.utils';
@@ -173,14 +174,9 @@ function formToSearchParams(
 
 	const selectedRunData = getSelectedRunData(runData);
 
-	selectedRunData.length
-		? params.set('runData', selectedRunData.join(';'))
-		: params.delete('runData');
-
 	tagExpr ? params.set('tagExpr', tagExpr) : params.delete('tagExpr');
 
-	params.set('page', '1');
-	return params;
+	return applyRunDataToSearchParams(params, selectedRunData);
 }
 
 export { RunsFormContainer };

--- a/libs/bublik/features/runs/src/lib/runs-form/runs-form.utils.ts
+++ b/libs/bublik/features/runs/src/lib/runs-form/runs-form.utils.ts
@@ -1,0 +1,102 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+import { getLocalTimeZone } from '@internationalized/date';
+import { formatISODuration, intervalToDuration } from 'date-fns';
+
+import { formatTimeToAPI } from '@/shared/utils';
+
+import type { RunsFormValues } from './runs-form.component';
+
+export interface RunsFormFiltersSnapshot {
+	calendarMode: RunsFormValues['calendarMode'];
+	startDate: string;
+	finishDate: string;
+	duration: string;
+	tagExpr: string;
+	runData: string[];
+}
+
+const normalizeRunData = (runData: string[]): string[] =>
+	Array.from(new Set(runData.filter(Boolean))).sort((left, right) =>
+		left.localeCompare(right)
+	);
+
+const normalizeFilterValue = (value: string | null | undefined): string =>
+	value ?? '';
+
+export const getSelectedRunData = (
+	runData: RunsFormValues['runData']
+): string[] =>
+	normalizeRunData(
+		runData.filter((value) => value.isSelected).map((value) => value.value)
+	);
+
+export function createRunsFormFiltersSnapshot(
+	form: RunsFormValues
+): RunsFormFiltersSnapshot {
+	const startDate = form.dates?.start
+		? formatTimeToAPI(form.dates.start.toDate(getLocalTimeZone()))
+		: '';
+	const finishDate = form.dates?.end
+		? formatTimeToAPI(form.dates.end.toDate(getLocalTimeZone()))
+		: '';
+	const duration =
+		form.calendarMode === 'duration' && form.dates?.start && form.dates?.end
+			? formatISODuration(
+					intervalToDuration({
+						start: form.dates.start.toDate(getLocalTimeZone()),
+						end: form.dates.end.toDate(getLocalTimeZone())
+					})
+			  )
+			: '';
+
+	return {
+		calendarMode: form.calendarMode,
+		startDate,
+		finishDate,
+		duration,
+		tagExpr: form.tagExpr,
+		runData: getSelectedRunData(form.runData)
+	};
+}
+
+export function createRunsSearchParamsFiltersSnapshot(
+	searchParams: URLSearchParams
+): RunsFormFiltersSnapshot {
+	return {
+		calendarMode: (searchParams.get('calendarMode') ??
+			'default') as RunsFormValues['calendarMode'],
+		startDate: normalizeFilterValue(searchParams.get('startDate')),
+		finishDate: normalizeFilterValue(searchParams.get('finishDate')),
+		duration: normalizeFilterValue(searchParams.get('duration')),
+		tagExpr: normalizeFilterValue(searchParams.get('tagExpr')),
+		runData: normalizeRunData(
+			normalizeFilterValue(searchParams.get('runData'))
+				.split(';')
+				.filter(Boolean)
+		)
+	};
+}
+
+export function areRunsFiltersSnapshotsEqual(
+	left: RunsFormFiltersSnapshot,
+	right: RunsFormFiltersSnapshot
+): boolean {
+	if (left.calendarMode !== right.calendarMode) return false;
+	if (left.tagExpr !== right.tagExpr) return false;
+	if (left.runData.length !== right.runData.length) return false;
+
+	const hasDifferentRunData = left.runData.some(
+		(value, index) => value !== right.runData[index]
+	);
+
+	if (hasDifferentRunData) return false;
+
+	if (left.calendarMode === 'duration') {
+		return left.duration === right.duration;
+	}
+
+	return (
+		left.startDate === right.startDate && left.finishDate === right.finishDate
+	);
+}

--- a/libs/bublik/features/runs/src/lib/runs-form/runs-form.utils.ts
+++ b/libs/bublik/features/runs/src/lib/runs-form/runs-form.utils.ts
@@ -31,6 +31,22 @@ export const getSelectedRunData = (
 		runData.filter((value) => value.isSelected).map((value) => value.value)
 	);
 
+export function applyRunDataToSearchParams(
+	initialSearchParams: URLSearchParams,
+	runData: string[]
+): URLSearchParams {
+	const params = new URLSearchParams(initialSearchParams);
+	const normalizedRunData = normalizeRunData(runData);
+
+	normalizedRunData.length
+		? params.set('runData', normalizedRunData.join(';'))
+		: params.delete('runData');
+
+	params.set('page', '1');
+
+	return params;
+}
+
 export function createRunsFormFiltersSnapshot(
 	form: RunsFormValues
 ): RunsFormFiltersSnapshot {

--- a/libs/bublik/features/runs/src/lib/runs-slice.selectors.ts
+++ b/libs/bublik/features/runs/src/lib/runs-slice.selectors.ts
@@ -1,19 +1,14 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import {
-	createEntityAdapter,
-	createSelector,
-	EntityId
-} from '@reduxjs/toolkit';
+import { createSelector } from '@reduxjs/toolkit';
 
-import type { RunsData } from '@/shared/types';
 import type { BoxValue } from '@/shared/tailwind-ui';
 
-import { type AppStateWithRunsSlice, RUNS_PAGE_SLICE } from './runs-slice';
-
-export const runsAdapter = createEntityAdapter<RunsData, EntityId>({
-	selectId: (run) => run.id.toString()
-});
+import {
+	type AppStateWithRunsSlice,
+	RUNS_PAGE_SLICE,
+	runsAdapter
+} from './runs-slice';
 
 const getRunsPageState = (state: AppStateWithRunsSlice) =>
 	state[RUNS_PAGE_SLICE];
@@ -39,6 +34,8 @@ export const getResults = createSelector(
 
 const { selectAll: selectAllRuns } = runsAdapter.getSelectors(getResults);
 
+export const RUN_DATA_GROUP_ORDER = ['Important', 'Metadata', 'Tags'] as const;
+
 export const selectAllTags = createSelector(
 	selectAllRuns,
 	selectGlobalFilter,
@@ -46,6 +43,7 @@ export const selectAllTags = createSelector(
 		const DEFAULT_BG = 'bg-badge-0';
 		const IMPORTANT_BG = 'bg-badge-6';
 		const META_BG = 'bg-badge-4';
+		const [IMPORTANT_GROUP, META_GROUP, TAGS_GROUP] = RUN_DATA_GROUP_ORDER;
 
 		const important = runs.flatMap((run) => run.important_tags);
 		const metas = runs.flatMap((run) => run.metadata);
@@ -55,38 +53,38 @@ export const selectAllTags = createSelector(
 		const metaSet = new Set(metas);
 		const tagsSet = new Set(tags);
 
-		const currentTicked: BoxValue[] = globalFilter.map((filterValue) => {
-			let bgClassName = DEFAULT_BG;
+		const getGroupLabel = (value: string) => {
+			if (importantSet.has(value)) return IMPORTANT_GROUP;
+			if (metaSet.has(value)) return META_GROUP;
+			if (tagsSet.has(value)) return TAGS_GROUP;
+			return META_GROUP;
+		};
 
-			if (importantSet.has(filterValue)) bgClassName = IMPORTANT_BG;
-			if (metaSet.has(filterValue)) bgClassName = META_BG;
+		const getClassName = (value: string) => {
+			if (importantSet.has(value)) return IMPORTANT_BG;
+			if (metaSet.has(value)) return META_BG;
+			return DEFAULT_BG;
+		};
 
-			return {
-				label: filterValue,
-				value: filterValue,
-				isSelected: true,
-				className: bgClassName
-			};
-		});
+		const boxesMap = new Map<string, BoxValue>();
 
-		const importantBoxes: BoxValue[] = Array.from(importantSet).map((v) => ({
-			label: v,
-			value: v,
-			className: IMPORTANT_BG
-		}));
+		const upsertBox = (value: string, isSelected = false) => {
+			const current = boxesMap.get(value);
 
-		const metaBoxes: BoxValue[] = Array.from(metaSet).map((v) => ({
-			label: v,
-			value: v,
-			className: META_BG
-		}));
+			boxesMap.set(value, {
+				label: value,
+				value,
+				isSelected: current?.isSelected || isSelected,
+				className: getClassName(value),
+				groupLabel: getGroupLabel(value)
+			});
+		};
 
-		const tagsBoxes: BoxValue[] = Array.from(tagsSet).map((v) => ({
-			label: v,
-			value: v,
-			className: DEFAULT_BG
-		}));
+		globalFilter.forEach((value) => upsertBox(value, true));
+		Array.from(importantSet).forEach((value) => upsertBox(value));
+		Array.from(metaSet).forEach((value) => upsertBox(value));
+		Array.from(tagsSet).forEach((value) => upsertBox(value));
 
-		return [...currentTicked, ...importantBoxes, ...metaBoxes, ...tagsBoxes];
+		return Array.from(boxesMap.values());
 	}
 );

--- a/libs/bublik/features/runs/src/lib/runs-slice.ts
+++ b/libs/bublik/features/runs/src/lib/runs-slice.ts
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
 import {
+	createEntityAdapter,
 	createSlice,
 	EntityId,
 	EntityState,
@@ -10,7 +11,9 @@ import {
 import { bublikAPI } from '@/services/bublik-api';
 import { RunsData } from '@/shared/types';
 
-import { runsAdapter } from './runs-slice.selectors';
+export const runsAdapter = createEntityAdapter<RunsData, EntityId>({
+	selectId: (run) => run.id.toString()
+});
 
 export const RUNS_PAGE_SLICE = 'runsPage';
 

--- a/libs/bublik/features/runs/src/lib/runs-table/runs-table.component.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-table/runs-table.component.tsx
@@ -123,42 +123,45 @@ function RunsTable(props: RunsTableProps) {
 
 	return (
 		<div>
-			<table className="border-separate border-spacing-y-1 h-full p-0 m-0 w-full">
-				<thead>
-					{table.getHeaderGroups().map((headerGroup) => (
-						<tr key={headerGroup.id} className="h-8">
-							{headerGroup.headers.map((header) => {
-								const headerClassName =
-									header.column.columnDef.meta?.headerClassName || '';
+			<div className="-mt-1">
+				{/* border-spacing adds outer spacing above the first row; offset it to keep a 4px page-level gap */}
+				<table className="border-separate border-spacing-y-1 h-full p-0 m-0 w-full">
+					<thead>
+						{table.getHeaderGroups().map((headerGroup) => (
+							<tr key={headerGroup.id} className="h-8">
+								{headerGroup.headers.map((header) => {
+									const headerClassName =
+										header.column.columnDef.meta?.headerClassName || '';
 
-								return (
-									<th
-										key={header.id}
-										className={cn(
-											'py-2 px-1 text-[0.6875rem] font-semibold leading-[0.875rem] text-left bg-white sticky top-0 z-10',
-											headerClassName
-										)}
-									>
-										{header.isPlaceholder
-											? null
-											: flexRender(
-													header.column.columnDef.header,
-													header.getContext()
-											  )}
-									</th>
-								);
-							})}
-						</tr>
-					))}
-				</thead>
-				<tbody>
-					{table.getRowModel().rows.map((row) => {
-						return (
-							<RunsRow key={row.id} row={row} onRowClick={handleRowClick} />
-						);
-					})}
-				</tbody>
-			</table>
+									return (
+										<th
+											key={header.id}
+											className={cn(
+												'py-2 px-1 text-[0.6875rem] font-semibold leading-[0.875rem] text-left bg-white sticky top-0 z-10',
+												headerClassName
+											)}
+										>
+											{header.isPlaceholder
+												? null
+												: flexRender(
+														header.column.columnDef.header,
+														header.getContext()
+												  )}
+										</th>
+									);
+								})}
+							</tr>
+						))}
+					</thead>
+					<tbody>
+						{table.getRowModel().rows.map((row) => {
+							return (
+								<RunsRow key={row.id} row={row} onRowClick={handleRowClick} />
+							);
+						})}
+					</tbody>
+				</table>
+			</div>
 			{pageCount ? (
 				<div className="flex justify-center">
 					<Pagination

--- a/libs/bublik/features/runs/src/lib/runs-table/runs-table.container.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-table/runs-table.container.tsx
@@ -1,6 +1,16 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { useGetRunsTablePageQuery } from '@/services/bublik-api';
+import { useCallback } from 'react';
+import { OnChangeFn } from '@tanstack/react-table';
+import { useDispatch } from 'react-redux';
+import { useSearchParams } from 'react-router-dom';
+
+import {
+	BUBLIK_TAG,
+	bublikAPI,
+	useGetRunsTablePageQuery
+} from '@/services/bublik-api';
+import { useUserPreferences } from '@/bublik/features/user-preferences';
 
 import {
 	useRunsGlobalFilter,
@@ -14,12 +24,43 @@ import {
 	RunsTableError,
 	RunsTableEmpty
 } from './runs-table.component';
+import { applyRunDataToSearchParams } from '../runs-form/runs-form.utils';
 
 export const RunsTableContainer = () => {
+	const dispatch = useDispatch();
+	const [searchParams, setSearchParams] = useSearchParams();
+	const { userPreferences } = useUserPreferences();
 	const { pagination, handlePaginationChange } = useRunsPagination();
 	const { localGlobalFilter, handleGlobalFilterChange } = useRunsGlobalFilter();
 	const { rowSelection, addSelection, removeSelection, compareIds } =
 		useRunsSelection();
+	const autoApplyBadgeFilters = userPreferences.runs.autoApplyBadgeFilters;
+	const handleTableGlobalFilterChange: OnChangeFn<string[]> = useCallback(
+		(updater) => {
+			const nextGlobalFilter =
+				typeof updater === 'function' ? updater(localGlobalFilter) : updater;
+
+			handleGlobalFilterChange(nextGlobalFilter);
+
+			if (!autoApplyBadgeFilters) return;
+
+			setSearchParams(
+				applyRunDataToSearchParams(searchParams, nextGlobalFilter),
+				{
+					replace: true
+				}
+			);
+			dispatch(bublikAPI.util.invalidateTags([BUBLIK_TAG.SessionList]));
+		},
+		[
+			autoApplyBadgeFilters,
+			dispatch,
+			handleGlobalFilterChange,
+			localGlobalFilter,
+			searchParams,
+			setSearchParams
+		]
+	);
 
 	const { query } = useRunsQuery();
 	const { data, isFetching, isLoading, error } = useGetRunsTablePageQuery(
@@ -45,7 +86,7 @@ export const RunsTableContainer = () => {
 				onPaginationChange={handlePaginationChange}
 				pageCount={data.pagination.count}
 				globalFilter={localGlobalFilter}
-				onGlobalFilterChange={handleGlobalFilterChange}
+				onGlobalFilterChange={handleTableGlobalFilterChange}
 				rowSelection={rowSelection}
 				addSelection={addSelection}
 				removeSelection={removeSelection}

--- a/libs/bublik/features/settings/src/contents/preferences-settings.tsx
+++ b/libs/bublik/features/settings/src/contents/preferences-settings.tsx
@@ -1,6 +1,9 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
 import {
 	HistoryPreferencesForm,
-	LogPreferencesForm
+	LogPreferencesForm,
+	RunsPreferencesForm
 } from '@/bublik/features/user-preferences';
 import { SettingsPane } from '../components/settings-pane';
 import { SettingsSection } from '../components/settings-section';
@@ -22,6 +25,12 @@ export function PreferencesSettingsContent() {
 				description="Configure log display preferences"
 			>
 				<LogPreferencesForm />
+			</SettingsSection>
+			<SettingsSection
+				title="Runs"
+				description="Configure runs page filtering behavior"
+			>
+				<RunsPreferencesForm />
 			</SettingsSection>
 		</SettingsPane>
 	);

--- a/libs/bublik/features/user-preferences/src/lib/user-preferences-form/index.ts
+++ b/libs/bublik/features/user-preferences/src/lib/user-preferences-form/index.ts
@@ -3,3 +3,4 @@
 export * from './user-preferences.hooks';
 export * from './history-preferences-form.component';
 export * from './log-preferences-form.component';
+export * from './runs-preferences-form.component';

--- a/libs/bublik/features/user-preferences/src/lib/user-preferences-form/runs-preferences-form.component.tsx
+++ b/libs/bublik/features/user-preferences/src/lib/user-preferences-form/runs-preferences-form.component.tsx
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Controller, useForm } from 'react-hook-form';
+
+import { Checkbox } from '@/shared/tailwind-ui';
+
+import { useUserPreferences } from './user-preferences.hooks';
+import { UserPreferencesSchema } from './user-preference.types';
+
+function RunsPreferencesForm() {
+	const { userPreferences, setUserPreferences } = useUserPreferences();
+	const { control } = useForm({
+		defaultValues: userPreferences,
+		resolver: zodResolver(UserPreferencesSchema)
+	});
+
+	return (
+		<div className="max-w-md">
+			<Controller
+				name="runs.autoApplyBadgeFilters"
+				control={control}
+				render={({ field }) => (
+					<div>
+						<div className="flex items-center">
+							<Checkbox
+								id="runs-auto-apply-badge-filters"
+								checked={field.value}
+								onCheckedChange={(checked) => {
+									field.onChange(checked);
+									setUserPreferences({
+										...userPreferences,
+										runs: {
+											...userPreferences.runs,
+											autoApplyBadgeFilters: checked === true
+										}
+									});
+								}}
+							/>
+							<label
+								htmlFor="runs-auto-apply-badge-filters"
+								className="pl-2 text-sm font-normal"
+							>
+								Apply badge filters immediately
+							</label>
+						</div>
+						<p className="text-xs text-text-menu ml-8">
+							Sync runs table badge clicks to fetched filters right away
+						</p>
+					</div>
+				)}
+			></Controller>
+		</div>
+	);
+}
+
+export { RunsPreferencesForm };

--- a/libs/bublik/features/user-preferences/src/lib/user-preferences-form/user-preference.types.ts
+++ b/libs/bublik/features/user-preferences/src/lib/user-preferences-form/user-preference.types.ts
@@ -13,15 +13,20 @@ export const UserPreferencesSchema = z
 			.default({ defaultMode: 'linear' }),
 		log: z
 			.object({ preferLegacyLog: z.boolean().default(false) })
-			.default({ preferLegacyLog: false })
+			.default({ preferLegacyLog: false }),
+		runs: z
+			.object({ autoApplyBadgeFilters: z.boolean().default(true) })
+			.default({ autoApplyBadgeFilters: true })
 	})
 	.default({
 		history: { defaultMode: 'linear' },
-		log: { preferLegacyLog: false }
+		log: { preferLegacyLog: false },
+		runs: { autoApplyBadgeFilters: true }
 	})
 	.catch({
 		history: { defaultMode: 'linear' },
-		log: { preferLegacyLog: false }
+		log: { preferLegacyLog: false },
+		runs: { autoApplyBadgeFilters: true }
 	});
 
 export const USER_PREFERENCES_DEFAULTS = UserPreferencesSchema.parse({});

--- a/libs/bublik/features/user-preferences/src/lib/user-preferences-form/user-preferences.hooks.ts
+++ b/libs/bublik/features/user-preferences/src/lib/user-preferences-form/user-preferences.hooks.ts
@@ -5,16 +5,33 @@ import { useLocalStorage } from '@/shared/hooks';
 
 import {
 	USER_PREFERENCES_DEFAULTS,
+	UserPreferencesSchema,
 	UserPreferences
 } from './user-preference.types';
 
 export function useUserPreferences() {
 	const USER_PREFERENCES_KEY = 'user-preferences';
-	const [userPreferences, setUserPreferences] =
+	const [storedUserPreferences, setStoredUserPreferences] =
 		useLocalStorage<UserPreferences>(
 			USER_PREFERENCES_KEY,
 			USER_PREFERENCES_DEFAULTS
 		);
+	const userPreferences = UserPreferencesSchema.parse(storedUserPreferences);
+
+	const setUserPreferences = (
+		value: UserPreferences | ((val: UserPreferences) => UserPreferences)
+	) => {
+		if (typeof value === 'function') {
+			setStoredUserPreferences((currentValue) =>
+				UserPreferencesSchema.parse(
+					value(UserPreferencesSchema.parse(currentValue))
+				)
+			);
+			return;
+		}
+
+		setStoredUserPreferences(UserPreferencesSchema.parse(value));
+	};
 
 	return { userPreferences, setUserPreferences };
 }

--- a/libs/shared/hooks/src/lib/useLocalStorage.ts
+++ b/libs/shared/hooks/src/lib/useLocalStorage.ts
@@ -1,28 +1,109 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { useState } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
+
+const LOCAL_STORAGE_CHANGE_EVENT = 'local-storage-change';
+const localStorageSnapshotCache = new Map<
+	string,
+	{ rawValue: string | null; parsedValue: unknown }
+>();
+
+const readLocalStorageValue = <T>(key: string, initialValue: T): T => {
+	try {
+		const rawValue = window.localStorage.getItem(key);
+		const cachedValue = localStorageSnapshotCache.get(key);
+
+		if (cachedValue && cachedValue.rawValue === rawValue) {
+			return cachedValue.parsedValue as T;
+		}
+
+		const parsedValue = rawValue ? JSON.parse(rawValue) : initialValue;
+
+		localStorageSnapshotCache.set(key, { rawValue, parsedValue });
+
+		return parsedValue;
+	} catch (error) {
+		console.log(error);
+
+		localStorageSnapshotCache.set(key, {
+			rawValue: null,
+			parsedValue: initialValue
+		});
+
+		return initialValue;
+	}
+};
+
+const dispatchLocalStorageChange = (key: string) => {
+	window.dispatchEvent(
+		new CustomEvent(LOCAL_STORAGE_CHANGE_EVENT, {
+			detail: { key }
+		})
+	);
+};
+
+const isStorageEventForKey = (event: Event, key: string) =>
+	event instanceof StorageEvent && (!event.key || event.key === key);
+
+const isLocalStorageChangeEventForKey = (event: Event, key: string) =>
+	event instanceof CustomEvent &&
+	event.detail &&
+	typeof event.detail === 'object' &&
+	'key' in event.detail &&
+	event.detail.key === key;
 
 export const useLocalStorage = <T>(key: string, initialValue: T) => {
-	const [storedValue, setStoredValue] = useState<T>(() => {
-		try {
-			const item = window.localStorage.getItem(key);
+	const subscribe = useCallback(
+		(onStoreChange: () => void) => {
+			const handleStorageChange = (event: Event) => {
+				if (
+					!isStorageEventForKey(event, key) &&
+					!isLocalStorageChangeEventForKey(event, key)
+				) {
+					return;
+				}
 
-			return item ? JSON.parse(item) : initialValue;
-		} catch (error) {
-			console.log(error);
+				onStoreChange();
+			};
 
-			return initialValue;
-		}
-	});
+			window.addEventListener('storage', handleStorageChange);
+			window.addEventListener(LOCAL_STORAGE_CHANGE_EVENT, handleStorageChange);
+
+			return () => {
+				window.removeEventListener('storage', handleStorageChange);
+				window.removeEventListener(
+					LOCAL_STORAGE_CHANGE_EVENT,
+					handleStorageChange
+				);
+			};
+		},
+		[key]
+	);
+
+	const getSnapshot = useCallback(
+		() => readLocalStorageValue(key, initialValue),
+		[initialValue, key]
+	);
+	const storedValue = useSyncExternalStore(
+		subscribe,
+		getSnapshot,
+		() => initialValue
+	);
 
 	const setValue = (value: T | ((val: T) => T)) => {
 		try {
 			const valueToStore =
-				value instanceof Function ? value(storedValue) : value;
+				value instanceof Function
+					? value(readLocalStorageValue(key, initialValue))
+					: value;
+			const rawValue = JSON.stringify(valueToStore);
 
-			setStoredValue(valueToStore);
-
-			localStorage.setItem(key, JSON.stringify(valueToStore));
+			localStorage.setItem(key, rawValue);
+			localStorageSnapshotCache.set(key, {
+				rawValue,
+				parsedValue: valueToStore
+			});
+			dispatchLocalStorageChange(key);
 		} catch (error) {
 			console.log(error);
 		}

--- a/libs/shared/tailwind-ui/src/lib/badge-box/badge-box.tsx
+++ b/libs/shared/tailwind-ui/src/lib/badge-box/badge-box.tsx
@@ -1,133 +1,88 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
 import {
+	KeyboardEvent,
+	MouseEvent,
 	ReactNode,
-	useCallback,
-	useEffect,
 	useMemo,
 	useRef,
 	useState
 } from 'react';
-import { Command as CommandPrimitive } from 'cmdk';
 import { CheckIcon } from '@radix-ui/react-icons';
 
-import { useMeasure } from '@/shared/hooks';
-import { throttle } from '@/shared/utils';
-
-import { cn } from '../utils';
 import { Badge } from '../badge';
-import { Command, CommandGroup, CommandItem, CommandList } from '../command';
-import { Popover, PopoverContent, PopoverTrigger } from '../popover';
 import { ButtonTw } from '../button';
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+	CommandSeparator
+} from '../command';
 import { Icon } from '../icon';
+import { Popover, PopoverContent, PopoverTrigger } from '../popover';
+import { Separator } from '../separator';
+import { cn, cva } from '../utils';
 
 export type BoxValue = {
 	label: string;
 	value: string;
 	isSelected?: boolean;
 	className?: string;
+	groupLabel?: string;
 };
 
-export interface UserTagsComboboxParams<T extends BoxValue> {
-	values: T[];
-	onChange?: (boxes: T[]) => void;
-}
+const normalizeInputValue = (value: string) =>
+	value.trim().replace(/\s+/g, ' ');
 
-const useTagsCombobox = <T extends BoxValue>(
-	params: UserTagsComboboxParams<T>
-) => {
-	const { values, onChange } = params;
-	const [inputValue, setInputValue] = useState<string>('');
+const normalizeForMatch = (value: string) =>
+	normalizeInputValue(value).toLowerCase();
 
-	const create = (value: string) => {
-		const newFramework = {
-			value,
-			label: value,
-			isSelected: true
-		} as T;
-
-		const nextState = [...values, newFramework];
-		setInputValue('');
-		onChange?.(nextState);
-	};
-
-	const toggle = (passedBox: BoxValue) => {
-		const current = values.find((b) => b.value === passedBox.value);
-
-		if (!current) return;
-
-		const nextState = !current.isSelected
-			? check(passedBox)
-			: uncheck(passedBox);
-
-		onChange?.(nextState);
-	};
-
-	const check = (value: BoxValue) => {
-		return values.map((box) => {
-			if (box.value === value.value) box.isSelected = true;
-
-			return box;
-		});
-	};
-
-	const uncheck = (toRemove: BoxValue) => {
-		return values.map((box) => {
-			if (box.value === toRemove.value) {
-				box.isSelected = false;
-			}
-
-			return box;
-		});
-	};
-
-	const remove = (toRemove: BoxValue) => {
-		onChange?.(uncheck(toRemove));
-	};
-
-	const handleBackspace = useCallback(
-		(e: KeyboardEvent) => {
-			if (e.key === 'Backspace' && inputValue === '') {
-				const filtered = values.filter((b) => b.isSelected);
-
-				const lastValue = filtered.at(-1);
-
-				if (!lastValue) return;
-
-				setInputValue(lastValue.label);
-
-				const nextState = values.map((box) => {
-					if (box.value === lastValue.value) box.isSelected = false;
-
-					return box;
-				});
-
-				onChange?.(nextState);
-			}
-		},
-		[inputValue, onChange, values]
+const updateSelection = <T extends BoxValue>(
+	values: T[],
+	targetValue: string,
+	isSelected: boolean
+): T[] =>
+	values.map((box) =>
+		box.value === targetValue ? ({ ...box, isSelected } as T) : box
 	);
 
-	const selectedValues = useMemo(
-		() => values.filter((box) => box.isSelected),
-		[values]
+const clearSelection = <T extends BoxValue>(values: T[]): T[] =>
+	values.map((box) =>
+		box.isSelected ? ({ ...box, isSelected: false } as T) : box
 	);
 
-	useEffect(() => {
-		document.addEventListener('keydown', handleBackspace);
-		return () => document.removeEventListener('keydown', handleBackspace);
-	}, [handleBackspace]);
+const triggerLabelStyles = cva({
+	variants: {
+		size: {
+			xss: 'text-xs font-medium',
+			'xs/2': 'text-xs font-medium',
+			md: 'text-[0.875rem] font-medium leading-[1.5rem]'
+		}
+	}
+});
 
-	return {
-		create,
-		uncheck,
-		toggle,
-		setInputValue,
-		remove,
-		inputValue,
-		selectedValues
-	};
-};
+const triggerSummaryStyles = cva({
+	variants: {
+		size: {
+			xss: 'text-xs font-normal',
+			'xs/2': 'text-xs font-normal',
+			md: 'text-[0.875rem] font-normal leading-[1.5rem]'
+		}
+	}
+});
+
+const triggerBadgeStyles = cva({
+	variants: {
+		size: {
+			xss: 'text-xs leading-4',
+			'xs/2': 'text-xs leading-4',
+			md: 'text-xs leading-4'
+		}
+	}
+});
 
 export interface FancyBoxProps {
 	/** Label of the component */
@@ -144,185 +99,341 @@ export interface FancyBoxProps {
 	startIcon?: ReactNode;
 	/** End icon for trigger button */
 	endIcon?: ReactNode;
+	/** Button size */
+	size?: 'xss' | 'xs/2' | 'md';
+	/** Group label for newly created values */
+	createdGroupLabel?: string;
+	/** Order for rendering grouped sections */
+	groupOrder?: readonly string[];
 }
 
 /**
- * Tags box input is a button with combobox popover for inputting tags
- * Supports autocomplete and creating tags
+ * Tags box input is a button with combobox popover for selecting and creating tags.
  */
-export const TagsBoxInput = (props: FancyBoxProps) => {
-	const {
-		label,
-		endIcon,
-		startIcon,
-		placeholder,
-		valueLabel,
-		values,
-		onChange
-	} = props;
-
+export const TagsBoxInput = ({
+	label,
+	endIcon,
+	startIcon,
+	placeholder,
+	valueLabel,
+	values,
+	onChange,
+	size = 'md',
+	createdGroupLabel,
+	groupOrder
+}: FancyBoxProps) => {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [openCombobox, setOpenCombobox] = useState(false);
+	const [inputValue, setInputValue] = useState('');
 
-	const handleChange = (boxes: BoxValue[]) => {
-		onChange?.(boxes);
+	const selectedValues = useMemo(
+		() => values.filter((box) => box.isSelected),
+		[values]
+	);
+	const groupedValues = useMemo(() => {
+		const groups = values.reduce<Map<string | undefined, BoxValue[]>>(
+			(acc, box) => {
+				const groupLabel = box.groupLabel;
+				const current = acc.get(groupLabel) || [];
+
+				acc.set(groupLabel, [...current, box]);
+				return acc;
+			},
+			new Map()
+		);
+
+		return Array.from(groups.entries()).sort(([left], [right]) => {
+			if (groupOrder?.length) {
+				const leftIndex =
+					left === undefined ? groupOrder.length : groupOrder.indexOf(left);
+				const rightIndex =
+					right === undefined ? groupOrder.length : groupOrder.indexOf(right);
+				const normalizedLeft =
+					leftIndex === -1 ? groupOrder.length + 1 : leftIndex;
+				const normalizedRight =
+					rightIndex === -1 ? groupOrder.length + 1 : rightIndex;
+
+				return normalizedLeft - normalizedRight;
+			}
+
+			if (left === undefined) return 1;
+			if (right === undefined) return -1;
+			return 0;
+		});
+	}, [groupOrder, values]);
+	const normalizedInputValue = normalizeInputValue(inputValue);
+	const normalizedValueLabel = (valueLabel || label).toLowerCase();
+	const hasNormalizedMatch = values.some(
+		(box) =>
+			normalizeForMatch(box.value) ===
+				normalizeForMatch(normalizedInputValue) ||
+			normalizeForMatch(box.label) === normalizeForMatch(normalizedInputValue)
+	);
+	const canCreate = normalizedInputValue.length > 0 && !hasNormalizedMatch;
+
+	const focusInput = () => queueMicrotask(() => inputRef.current?.focus());
+
+	const handleOpenChange = (isOpen: boolean) => {
+		setOpenCombobox(isOpen);
+		if (isOpen) focusInput();
 	};
 
-	const { create, toggle, inputValue, setInputValue, selectedValues, remove } =
-		useTagsCombobox({ values, onChange: handleChange });
-
-	const handleComboboxOpenChange = (value: boolean) => {
-		setTimeout(() => {
-			if (value) inputRef.current?.focus();
-		}, 0);
-		setOpenCombobox(value);
+	const handleChange = (nextValues: BoxValue[]) => {
+		onChange?.(nextValues);
 	};
 
-	const groupRef = useRef<HTMLDivElement>(null);
-	const [isScrolled, setIsScrolled] = useState(false);
-	const handleScroll = throttle(() => {
-		if ((groupRef.current?.scrollTop || 0) > 0) {
-			setIsScrolled(true);
-		} else {
-			setIsScrolled(false);
+	const handleToggle = (box: BoxValue) => {
+		handleChange(updateSelection(values, box.value, !box.isSelected));
+		focusInput();
+	};
+
+	const handleRemove = (box: BoxValue) => {
+		handleChange(updateSelection(values, box.value, false));
+		focusInput();
+	};
+
+	const handleCreate = () => {
+		if (!canCreate) return;
+
+		handleChange([
+			...values,
+			{
+				value: normalizedInputValue,
+				label: normalizedInputValue,
+				isSelected: true,
+				groupLabel: createdGroupLabel || valueLabel || label
+			}
+		]);
+		setInputValue('');
+		focusInput();
+	};
+
+	const handleClearSelection = () => {
+		handleChange(clearSelection(values));
+		focusInput();
+	};
+
+	const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+		if (event.key === 'Enter' && canCreate) {
+			event.preventDefault();
+			handleCreate();
+			return;
 		}
-	}, 200);
 
-	const [tagsRef, { height: tagsHeight }] = useMeasure<HTMLDivElement>();
+		if (event.key !== 'Backspace' || inputValue.length > 0) return;
+
+		const lastValue = selectedValues.at(-1);
+
+		if (!lastValue) return;
+
+		event.preventDefault();
+		setInputValue(lastValue.label);
+		handleRemove(lastValue);
+	};
+
+	const keepPopoverOpen = (event: MouseEvent<HTMLButtonElement>) => {
+		event.preventDefault();
+		event.stopPropagation();
+	};
 
 	return (
-		<Popover open={openCombobox} onOpenChange={handleComboboxOpenChange} modal>
+		<Popover open={openCombobox} onOpenChange={handleOpenChange}>
 			<PopoverTrigger asChild>
 				<ButtonTw
 					variant="outline-secondary"
-					size="md"
-					state={openCombobox && 'active'}
+					size={size}
+					state={openCombobox ? 'active' : 'default'}
+					className={cn(
+						'max-w-[26rem] justify-start',
+						size !== 'xss' && 'gap-0'
+					)}
 					// eslint-disable-next-line jsx-a11y/role-has-required-aria-props
 					role="combobox"
 					aria-expanded={openCombobox}
 				>
-					{startIcon}
-					<span className="truncate text-[0.875rem] font-medium leading-[1.5rem]">
-						{selectedValues.length === 0 && label}
-						{selectedValues.length >= 1 &&
-							`${selectedValues.length} ${label} selected`}
+					{startIcon ? (
+						<span className="mr-2 shrink-0 text-text-menu">{startIcon}</span>
+					) : null}
+					<span className={cn('truncate', triggerLabelStyles({ size }))}>
+						{label}
 					</span>
-					{endIcon}
+					{selectedValues.length > 0 ? (
+						<>
+							<Separator orientation="vertical" className="mx-2 h-4 shrink-0" />
+							<div className="flex min-w-0 items-center gap-1 overflow-hidden">
+								{selectedValues.length > 2 ? (
+									<span
+										className={cn('truncate', triggerSummaryStyles({ size }))}
+									>
+										{selectedValues.length} selected
+									</span>
+								) : (
+									selectedValues.map((box) => (
+										<Badge
+											key={box.value}
+											className={cn(
+												'max-w-[8rem] truncate bg-primary-wash px-1.5 py-0',
+												triggerBadgeStyles({ size }),
+												box.className
+											)}
+										>
+											<span className="truncate">{box.label}</span>
+										</Badge>
+									))
+								)}
+							</div>
+						</>
+					) : null}
+					<span className="ml-2 shrink-0 text-text-menu">
+						{endIcon || <Icon name="ArrowShortSmall" />}
+					</span>
 				</ButtonTw>
 			</PopoverTrigger>
 			<PopoverContent
-				className="p-0 bg-white rounded-lg shadow-popover min-w-[380px] max-w-[380px] max-h-[var(--radix-popper-available-height)]"
-				sideOffset={8}
+				align="start"
+				sideOffset={4}
+				onOpenAutoFocus={(event) => {
+					event.preventDefault();
+					inputRef.current?.focus();
+				}}
+				className="w-[24rem] max-w-[calc(100vw-2rem)] rounded-lg bg-white p-0 shadow-popover"
 			>
 				<Command loop>
-					<div
-						className="relative flex flex-wrap w-full gap-1 px-2 py-3 overflow-hidden transition-shadow bg-primary-wash"
-						onClick={() => inputRef.current?.focus()}
-						ref={tagsRef}
-					>
-						{selectedValues.map(({ label, value, className }) => (
-							<Badge key={value} className={cn('bg-badge-10', className)}>
-								{label}
-								<button onClick={() => remove({ label, value })} type="button">
-									<Icon name="CrossSimple" size={16} className="ml-1" />
-								</button>
-							</Badge>
-						))}
-						<CommandPrimitive.Input
-							className={cn(
-								'text-sm border-none outline:none focus:ring-0 placeholder:text-text-menu disabled:cursor-not-allowed disabled:opacity-50 p-0 bg-transparent px-2 py-0.5 w-full'
-							)}
-							ref={inputRef}
-							placeholder={placeholder}
-							value={inputValue}
-							onValueChange={setInputValue}
-						/>
-					</div>
-					<CommandList>
-						<CommandGroup
-							className={cn(
-								'overflow-auto p-0',
-								'[&_[cmdk-group-heading]]:min-h-[38px] [&_[cmdk-group-heading]]:grid [&_[cmdk-group-heading]]:items-center [&_[cmdk-group-heading]]:border-b',
-								'[&_[cmdk-group-heading]]:sticky [&_[cmdk-group-heading]]:top-0 [&_[cmdk-group-heading]]:bg-white [&_[cmdk-group-heading]]:z-10',
-								isScrolled &&
-									'[&_[cmdk-group-heading]]:shadow-[0_0_8px_0_rgb(0_0_0/10%)]'
-							)}
-							heading="Select an option or create one"
-							style={{
-								maxHeight: `calc(var(--radix-popover-content-available-height) - ${Math.round(
-									tagsHeight + 24
-								)}px)`
-							}}
-							onScroll={handleScroll}
-							ref={groupRef}
-						>
-							{values.map((box) => {
-								return (
-									<CommandItem
-										key={box.value}
-										value={box.value}
-										onSelect={() => toggle(box)}
-										className="m-1"
-									>
-										<div
-											className={cn(
-												'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-text-menu',
-												box.isSelected
-													? 'bg-primary text-white border-primary'
-													: 'opacity-50 [&_svg]:invisible'
-											)}
-										>
-											<CheckIcon className={cn('h-4 w-4')} />
-										</div>
-										<Badge className={cn('bg-badge-10', box.className)}>
-											{box.label}
-										</Badge>
-									</CommandItem>
-								);
-							})}
-							<CommandItemCreate
-								inputValue={inputValue}
-								values={values}
-								onSelect={() => create(inputValue)}
-								valueLabel={valueLabel || label}
+					<CommandInput
+						ref={inputRef}
+						placeholder={placeholder || label}
+						className="text-xs"
+						value={inputValue}
+						onValueChange={setInputValue}
+						onKeyDown={handleInputKeyDown}
+						startIcon={
+							<Icon
+								name="MagnifyingGlass"
+								size={18}
+								className="shrink-0 opacity-50"
 							/>
-						</CommandGroup>
+						}
+						endIcon={
+							normalizedInputValue ? (
+								<button
+									type="button"
+									className="rounded p-1 text-text-menu hover:bg-primary-wash hover:text-primary"
+									onMouseDown={keepPopoverOpen}
+									onClick={() => {
+										setInputValue('');
+										focusInput();
+									}}
+									aria-label="Clear search"
+								>
+									<Icon name="Cross" size={12} />
+								</button>
+							) : null
+						}
+					/>
+					{selectedValues.length > 0 ? (
+						<div className="flex flex-wrap gap-1 border-b border-border-primary bg-primary-wash px-3 py-2">
+							{selectedValues.map((box) => (
+								<Badge
+									key={box.value}
+									className={cn(
+										'flex items-center gap-1 bg-badge-10 px-1.5 py-0 text-xs leading-4',
+										box.className
+									)}
+								>
+									<span>{box.label}</span>
+									<button
+										type="button"
+										className="rounded text-text-menu hover:text-primary"
+										onMouseDown={keepPopoverOpen}
+										onClick={() => handleRemove(box)}
+										aria-label={`Remove ${box.label}`}
+									>
+										<Icon name="CrossSimple" size={14} />
+									</button>
+								</Badge>
+							))}
+						</div>
+					) : null}
+					<CommandList className="max-h-96 overflow-y-auto">
+						<CommandEmpty className="py-4 text-center text-xs">
+							No results found.
+						</CommandEmpty>
+						{groupedValues.map(([groupLabel, groupValues], index) => (
+							<CommandGroup
+								key={groupLabel || `group-${index}`}
+								heading={groupLabel}
+								className={cn(
+									'pt-0 [&_[cmdk-group-heading]]:-mx-1 [&_[cmdk-group-heading]]:mb-1 [&_[cmdk-group-heading]]:block [&_[cmdk-group-heading]]:border-y [&_[cmdk-group-heading]]:border-border-primary [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:py-2',
+									index === 0 && '[&_[cmdk-group-heading]]:border-t-0'
+								)}
+							>
+								{groupValues.map((box) => {
+									const isSelected = Boolean(box.isSelected);
+
+									return (
+										<CommandItem
+											key={box.value}
+											value={`${box.label} ${box.value} ${groupLabel}`.trim()}
+											onSelect={() => handleToggle(box)}
+											className="gap-2 text-xs data-[selected=true]:text-text-primary"
+										>
+											<div
+												className={cn(
+													'mr-0 flex h-4 w-4 items-center justify-center rounded-sm border border-text-menu',
+													isSelected
+														? 'border-primary bg-primary text-white'
+														: 'opacity-50 [&_svg]:invisible'
+												)}
+											>
+												<CheckIcon className="h-4 w-4" />
+											</div>
+											<Badge
+												className={cn(
+													'max-w-[18rem] truncate bg-badge-10 text-xs',
+													box.className
+												)}
+											>
+												{box.label}
+											</Badge>
+										</CommandItem>
+									);
+								})}
+							</CommandGroup>
+						))}
+						{canCreate ? (
+							<CommandGroup
+								heading="Create"
+								className="pt-0 [&_[cmdk-group-heading]]:-mx-1 [&_[cmdk-group-heading]]:mb-1 [&_[cmdk-group-heading]]:block [&_[cmdk-group-heading]]:border-y [&_[cmdk-group-heading]]:border-border-primary [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:py-2"
+							>
+								<CommandItem
+									value={inputValue}
+									onSelect={handleCreate}
+									className="min-h-[38px] gap-2 text-xs text-text-secondary data-[selected=true]:text-text-secondary"
+								>
+									<div className="mr-0 flex h-4 w-4 items-center justify-center rounded-sm border border-border-primary text-primary">
+										<Icon name="AddSymbol" size={10} />
+									</div>
+									Create new {normalizedValueLabel} &quot;{normalizedInputValue}
+									&quot;
+								</CommandItem>
+							</CommandGroup>
+						) : null}
 					</CommandList>
+					{selectedValues.length > 0 ? (
+						<>
+							<CommandSeparator />
+							<CommandGroup>
+								<CommandItem
+									onSelect={handleClearSelection}
+									className="justify-center text-center text-xs"
+								>
+									Clear selection
+								</CommandItem>
+							</CommandGroup>
+						</>
+					) : null}
 				</Command>
 			</PopoverContent>
 		</Popover>
-	);
-};
-
-const CommandItemCreate = ({
-	inputValue,
-	values,
-	onSelect,
-	valueLabel
-}: {
-	inputValue: string;
-	values: BoxValue[];
-	onSelect: () => void;
-	valueLabel: string;
-}) => {
-	const hasNoFramework = !values
-		.map(({ value }) => value)
-		.includes(`${inputValue.toLowerCase()}`);
-
-	const render = inputValue !== '' && hasNoFramework;
-
-	if (!render) return null;
-
-	// BUG: whenever a space is appended, the Create-Button will not be shown.
-	return (
-		<CommandItem
-			key={`${inputValue}`}
-			value={`${inputValue}`}
-			className="text-xs text-muted-foreground m-1 min-h-[38px]"
-			onSelect={onSelect}
-		>
-			<div className={cn('mr-2 h-4 w-4')} />
-			Create new {valueLabel.toLowerCase()} &quot;{inputValue}&quot;
-		</CommandItem>
 	);
 };


### PR DESCRIPTION
## Summary
Improve the runs-page filtering flow by making badge filters easier to browse, showing when form changes are not yet applied, and adding a user preference to auto-apply badge clicks from the runs table.

## What Changed
- Reworked `TagsBoxInput` to support grouped options, inline selected-badge summaries, search/clear flows, normalized value creation, and clear-all behavior.
- Grouped run-data filters into `Important`, `Metadata`, and `Tags`, while deduplicating and normalizing selected values before syncing them to search params.
- Added reusable runs-filter snapshot helpers so the form can compare in-progress values with the currently applied URL filters.
- Updated the runs form submit button to visually highlight only when the form differs from the applied filters.
- Added a new `runs.autoApplyBadgeFilters` user preference, exposed under `Settings -> Preferences -> Runs`.