### PR TITLE
chore(measurements): normalize stacked chart y-axes for multi-axis plots

### DIFF
--- a/libs/shared/charts/src/lib/single-measurement-chart/measurement-chart.component.utils.ts
+++ b/libs/shared/charts/src/lib/single-measurement-chart/measurement-chart.component.utils.ts
@@ -325,6 +325,14 @@ function resolveStackedOptions(
 			groupedPlotIndices.push(idx);
 		}
 	});
+
+	if (yAxisConfigs.length > 1) {
+		yAxisConfigs.forEach((yAxisConfig) => {
+			yAxisConfig.min = 0;
+			yAxisConfig.max = 'dataMax';
+		});
+	}
+
 	const plotToYAxisIndex = new Map<number, number>();
 	yAxisGroups.forEach((plotIndices, _yAxisLabel) => {
 		const yAxisIndex = Array.from(yAxisGroups.keys()).indexOf(_yAxisLabel);


### PR DESCRIPTION
Set y-axis bounds for `StackedMeasurementChart` when multiple y-axes are rendered so each axis starts at 0 and ends at its data max. This avoids ECharts auto-scaling each axis independently from non-zero minima, which can make multi-axis comparisons visually misleading.