### PR TITLE
Update run import UI for task-based session import API

### DIFF
--- a/libs/bublik/features/run-import/src/lib/import-events-table/__snapshots__/import-event-table.component.spec.tsx.snap
+++ b/libs/bublik/features/run-import/src/lib/import-events-table/__snapshots__/import-event-table.component.spec.tsx.snap
@@ -171,7 +171,7 @@ exports[`ImportEventTableComponent > should render successfully 1`] = `
     >
       <div
         class="grid"
-        style="grid-template-columns: 24px min-content 0.1fr 0.1fr 0.1fr 1fr 1fr min-content;"
+        style="grid-template-columns: 24px min-content min-content max-content 96px max-content max-content minmax(280px, 2fr) minmax(220px, 1.35fr) 72px;"
       >
         <div
           class="tracking-wider sticky top-0 mb-1 text-left text-[0.6875rem] font-semibold leading-[0.875rem] bg-white p-0"
@@ -188,35 +188,41 @@ exports[`ImportEventTableComponent > should render successfully 1`] = `
         <div
           class="tracking-wider sticky top-0 mb-1 px-1 py-2 text-left text-[0.6875rem] font-semibold leading-[0.875rem] bg-white"
         >
-          Date
-        </div>
-        <div
-          class="tracking-wider sticky top-0 mb-1 px-1 py-2 text-left text-[0.6875rem] font-semibold leading-[0.875rem] bg-white"
-        >
           <span
-            class="pl-2"
+            class="pl-2.5"
           >
-            Facility
+            Status
           </span>
         </div>
         <div
           class="tracking-wider sticky top-0 mb-1 px-1 py-2 text-left text-[0.6875rem] font-semibold leading-[0.875rem] bg-white"
         >
-          <span
-            class="pl-2"
-          >
-            Severity
-          </span>
+          Started At
         </div>
         <div
           class="tracking-wider sticky top-0 mb-1 px-1 py-2 text-left text-[0.6875rem] font-semibold leading-[0.875rem] bg-white"
         >
-          Message
+          Runtime
+        </div>
+        <div
+          class="tracking-wider sticky top-0 mb-1 px-1 py-2 text-left text-[0.6875rem] font-semibold leading-[0.875rem] bg-white"
+        >
+          Job Id
+        </div>
+        <div
+          class="tracking-wider sticky top-0 mb-1 px-1 py-2 text-left text-[0.6875rem] font-semibold leading-[0.875rem] bg-white"
+        >
+          Run Id
         </div>
         <div
           class="tracking-wider sticky top-0 mb-1 px-1 py-2 text-left text-[0.6875rem] font-semibold leading-[0.875rem] bg-white"
         >
           URL
+        </div>
+        <div
+          class="tracking-wider sticky top-0 mb-1 px-1 py-2 text-left text-[0.6875rem] font-semibold leading-[0.875rem] bg-white"
+        >
+          Error
         </div>
         <div
           class="tracking-wider sticky top-0 mb-1 px-1 py-2 text-left text-[0.6875rem] font-semibold leading-[0.875rem] bg-white"

--- a/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.columns.tsx
+++ b/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.columns.tsx
@@ -5,31 +5,23 @@ import { createColumnHelper } from '@tanstack/react-table';
 import { z } from 'zod';
 import { RocketIcon } from '@radix-ui/react-icons';
 
-import { Facility, LogEventWithChildren, Severity } from '@/shared/types';
+import { ImportTaskRow } from '@/shared/types';
 import { config } from '@/bublik/config';
 import { LinkWithProject } from '@/bublik/features/projects';
 import { useImportRunsMutation } from '@/services/bublik-api';
-import {
-	Badge,
-	ButtonTw,
-	cn,
-	Icon,
-	toast,
-	Tooltip
-} from '@/shared/tailwind-ui';
-import { formatTimeToDot } from '@/shared/utils';
+import { useCopyToClipboard } from '@/shared/hooks';
+import { ButtonTw, cn, Icon, toast, Tooltip } from '@/shared/tailwind-ui';
+import { parseDetailDate } from '@/shared/utils';
 import { routes } from '@/router';
 
-import { SEVERITY_MAP } from '../utils';
-import { getSeverityBgColor } from './import-event-table-utils';
 import { useImportLog } from './import-log.component';
