### PR TITLE
Send current URL information to parent window

### DIFF
--- a/apps/bublik/src/app/router.tsx
+++ b/apps/bublik/src/app/router.tsx
@@ -191,6 +191,42 @@ function AnalyticsRouteTracker() {
 	return null;
 }
 
+/**
+ * When Bublik runs inside a cross-origin iframe (e.g. embedded in other webapp),
+ * the parent frame cannot read URL due to Same-Origin Policy.
+ * This component fires a `postMessage` to the parent on every route change
+ * so the parent can track the currently focused test without any DOM hacks.
+ *
+ * Message format:
+ * { "type": "bublik:navigation", "path": "/log/1", "search": "?focusId=336&mode=...", "focusId": 336 }
+ * `focusId` is `null` when the run-level log (no specific test) is shown.
+ */
+function IframeNavigationReporter() {
+	const location = useLocation();
+
+	useEffect(() => {
+		// Skip when not embedded — avoids unnecessary postMessage noise.
+		if (window.parent === window) return;
+
+		const params = new URLSearchParams(location.search);
+		const raw = params.get('focusId');
+		const parsed = raw !== null ? parseInt(raw, 10) : null;
+		const focusId = parsed !== null && !Number.isNaN(parsed) ? parsed : null;
+
+		window.parent.postMessage(
+			{
+				type: 'bublik:navigation',
+				path: location.pathname,
+				search: location.search,
+				focusId
+			},
+			'*'
+		);
+	}, [location.pathname, location.search]);
+
+	return null;
+}
+
 const router = createBrowserRouter(
 	[
 		{
@@ -201,6 +237,7 @@ const router = createBrowserRouter(
 				>
 					<BublikCommand />
 					<AnalyticsRouteTracker />
+					<IframeNavigationReporter />
 					<Outlet />
 				</QueryParamProvider>
 			),


### PR DESCRIPTION
If bublik is integrated as an iframe, we need some mechanism to report the URL information back. Message is the easiest way.

I've tested it in my project and it works, message is sent as intended.