-import { FacilityBadge } from './import-event-table.component';
+import { StatusBadge } from './import-event-table.component';
 
 export function getBgByStatus(status: string): string {
 	const statusMap: Record<string, string> = {
 		SUCCESS: 'bg-bg-ok',
 		FAILURE: 'bg-bg-error',
-		STARTED: 'bg-bg-running',
+		RUNNING: 'bg-bg-running',
 		RECEIVED: 'bg-gray-400'
 	};
 
@@ -43,14 +35,14 @@ export function getIconByStatus(status: string) {
 	> = {
 		SUCCESS: (props) => <Icon name="InformationCircleCheckmark" {...props} />,
 		FAILURE: (props) => <Icon name="InformationCircleCrossMark" {...props} />,
-		STARTED: (props) => <Icon name="Play" {...props} />,
+		RUNNING: (props) => <Icon name="Play" {...props} />,
 		RECEIVED: (props) => <Icon name="Download" {...props} />
 	};
 
 	return statusMap[status];
 }
 
-const columnHelper = createColumnHelper<LogEventWithChildren>();
+const columnHelper = createColumnHelper<ImportTaskRow>();
 
 interface ActionCellProps {
 	taskId?: string | null;
@@ -90,7 +82,7 @@ function ActionsCell(props: ActionCellProps) {
 				variant="secondary"
 				size="xss"
 				className="justify-start"
-				onClick={toggle(taskId, status === 'STARTED')}
+				onClick={toggle(taskId, status === 'RUNNING')}
 			>
 				<Icon name="Paper" size={20} className="mr-1.5" />
 				<span>Log</span>
@@ -111,6 +103,63 @@ function ActionsCell(props: ActionCellProps) {
 				</a>
 			</ButtonTw>
 		</div>
+	);
+}
+
+function formatRuntime(seconds: number): string {
+	const hrs = Math.floor(seconds / 3600);
+	const mins = Math.floor((seconds % 3600) / 60);
+	const secs = (seconds % 60).toFixed(2);
+
+	const parts = [];
+	if (hrs > 0) parts.push(`${hrs}h`);
+	if (mins > 0) parts.push(`${mins}m`);
+	parts.push(`${secs}s`);
+
+	return parts.join(' ');
+}
+
+interface CopyableValueProps {
+	value?: string | number | null;
+	label: string;
+}
+
+function CopyableValue({ value, label }: CopyableValueProps) {
+	const [, copy] = useCopyToClipboard();
+	const canCopy = value !== null && value !== undefined;
+
+	const handleCopy = () => {
+		if (!canCopy) return;
+
+		copy(String(value)).then((success) => {
+			if (success) {
+				toast.success(`Copied ${label.toLowerCase()} to clipboard`);
+			} else {
+				toast.error(`Failed to copy ${label.toLowerCase()}`);
+			}
+		});
+	};
+
+	return (
+		<span
+			className={cn(
+				'inline-flex items-center gap-1 font-medium',
+				canCopy && 'cursor-pointer hover:text-primary group'
+			)}
+			onClick={(event) => {
+				event.stopPropagation();
+				handleCopy();
+			}}
+		>
+			{value ?? '-'}
+			{canCopy ? (
+				<Icon
+					name="PaperStack"
+					size={14}
+					className="opacity-0 group-hover:opacity-100 transition-opacity text-primary"
+				/>
+			) : null}
+		</span>
 	);
 }
 
@@ -144,68 +193,53 @@ export const columns = [
 		cell: (cell) => (
 			<ActionsCell
 				taskId={cell.getValue()}
-				runId={cell.row.original.run_id}
+				runId={cell.row.original.run_id ?? undefined}
 				status={cell.row.original.status}
 			/>
 		),
 		meta: { width: 'min-content' }
 	}),
-	columnHelper.accessor('timestamp', {
-		header: 'Date',
+	columnHelper.accessor('status', {
+		header: () => <span className="pl-2.5">Status</span>,
+		cell: (cell) => {
+			const status = cell.getValue();
+			return <StatusBadge status={status} />;
+		},
+		meta: { width: 'min-content' }
+	}),
+	columnHelper.accessor('started_at', {
+		header: 'Started At',
 		cell: (cell) => {
 			const date = cell.getValue();
-
 			if (!date) return null;
-
-			return formatTimeToDot(date);
+			return parseDetailDate(date);
 		},
-		meta: { width: '0.1fr' }
+		meta: { width: 'max-content' }
 	}),
-	columnHelper.accessor('facility', {
-		header: () => <span className="pl-2">Facility</span>,
-		cell: (cell) => {
-			const facility = cell.getValue();
-
-			return <FacilityBadge facility={facility} />;
-		},
-		meta: { width: '0.1fr' }
-	}),
-	columnHelper.accessor('severity', {
-		header: () => <span className="pl-2">Severity</span>,
+	columnHelper.accessor('runtime', {
+		header: 'Runtime',
 		cell: (cell) => {
 			const value = cell.getValue();
-
-			if (!value) return null;
-
-			return (
-				<Badge className={getSeverityBgColor(value)}>
-					{SEVERITY_MAP.has(value)
-						? SEVERITY_MAP.get(value)?.toUpperCase()
-						: value.toUpperCase()}
-				</Badge>
-			);
+			if (value == null) return null;
+			return <span>{formatRuntime(value)}</span>;
 		},
-		meta: { width: '0.1fr' }
+		meta: { width: '96px' }
 	}),
-	columnHelper.accessor('error_msg', {
-		header: 'Message',
-		cell: (cell) => {
-			const value = cell.getValue();
-
-			if (!value) return null;
-
-			return <span className="whitespace-pre-wrap font-mono">{value}</span>;
-		},
-		meta: { width: '1fr' }
+	columnHelper.accessor('job_id', {
+		header: 'Job Id',
+		cell: (cell) => <CopyableValue label="Job ID" value={cell.getValue()} />,
+		meta: { width: 'max-content' }
 	}),
-	columnHelper.accessor('uri', {
-		id: 'URI',
+	columnHelper.accessor('run_id', {
+		header: 'Run Id',
+		cell: (cell) => <CopyableValue label="Run ID" value={cell.getValue()} />,
+		meta: { width: 'max-content' }
+	}),
+	columnHelper.accessor('run_source_url', {
 		header: 'URL',
 		cell: (cell) => {
 			const url = cell.getValue();
-
 			if (!z.string().url().safeParse(url).success) return null;
-
 			return (
 				<a
 					href={url}
@@ -217,14 +251,25 @@ export const columns = [
 				</a>
 			);
 		},
-		meta: { width: '1fr' }
+		meta: { width: 'minmax(280px, 2fr)' }
+	}),
+	columnHelper.accessor('error_msg', {
+		header: 'Error',
+		cell: (cell) => {
+			const value = cell.getValue();
+			if (!value) return null;
+			return (
+				<span className="whitespace-pre-wrap font-mono text-xs text-red-600">
+					{value}
+				</span>
+			);
+		},
+		meta: { width: 'minmax(220px, 1.35fr)' }
 	}),
 	columnHelper.display({
 		id: 'expand',
 		cell: ({ row }) => {
-			const isError =
-				row.original.severity === Severity.ERROR &&
-				row.original.facility === Facility.ImportRuns;
+			const isError = row.original.status === 'FAILURE';
 
 			// eslint-disable-next-line react-hooks/rules-of-hooks
 			const [importRuns] = useImportRunsMutation();
@@ -237,7 +282,11 @@ export const columns = [
 							size="xss"
 							onClick={async () => {
 								const promise = importRuns([
-									{ force: true, url: row.original.uri, range: null }
+									{
+										force: true,
+										url: row.original.run_source_url,
+										range: null
+									}
 								]);
 
 								toast.promise(promise, {
@@ -275,6 +324,6 @@ export const columns = [
 				</div>
 			);
 		},
-		meta: { width: 'min-content' }
+		meta: { width: '72px' }
 	})
 ];

--- a/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.component.tsx
+++ b/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.component.tsx
@@ -1,13 +1,12 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { ComponentProps, Fragment, useState } from 'react';
+import { ComponentProps, ComponentType, Fragment, useState } from 'react';
 import {
 	ExpandedState,
 	flexRender,
 	getCoreRowModel,
 	getExpandedRowModel,
 	getFilteredRowModel,
-	getGroupedRowModel,
 	getPaginationRowModel,
 	OnChangeFn,
 	PaginationState,
@@ -18,7 +17,8 @@ import {
 import { format, parseISO } from 'date-fns';
 import { RocketIcon } from '@radix-ui/react-icons';
 
-import { Facility, LogEventWithChildren, Severity } from '@/shared/types';
+import { Facility, ImportTaskRow, Severity } from '@/shared/types';
+import { useCopyToClipboard } from '@/shared/hooks';
 import {
 	Badge,
 	ButtonTw,
@@ -26,7 +26,8 @@ import {
 	cva,
 	Icon,
 	Pagination,
-	Skeleton
+	Skeleton,
+	toast
 } from '@/shared/tailwind-ui';
 import { TIME_DOT_FORMAT_FULL } from '@/shared/utils';
 import { config } from '@/bublik/config';
@@ -49,7 +50,7 @@ declare module '@tanstack/react-table' {
 }
 
 interface ImportEventTableProps {
-	data: LogEventWithChildren[];
+	data: ImportTaskRow[];
 	pagination: PaginationState;
 	setPagination: OnChangeFn<PaginationState>;
 	expanded: ExpandedState;
@@ -69,12 +70,11 @@ function ImportEventTable(props: ImportEventTableProps) {
 		getCoreRowModel: getCoreRowModel(),
 		getFilteredRowModel: getFilteredRowModel(),
 		getPaginationRowModel: getPaginationRowModel(),
-		getGroupedRowModel: getGroupedRowModel(),
 		getExpandedRowModel: getExpandedRowModel(),
 		onPaginationChange: setPagination,
 		onExpandedChange: setExpanded,
-		getRowId: (row) => row.event_id.toString(),
-		getRowCanExpand: (row) => row?.original?.children?.length > 1,
+		getRowId: (row) => row.celery_task ?? row.run_source_url,
+		getRowCanExpand: (row) => row?.original?.event_logs?.length > 0,
 		rowCount,
 		manualPagination: true
 	});
@@ -132,7 +132,7 @@ function ImportEventTable(props: ImportEventTableProps) {
 }
 
 interface EventRowProps {
-	row: Row<LogEventWithChildren>;
+	row: Row<ImportTaskRow>;
 }
 
 function EventRow({ row }: EventRowProps) {
@@ -175,7 +175,13 @@ function EventRow({ row }: EventRowProps) {
 				);
 			})}
 			{row.getIsExpanded() && (
-				<div className={'col-span-full'}>{renderTimeline({ row, toggle })}</div>
+				<div className={'col-span-full'}>
+					{renderEventLogs({
+						eventLogs: row.original.event_logs,
+						taskId: row.original.celery_task,
+						toggle
+					})}
+				</div>
 			)}
 		</Fragment>
 	);
@@ -216,164 +222,184 @@ const ImportEventTableEmpty = () => {
 	);
 };
 
-type TimelineOptions = {
-	row: Row<LogEventWithChildren>;
+interface EventLogsOptions {
+	eventLogs: ImportTaskRow['event_logs'];
+	taskId?: string | null;
 	toggle: ReturnType<typeof useImportLog>['toggle'];
-};
+}
 
-const NO_TASK_GROUP = '__no-task__';
-
-function renderTimeline(props: TimelineOptions) {
-	const {
-		row: {
-			original: { children: events }
-		},
-		toggle
-	} = props;
-	const groupedEvents = events.reduce<Record<string, typeof events>>(
-		(acc, evt) => {
-			const taskId = evt.celery_task ?? NO_TASK_GROUP;
-			if (!acc[taskId]) acc[taskId] = [];
-			acc[taskId].push(evt);
-			return acc;
-		},
-		{}
-	);
+function renderEventLogs(props: EventLogsOptions) {
+	const { eventLogs, taskId, toggle } = props;
+	const orderedEventLogs = eventLogs.slice().reverse();
 
 	return (
 		<div className="bg-white px-4 py-8 border-t border-border-primary mb-1">
 			<div className="relative flex flex-col gap-8">
-				{/* Continuous vertical line across all groups */}
+				{/* Continuous vertical line */}
 				<div className="absolute left-10 top-12 bottom-16 z-10 w-0.5 bg-border-primary" />
 
-				{Object.entries(groupedEvents).map(([taskId, taskEvents], idx, arr) => {
-					const isNoTask = taskId === NO_TASK_GROUP;
-
-					return (
-						<div
-							key={taskId}
-							className="border relative rounded-md border-border-primary p-4 hover:border-primary transition-colors"
-						>
-							{idx !== arr.length - 1 && (
-								<div className="absolute left-7 top-[95%] size-6 bg-white z-0" />
-							)}
-							{idx !== 0 && (
-								<div className="absolute left-7 -top-[5%] size-6 bg-white z-0" />
-							)}
-							<div className="flex items-center absolute -top-[15px] px-2 left-[80px] bg-white">
-								<span className="text-sm text-text-primary font-semibold">
-									Task:
-								</span>
-								{isNoTask ? (
-									<>
-										<Badge variant="warning" className="ml-2">
-											No celery task available
-										</Badge>
-										<span className="text-xs text-text-secondary ml-2">
-											These events cannot be opened in Flower or have their logs
-											viewed
-										</span>
-									</>
-								) : (
-									<>
-										<code className="text-sm text-gray-800 whitespace-pre-wrap">
-											{' '}
-											{taskId}
-										</code>
-										<span className="px-2">•</span>
-										<div className="flex items-center gap-2">
-											<ButtonTw
-												variant="secondary"
-												size="xss"
-												onClick={toggle(taskId)}
-											>
-												<Icon name="Paper" size={20} className="mr-1.5" />
-												<span>Log</span>
-											</ButtonTw>
-											<ButtonTw
-												variant="secondary"
-												size="xss"
-												className="justify-start"
-												asChild
-											>
-												<a
-													href={`${config.oldBaseUrl}/flower/task/${taskId}`}
-													target="_blank"
-													rel="noreferrer"
-												>
-													<RocketIcon className="mr-1.5 size-4" />
-													<span>Task</span>
-												</a>
-											</ButtonTw>
-										</div>
-									</>
-								)}
-							</div>
-							<div className="relative pl-8">
-								<div className="space-y-4">
-									{taskEvents.map((evt, _) => {
-										const StatusIcon = getIconByStatus(evt.status);
-										const bg = getBgByStatus(evt.status);
-
-										return (
-											<div key={evt.event_id} className="relative">
-												{/* Status icon circle */}
-												<div
-													className={`absolute -left-[24px] top-[11px] flex size-8 items-center justify-center rounded-full ${bg} text-white z-10`}
-												>
-													<StatusIcon className="size-6" />
-												</div>
-
-												{/* Event content */}
-												<div className="space-y-3 rounded-lg ml-4 border border-border-primary bg-gray-50/70 p-4">
-													<div className="flex flex-col gap-2">
-														<div className="flex items-center gap-2">
-															<StatusBadge status={evt.status} />
-															<FacilityBadge facility={evt.facility} />
-															<SeverityBadge severity={evt.severity} />
-														</div>
-														<div>
-															<div className="flex items-center gap-2 text-xs leading-5 text-text-primary flex-wrap">
-																<div className="flex items-center gap-1">
-																	<Icon name="Clock" className="size-4" />
-																	<span>
-																		{format(
-																			parseISO(evt.timestamp),
-																			TIME_DOT_FORMAT_FULL
-																		)}
-																	</span>
-																</div>
-																{evt.runtime && (
-																	<>
-																		<span>•</span>
-																		<div className="flex items-center gap-1">
-																			<span>
-																				Runtime: {formatRuntime(evt.runtime)}
-																			</span>
-																		</div>
-																	</>
-																)}
-															</div>
-														</div>
-													</div>
-													{evt.error_msg && (
-														<p className="font-medium text-xs bg-primary-wash p-4 rounded-md">
-															{evt.error_msg}
-														</p>
-													)}
-												</div>
-											</div>
-										);
-									})}
-								</div>
+				<div className="border relative rounded-md border-border-primary p-4 hover:border-primary transition-colors">
+					{taskId ? (
+						<div className="flex items-center absolute -top-[15px] px-2 left-[80px] bg-white">
+							<span className="text-sm text-text-primary font-semibold">
+								Task: &nbsp;
+							</span>
+							<CopyableTaskId taskId={taskId} />
+							<span className="px-2">•</span>
+							<div className="flex items-center gap-2">
+								<ButtonTw
+									variant="secondary"
+									size="xss"
+									onClick={toggle(taskId)}
+								>
+									<Icon name="Paper" size={20} className="mr-1.5" />
+									<span>Log</span>
+								</ButtonTw>
+								<ButtonTw
+									variant="secondary"
+									size="xss"
+									className="justify-start"
+									asChild
+								>
+									<a
+										href={`${config.oldBaseUrl}/flower/task/${taskId}`}
+										target="_blank"
+										rel="noreferrer"
+									>
+										<RocketIcon className="mr-1.5 size-4" />
+										<span>Task</span>
+									</a>
+								</ButtonTw>
 							</div>
 						</div>
-					);
-				})}
+					) : (
+						<div className="flex items-center absolute -top-[15px] px-2 left-[80px] bg-white">
+							<Badge variant="warning" className="ml-2">
+								No celery task available
+							</Badge>
+							<span className="text-xs text-text-secondary ml-2">
+								These events cannot be opened in Flower or have their logs
+								viewed
+							</span>
+						</div>
+					)}
+					<div className="relative pl-8">
+						<div className="space-y-4">
+							{orderedEventLogs.map((evt) => {
+								const StatusIcon = getEventLogIcon(evt.severity);
+								const bg = getEventLogBg(evt.severity);
+
+								return (
+									<div key={evt.timestamp + evt.msg} className="relative">
+										<div
+											className={`absolute -left-[24px] top-[11px] flex size-8 items-center justify-center rounded-full ${bg} text-white z-10`}
+										>
+											<StatusIcon className="size-6" />
+										</div>
+
+										<div className="space-y-3 rounded-lg ml-4 border border-border-primary bg-gray-50/70 p-4">
+											<div className="flex flex-col gap-2">
+												<div className="flex items-center gap-2">
+													<FacilityBadge facility={evt.facility as Facility} />
+													<SeverityBadge severity={evt.severity as Severity} />
+												</div>
+												<div>
+													<div className="flex items-center gap-2 text-xs leading-5 text-text-primary flex-wrap">
+														<div className="flex items-center gap-1">
+															<Icon name="Clock" className="size-4" />
+															<span>
+																{format(
+																	parseISO(evt.timestamp),
+																	TIME_DOT_FORMAT_FULL
+																)}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+											<p className="font-medium text-xs bg-primary-wash p-4 rounded-md">
+												{evt.msg}
+											</p>
+										</div>
+									</div>
+								);
+							})}
+						</div>
+					</div>
+				</div>
 			</div>
 		</div>
 	);
 }
+
+interface CopyableTaskIdProps {
+	taskId: string;
+}
+
+function CopyableTaskId({ taskId }: CopyableTaskIdProps) {
+	const [, copy] = useCopyToClipboard();
+
+	return (
+		<button
+			type="button"
+			className="inline-flex items-center gap-1 text-sm text-gray-800 whitespace-pre-wrap group hover:text-primary"
+			onClick={(event) => {
+				event.stopPropagation();
+				copy(taskId).then((success) => {
+					if (success) {
+						toast.success('Copied task id to clipboard');
+					} else {
+						toast.error('Failed to copy task id');
+					}
+				});
+			}}
+		>
+			<code>{taskId}</code>
+			<Icon
+				name="PaperStack"
+				size={14}
+				className="opacity-0 group-hover:opacity-100 transition-opacity text-primary"
+			/>
+		</button>
+	);
+}
+
+function getEventLogBg(severity: string): string {
+	switch (severity) {
+		case Severity.ERROR:
+			return 'bg-bg-error';
+		case Severity.WARNING:
+			return 'bg-yellow-500';
+		case Severity.DEBUG:
+			return 'bg-gray-500';
+		case Severity.INFO:
+		default:
+			return 'bg-primary';
+	}
+}
+
+type EventLogIconProps = Omit<ComponentProps<typeof Icon>, 'name'>;
+
+function getEventLogIcon(severity: string): ComponentType<EventLogIconProps> {
+	switch (severity) {
+		case Severity.ERROR:
+			return (props: EventLogIconProps) => (
+				<Icon {...props} name="InformationCircleCrossMark" />
+			);
+		case Severity.WARNING:
+			return (props: EventLogIconProps) => (
+				<Icon {...props} name="TriangleExclamationMark" />
+			);
+		case Severity.DEBUG:
+			return (props: EventLogIconProps) => <Icon {...props} name="IssueIcon" />;
+		case Severity.INFO:
+		default:
+			return (props: EventLogIconProps) => (
+				<Icon {...props} name="InformationCircleCheckmark" />
+			);
+	}
+}
+
 const facilityStyles = cva({
 	base: [
 		'inline-flex',
@@ -457,9 +483,10 @@ export const statusBadgeStyles = cva({
 	],
 	variants: {
 		variant: {
-			SUCCESS: ['bg-bg-ok', 'text-white'],
+			SUCCESS: ['bg-badge-3', 'text-text-expected'],
 			FAILURE: ['bg-badge-12', 'text-white'],
-			STARTED: ['bg-primary', 'text-white'],
+			RUNNING: ['bg-primary', 'text-white'],
+			RECEIVED: ['bg-badge-0', 'text-text-secondary'],
 			UNKNOWN: ['bg-badge-0', 'text-text-primary']
 		}
 	},

--- a/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.container.tsx
+++ b/libs/bublik/features/run-import/src/lib/import-events-table/import-event-table.container.tsx
@@ -5,7 +5,7 @@ import { JsonParam, useQueryParam, withDefault } from 'use-query-params';
 import { ExpandedState, PaginationState } from '@tanstack/react-table';
 
 import { analyticsEventNames, trackEvent } from '@/bublik/features/analytics';
-import { LogQuery } from '@/shared/types';
+import { ImportTaskFilters } from '@/shared/types';
 import { useGetImportEventLogQuery } from '@/services/bublik-api';
 
 import {
@@ -17,12 +17,11 @@ import {
 import { ImportRunFilterForm } from '../import-run-filter-form';
 
 const FilterParams = withDefault(JsonParam, {
-	date: undefined,
-	facility: 'importruns',
-	msg: undefined,
-	severity: undefined,
-	task_id: undefined,
-	url: undefined
+	job: undefined,
+	run: undefined,
+	url: undefined,
+	celery_task: undefined,
+	status: undefined
 });
 
 const PaginationParam = withDefault(JsonParam, {
@@ -49,16 +48,18 @@ function useImportLogExpanded() {
 }
 
 const useEventFilters = () => {
-	const [params, setParams] = useQueryParam<LogQuery>('filters', FilterParams);
+	const [params, setParams] = useQueryParam<ImportTaskFilters>(
+		'filters',
+		FilterParams
+	);
 
-	const handleFilterChange = (values: LogQuery) => {
+	const handleFilterChange = (values: ImportTaskFilters) => {
 		trackEvent(analyticsEventNames.importEventsFilterApply, {
-			hasMessage: Boolean(values.msg),
 			hasUrl: Boolean(values.url),
-			hasTaskId: Boolean(values.task_id),
-			hasDate: Boolean(values.date),
-			hasSeverity: Boolean(values.severity),
-			hasFacility: Boolean(values.facility)
+			hasCeleryTask: Boolean(values.celery_task),
+			hasJob: Boolean(values.job),
+			hasRun: Boolean(values.run),
+			hasStatus: Boolean(values.status)
 		});
 
 		setParams(values, 'replaceIn');
@@ -71,22 +72,18 @@ const useEventFilters = () => {
 
 		setParams(
 			{
-				date: undefined,
-				facility: 'importruns',
-				msg: undefined,
-				severity: undefined,
-				task_id: undefined,
-				url: undefined
+				job: undefined,
+				run: undefined,
+				url: undefined,
+				celery_task: undefined,
+				status: undefined
 			},
 			'replace'
 		);
 	};
 
 	return {
-		query: {
-			...params,
-			date: params?.date ? new Date(params.date) : undefined
-		},
+		query: params,
 		setQuery: handleFilterChange,
 		onResetClick: handleResetClick
 	};

--- a/libs/bublik/features/run-import/src/lib/import-run-filter-form/import-run-filter-form.component.tsx
+++ b/libs/bublik/features/run-import/src/lib/import-run-filter-form/import-run-filter-form.component.tsx
@@ -3,23 +3,29 @@
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
-import { LogQuery, LogQuerySchema } from '@/shared/types';
+import { ImportTaskFilters, ImportTaskFiltersSchema } from '@/shared/types';
 import {
 	ButtonTw,
-	DatePickerField,
 	Icon,
 	Input,
 	SelectField,
 	Tooltip
 } from '@/shared/tailwind-ui';
 
-import { facilityOptions, severityOptions } from '../utils';
 import { BUBLIK_TAG, bublikAPI } from '@/services/bublik-api';
 import { useDispatch } from 'react-redux';
 
+const statusOptions = [
+	{ value: 'all', displayValue: 'All' },
+	{ value: 'RECEIVED', displayValue: 'Received' },
+	{ value: 'RUNNING', displayValue: 'Running' },
+	{ value: 'SUCCESS', displayValue: 'Success' },
+	{ value: 'FAILURE', displayValue: 'Failure' }
+];
+
 export interface ImportRunFilterProps {
-	onFiltersChange?: (filters: LogQuery) => void;
-	defaultValues?: LogQuery;
+	onFiltersChange?: (filters: ImportTaskFilters) => void;
+	defaultValues?: ImportTaskFilters;
 	onResetClick?: () => void;
 }
 
@@ -29,25 +35,23 @@ export const ImportRunFilterForm = (props: ImportRunFilterProps) => {
 		control,
 		handleSubmit,
 		formState: { errors }
-	} = useForm<LogQuery>({
+	} = useForm<ImportTaskFilters>({
 		defaultValues: props.defaultValues,
-		resolver: zodResolver(LogQuerySchema)
+		resolver: zodResolver(ImportTaskFiltersSchema)
 	});
 	const dispatch = useDispatch();
 
 	const handleInitialSubmit = () => {
 		return handleSubmit((values) => {
-			const severity = values.severity === 'all' ? undefined : values.severity;
-			const facility = values.facility === 'all' ? undefined : values.facility;
+			const status = values.status === 'all' ? undefined : values.status;
 			dispatch(bublikAPI.util.invalidateTags([BUBLIK_TAG.importEvents]));
 
 			return props.onFiltersChange?.({
-				severity,
-				facility,
-				date: values.date,
-				msg: values.msg?.trim(),
-				task_id: values.task_id?.trim(),
-				url: values.url?.trim()
+				job: values.job,
+				run: values.run,
+				url: values.url?.trim(),
+				celery_task: values.celery_task?.trim(),
+				status
 			});
 		});
 	};
@@ -58,29 +62,21 @@ export const ImportRunFilterForm = (props: ImportRunFilterProps) => {
 			className="flex flex-wrap items-center gap-4"
 		>
 			<div>
-				<SelectField
-					name="severity"
-					placeholder="Select severity"
-					control={control}
-					label="Severity"
-					options={severityOptions}
-				/>
-			</div>
-			<div>
-				<SelectField
-					name="facility"
-					placeholder="Select facility"
-					control={control}
-					label="Facility"
-					options={facilityOptions}
+				<Input
+					label="Job ID"
+					placeholder="1"
+					type="number"
+					{...register('job', { valueAsNumber: true })}
+					error={errors.job?.message}
 				/>
 			</div>
 			<div>
 				<Input
-					label="Message"
-					placeholder="Message..."
-					{...register('msg')}
-					error={errors.msg?.message}
+					label="Run ID"
+					placeholder="123"
+					type="number"
+					{...register('run', { valueAsNumber: true })}
+					error={errors.run?.message}
 				/>
 			</div>
 			<div>
@@ -95,12 +91,18 @@ export const ImportRunFilterForm = (props: ImportRunFilterProps) => {
 				<Input
 					label="Task ID"
 					placeholder="c8a4d0b8-b3d4-4b38-9dbd-352fcd8beae0"
-					{...register('task_id')}
-					error={errors.task_id?.message}
+					{...register('celery_task')}
+					error={errors.celery_task?.message}
 				/>
 			</div>
 			<div>
-				<DatePickerField label="Date" name="date" control={control} />
+				<SelectField
+					name="status"
+					placeholder="Select status"
+					control={control}
+					label="Status"
+					options={statusOptions}
+				/>
 			</div>
 			<div className="flex items-center gap-4">
 				<ButtonTw

--- a/libs/bublik/features/run-import/src/lib/import-run-form/import-run-form-result-list.component.tsx
+++ b/libs/bublik/features/run-import/src/lib/import-run-form/import-run-form-result-list.component.tsx
@@ -3,8 +3,7 @@
 import { format } from 'date-fns';
 import { RocketIcon } from '@radix-ui/react-icons';
 
-import { config } from '@/bublik/config';
-import { ImportEventResponse } from '@/shared/types';
+import { ImportRunsJobResponse } from '@/shared/types';
 import {
 	ButtonTw,
 	DialogDescription,
@@ -16,7 +15,7 @@ import { useImportLog } from '../import-events-table';
 import { StatusBadge } from '../import-events-table/import-event-table.component';
 
 interface RunImportResultProps {
-	results: ImportEventResponse[];
+	results: ImportRunsJobResponse[];
 	timestamp?: Date;
 }
 
@@ -25,6 +24,13 @@ function RunImportResult({
 	timestamp = new Date()
 }: RunImportResultProps) {
 	const { toggle } = useImportLog();
+
+	const allTasks = results.flatMap((job) =>
+		job.job_tasks_data.map((task) => ({
+			...task,
+			jobId: job.job_id
+		}))
+	);
 
 	return (
 		<div>
@@ -40,14 +46,15 @@ function RunImportResult({
 			</p>
 			<h3 className="text-sm font-medium text-text-primary mb-2">Imports</h3>
 			<ul className="border rounded-md [&>*:not(:last-child)]:border-b [&>*]:border-border-primary">
-				{results.map((result, i) => {
-					const url = result.url ? new URL(result.url) : null;
+				{allTasks.map((task, i) => {
+					const url = task.run_source_url ? new URL(task.run_source_url) : null;
 					const cleanUrl = url ? url.origin + url.pathname : '';
+					const hasTask = Boolean(task.celery_task_id);
 
 					return (
 						<li key={i} className="space-y-2 p-4">
 							<div className="flex items-center justify-between gap-2">
-								<StatusBadge status={result.taskId ? 'SUCCESS' : 'FAILURE'} />
+								<StatusBadge status={hasTask ? 'SUCCESS' : 'FAILURE'} />
 								<span className="text-xs text-gray-500">
 									{format(
 										new Date(
@@ -57,6 +64,9 @@ function RunImportResult({
 										'hh:mm a'
 									)}
 								</span>
+							</div>
+							<div className="flex items-center gap-2 text-xs text-gray-500">
+								<span>Job #{task.jobId}</span>
 							</div>
 							{cleanUrl ? (
 								<a
@@ -72,7 +82,9 @@ function RunImportResult({
 								<ButtonTw
 									variant="outline-secondary"
 									onClick={
-										result.taskId ? toggle(result.taskId, true) : undefined
+										task.celery_task_id
+											? toggle(task.celery_task_id, true)
+											: undefined
 									}
 									className="flex-1"
 								>
@@ -85,7 +97,7 @@ function RunImportResult({
 									asChild
 								>
 									<a
-										href={`${config.oldBaseUrl}/flower/task/${result.taskId}`}
+										href={task.flower ?? undefined}
 										target="_blank"
 										rel="noreferrer"
 									>

--- a/libs/bublik/features/run-import/src/lib/import-run-form/import-run-form.container.tsx
+++ b/libs/bublik/features/run-import/src/lib/import-run-form/import-run-form.container.tsx
@@ -4,7 +4,7 @@ import { useRef, useState } from 'react';
 import { z } from 'zod';
 
 import { analyticsEventNames, trackEvent } from '@/bublik/features/analytics';
-import { ImportEventResponse, ImportRunsFormValues } from '@/shared/types';
+import { ImportRunsJobResponse, ImportRunsFormValues } from '@/shared/types';
 import { bublikAPI, useImportRunsMutation } from '@/services/bublik-api';
 import { setErrorsOnForm } from '@/shared/utils';
 
@@ -20,7 +20,7 @@ type FormState = 'form' | 'result';
 export const useImportTasks = () => {
 	const [importRuns] = useImportRunsMutation();
 	const [step, setStep] = useState<FormState>('form');
-	const [celeryTasks, setCeleryTasks] = useState<ImportEventResponse[]>([]);
+	const [importJobs, setImportJobs] = useState<ImportRunsJobResponse[]>([]);
 	const importFormRef = useRef<ImportRunFormHandle>(null);
 
 	const onFormSubmit = async ({ runs }: ImportRunsFormValues) => {
@@ -46,15 +46,20 @@ export const useImportTasks = () => {
 
 			const results = await importRuns(onlyUrls).unwrap();
 
+			const taskCount = results.reduce(
+				(sum, job) => sum + job.job_tasks_data.length,
+				0
+			);
+
 			trackEvent(analyticsEventNames.importRunsSubmit, {
 				providedRunsCount: runs.length,
 				validRunsCount: onlyUrls.length,
 				status: 'success',
-				taskCount: results.length
+				taskCount
 			});
 
 			setStep('result');
-			setCeleryTasks(results);
+			setImportJobs(results);
 		} catch (e: unknown) {
 			trackEvent(analyticsEventNames.importRunsSubmit, {
 				providedRunsCount: runs.length,
@@ -67,14 +72,14 @@ export const useImportTasks = () => {
 
 	const onFormClose = () => {
 		setStep('form');
-		setCeleryTasks([]);
+		setImportJobs([]);
 	};
 
-	return { step, onFormClose, onFormSubmit, celeryTasks, importFormRef };
+	return { step, onFormClose, onFormSubmit, importJobs, importFormRef };
 };
 
 export const ImportRunFormContainer = () => {
-	const { step, onFormClose, onFormSubmit, celeryTasks, importFormRef } =
+	const { step, onFormClose, onFormSubmit, importJobs, importFormRef } =
 		useImportTasks();
 	const { data, error, isLoading } = bublikAPI.useGetAllProjectsQuery();
 
@@ -87,7 +92,7 @@ export const ImportRunFormContainer = () => {
 					ref={importFormRef}
 				/>
 			)}
-			{step === 'result' && <RunImportResult results={celeryTasks} />}
+			{step === 'result' && <RunImportResult results={importJobs} />}
 		</ImportRunFormModal>
 	);
 };

--- a/libs/services/bublik-api/src/lib/endpoints/import/import-log-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/import/import-log-endpoints.ts
@@ -4,12 +4,14 @@ import { EndpointBuilder, QueryReturnValue } from '@reduxjs/toolkit/query';
 import { z } from 'zod';
 
 import {
-	ImportEventResponse,
 	ImportRunInput,
+	ImportRunsJobResponse,
+	ImportRunsJobResponseSchema,
 	ImportJsonLog,
-	LogRawApiResponseSchema,
-	LogQuerySchema,
-	LogEventResponseSchema
+	ImportJsonLogResponseSchema,
+	ImportTaskListRawResponseSchema,
+	ImportTaskListResponseSchema,
+	ImportTaskFiltersSchema
 } from '@/shared/types';
 import { formatTimeToAPI } from '@/shared/utils';
 import { config } from '@/bublik/config';
@@ -17,7 +19,6 @@ import { config } from '@/bublik/config';
 import { BublikBaseQueryFn, withApiV2 } from '../../config';
 import { API_REDUCER_PATH } from '../../constants';
 import { BUBLIK_TAG } from '../../types';
-import { getUrl, runToImportUrl } from './parse-import-url';
 import { MaybePromise } from '../../utils';
 
 export const importLogEventsEndpoint = {
@@ -27,66 +28,80 @@ export const importLogEventsEndpoint = {
 		getImportEventLog: build.query({
 			query: (query) => ({
 				url: withApiV2('/session_import'),
-				params: {
-					...query,
-					date: query.date ? formatTimeToAPI(query.date) : undefined
-				},
+				params: query,
 				cache: 'no-cache'
 			}),
-			argSchema: LogQuerySchema,
-			responseSchema: LogEventResponseSchema,
-			rawResponseSchema: LogRawApiResponseSchema,
+			argSchema: ImportTaskFiltersSchema,
+			responseSchema: ImportTaskListResponseSchema,
+			rawResponseSchema: ImportTaskListRawResponseSchema,
 			transformResponse: (
-				response: z.infer<typeof LogRawApiResponseSchema>
-			): z.infer<typeof LogEventResponseSchema> => ({
+				response: z.infer<typeof ImportTaskListRawResponseSchema>
+			): z.infer<typeof ImportTaskListResponseSchema> => ({
 				...response,
-				results: response.results.map((result) => {
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					const latest = result.at(0)!;
-					const other = result.slice(0);
-					const maybeRunId = result.find(
-						(item) => item?.run_id !== undefined
-					)?.run_id;
-
-					return {
-						...latest,
-						children: other,
-						run_id: maybeRunId
-					};
-				})
+				results: response.results.map((result) => ({
+					...result,
+					runtime: result.runtime ? parseFloat(result.runtime) : null
+				}))
 			}),
 			providesTags: [BUBLIK_TAG.importEvents]
 		}),
-		importRuns: build.mutation<ImportEventResponse[], ImportRunInput[]>({
+		importRuns: build.mutation<ImportRunsJobResponse[], ImportRunInput[]>({
 			queryFn: async (runUrls, _api, _extraOptions, baseQuery) => {
 				const importRunPromises = runUrls.map((run) => {
-					const importUrl = runToImportUrl(run);
+					const params = new URLSearchParams();
+					params.set('url', run.url);
+					if (run.range?.startDate) {
+						params.set('from', formatTimeToAPI(run.range.startDate));
+					}
+					if (run.range?.endDate) {
+						params.set('to', formatTimeToAPI(run.range.endDate));
+					}
+					if (run.force) {
+						params.set('force', 'true');
+					}
+					if (run.project != null) {
+						params.set('project', String(run.project));
+					}
 
-					/**
-					 * For some reason base query here doesn't respect passed config base url in getApiConfig function
-					 * We need to add it manually
-					 */
-					const url = withApiV2(`/importruns/source/${importUrl}`, true);
+					const url = `${withApiV2(
+						'/importruns/source/',
+						true
+					)}?${params.toString()}`;
 
 					return baseQuery(`${config.rootUrl}${url}`) as MaybePromise<
-						QueryReturnValue<{ celery_task_id: string }>
+						QueryReturnValue<unknown>
 					>;
 				});
 
 				const responses = await Promise.allSettled(importRunPromises);
 
-				const data = responses.map((maybe, idx) => {
-					const maybeRunUrl = runUrls?.[idx];
-					const url = maybeRunUrl ? getUrl(maybeRunUrl).toString() : 'unknown';
+				const data: ImportRunsJobResponse[] = [];
+				const errors: string[] = [];
 
+				for (const maybe of responses) {
 					if (maybe.status === 'fulfilled' && maybe.value.data) {
-						const taskId = maybe.value.data.celery_task_id;
-
-						return { taskId, url };
+						const parsed = ImportRunsJobResponseSchema.safeParse(
+							maybe.value.data
+						);
+						if (parsed.success) {
+							data.push(parsed.data);
+						} else {
+							errors.push('Invalid response from import server');
+						}
+					} else if (maybe.status === 'rejected') {
+						errors.push(String(maybe.reason));
 					}
+				}
 
-					return { url, taskId: null };
-				});
+				if (errors.length) {
+					return {
+						error: {
+							status: 400,
+							title: 'Import failed',
+							description: errors.join('; ')
+						}
+					};
+				}
 
 				return { data };
 			},
@@ -96,7 +111,8 @@ export const importLogEventsEndpoint = {
 			query: (celery_task_id: string) => ({
 				url: withApiV2(`/importruns/log/?task_id=${celery_task_id}`, true),
 				cache: 'no-cache'
-			})
+			}),
+			responseSchema: z.array(ImportJsonLogResponseSchema)
 		})
 	})
 };

--- a/libs/shared/types/src/lib/run-import.ts
+++ b/libs/shared/types/src/lib/run-import.ts
@@ -16,69 +16,97 @@ export enum Facility {
 	Celery = 'celery'
 }
 
-export const LogEventSchema = z.object({
-	event_id: z.number(),
-	status: z.enum(['SUCCESS', 'FAILURE', 'STARTED']).or(z.string()),
-	uri: z.string(),
-	celery_task: z.string().optional().nullable(),
-	facility: z.nativeEnum(Facility),
-	severity: z.nativeEnum(Severity),
+export const ImportTaskEventLogSchema = z.object({
 	timestamp: z.string(),
-	run_id: z.number().optional().nullable(),
-	error_msg: z.string().optional().nullable(),
-	runtime: z.number().optional().nullable()
+	facility: z.string(),
+	severity: z.string(),
+	msg: z.string()
 });
 
-export const LogQuerySchema = z.object({
-	severity: z.nativeEnum(Severity).optional().or(z.string()),
-	facility: z.nativeEnum(Facility).optional().or(z.string()),
-	msg: z.preprocess((arg) => (arg ? arg : undefined), z.string().optional()),
-	date: z.date().optional(),
-	page: z.number().optional(),
-	page_size: z.number().optional(),
-	url: z.preprocess(
+export type ImportTaskEventLog = z.infer<typeof ImportTaskEventLogSchema>;
+
+export const ImportTaskRowRawSchema = z.object({
+	status: z.enum(['RECEIVED', 'RUNNING', 'SUCCESS', 'FAILURE']).or(z.string()),
+	run_source_url: z.string(),
+	celery_task: z.string().optional().nullable(),
+	started_at: z.string().nullable(),
+	finished_at: z.string().nullable(),
+	runtime: z.string().nullable(),
+	job_id: z.number(),
+	run_id: z.number().nullable(),
+	event_logs: z.array(ImportTaskEventLogSchema),
+	error_msg: z.string().nullable()
+});
+
+export type ImportTaskRowRaw = z.infer<typeof ImportTaskRowRawSchema>;
+
+export const ImportTaskRowSchema = ImportTaskRowRawSchema.extend({
+	runtime: z.number().nullable()
+});
+
+export type ImportTaskRow = z.infer<typeof ImportTaskRowSchema>;
+
+export const ImportTaskListRawResponseSchema = z.object({
+	pagination: z.object({ count: z.number() }),
+	results: z.array(ImportTaskRowRawSchema)
+});
+
+export const ImportTaskListResponseSchema = z.object({
+	pagination: z.object({ count: z.number() }),
+	results: z.array(ImportTaskRowSchema)
+});
+
+export type ImportTaskListResponse = z.infer<
+	typeof ImportTaskListResponseSchema
+>;
+
+export const ImportJobTaskDataSchema = z.object({
+	run_source_url: z.string(),
+	celery_task_id: z.string().nullable(),
+	flower: z.string().nullable(),
+	import_log: z.string().nullable()
+});
+
+export type ImportJobTaskData = z.infer<typeof ImportJobTaskDataSchema>;
+
+export const ImportRunsJobResponseSchema = z.object({
+	job_id: z.number(),
+	job_tasks_data: z.array(ImportJobTaskDataSchema)
+});
+
+export type ImportRunsJobResponse = z.infer<typeof ImportRunsJobResponseSchema>;
+
+const optionalNumberFilterSchema = z.preprocess((val) => {
+	if (val === '' || val == null) return undefined;
+
+	if (typeof val === 'number') {
+		return Number.isNaN(val) ? undefined : val;
+	}
+
+	const parsed = Number(val);
+	return Number.isNaN(parsed) ? undefined : parsed;
+}, z.number().optional());
+
+export const ImportTaskFiltersSchema = z.object({
+	job: optionalNumberFilterSchema,
+	run: optionalNumberFilterSchema,
+	url: z.preprocess((arg) => (arg ? arg : undefined), z.string().optional()),
+	celery_task: z.preprocess(
 		(arg) => (arg ? arg : undefined),
-		z.string().url().optional()
+		z.string().optional()
 	),
-	task_id: z.preprocess((arg) => (arg ? arg : undefined), z.string().optional())
+	status: z.preprocess(
+		(arg) => (arg ? arg : undefined),
+		z
+			.enum(['RECEIVED', 'RUNNING', 'SUCCESS', 'FAILURE'])
+			.or(z.string())
+			.optional()
+	),
+	page: z.number().optional(),
+	page_size: z.number().optional()
 });
 
-export const ImportRunMutationResponseSchema = z.object({
-	taskId: z.string().optional().nullable(),
-	url: z.string().nullable()
-});
-
-export const ImportRunMutationRequestSchema = z.object({
-	celery_task_id: z.string()
-});
-
-export type LogEvent = z.infer<typeof LogEventSchema>;
-
-export type LogQuery = z.infer<typeof LogQuerySchema>;
-
-export const LogRawApiResponseSchema = z.object({
-	pagination: z.object({ count: z.number() }),
-	results: z.array(z.array(LogEventSchema))
-});
-
-const LogEventWithChildrenSchema = LogEventSchema.extend({
-	children: z.array(LogEventSchema)
-});
-
-export type LogEventWithChildren = z.infer<typeof LogEventWithChildrenSchema>;
-
-export const LogEventResponseSchema = z.object({
-	pagination: z.object({ count: z.number() }),
-	results: z.array(LogEventWithChildrenSchema)
-});
-
-export type ImportEventResponse = z.infer<
-	typeof ImportRunMutationResponseSchema
->;
-
-export type ImportRunApiResponse = z.infer<
-	typeof ImportRunMutationRequestSchema
->;
+export type ImportTaskFilters = z.infer<typeof ImportTaskFiltersSchema>;
 
 export const ImportJsonLogResponseSchema = z.object({
 	asctime: z.string(),


### PR DESCRIPTION
## Summary
- update run import API schemas and endpoint validation to match the new task-based `session_import` and `importruns/source` responses
- rework the run import UI to render import jobs and task rows, including the new filters, status handling, result modal, and event log timeline
- remove assumptions about the old grouped event model so the frontend consumes the new backend contract directly

## Backend Dependency
- depends on backend changes in ts-factory/bublik#297