### PR TITLE
fix(history): support quoted badge values containing commas

### DIFF
--- a/libs/bublik/features/history/src/lib/history-context-menu/history-context-menu.container.tsx
+++ b/libs/bublik/features/history/src/lib/history-context-menu/history-context-menu.container.tsx
@@ -12,7 +12,8 @@ import {
 	ContextMenuSeparator,
 	toast,
 	VerdictListProps,
-	Icon
+	Icon,
+	formatBadgeString
 } from '@/shared/tailwind-ui';
 import { useCopyToClipboard } from '@/shared/hooks';
 
@@ -115,7 +116,7 @@ export const HistoryContextMenuContainer = (props: HistoryContextMenuProps) => {
 	};
 
 	const handleCopyAll = async () => {
-		const rawBadges = badges.map((badge) => badge.payload).join(', ');
+		const rawBadges = formatBadgeString(badges.map((badge) => badge.payload));
 
 		const isSuccess = await copy(rawBadges);
 

--- a/libs/shared/tailwind-ui/src/lib/badge-input/index.ts
+++ b/libs/shared/tailwind-ui/src/lib/badge-input/index.ts
@@ -3,3 +3,4 @@
 export * from './badge-input';
 export * from './badge-field';
 export * from './types';
+export * from './utils';

--- a/libs/shared/tailwind-ui/src/lib/badge-input/utils/index.spec.ts
+++ b/libs/shared/tailwind-ui/src/lib/badge-input/utils/index.spec.ts
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+import { describe, expect, it } from 'vitest';
+
+import { formatBadgeString, parseBadgeString } from './index';
+
+describe('badge input utils', () => {
+	describe('parseBadgeString', () => {
+		it('splits comma-separated values', () => {
+			expect(parseBadgeString('first, second')).toEqual(['first', 'second']);
+		});
+
+		it('preserves commas inside quoted values', () => {
+			expect(parseBadgeString('"failed, errno", timeout')).toEqual([
+				'failed, errno',
+				'timeout'
+			]);
+		});
+
+		it('unescapes doubled quotes inside quoted values', () => {
+			expect(parseBadgeString('"failed ""hard"", errno"')).toEqual([
+				'failed "hard", errno'
+			]);
+		});
+
+		it('keeps the existing delimiter conversion', () => {
+			expect(parseBadgeString('time_limit:30, "failed, errno"')).toEqual([
+				'time_limit=30',
+				'failed, errno'
+			]);
+		});
+	});
+
+	describe('formatBadgeString', () => {
+		it('joins values with comma and space', () => {
+			expect(formatBadgeString(['first', 'second'])).toBe('first, second');
+		});
+
+		it('quotes values containing commas', () => {
+			expect(formatBadgeString(['failed, errno', 'timeout'])).toBe(
+				'"failed, errno", timeout'
+			);
+		});
+
+		it('escapes quotes inside quoted values', () => {
+			expect(formatBadgeString(['failed "hard", errno'])).toBe(
+				'"failed ""hard"", errno"'
+			);
+		});
+
+		it('preserves values through a format and parse round trip', () => {
+			const values = [' plain ', 'failed, errno', 'failed "hard"', 'timeout'];
+
+			expect(parseBadgeString(formatBadgeString(values))).toEqual(values);
+		});
+	});
+});

--- a/libs/shared/tailwind-ui/src/lib/badge-input/utils/index.ts
+++ b/libs/shared/tailwind-ui/src/lib/badge-input/utils/index.ts
@@ -4,21 +4,105 @@ export interface ParseBadgeStringOptions {
 	separator: string;
 	delimeter: string;
 	originalDelimeter: string;
+	quote?: string;
 }
+
+const DEFAULT_QUOTE = '"';
 
 const PARSE_CONFIG: ParseBadgeStringOptions = {
 	separator: ',',
 	originalDelimeter: ':',
-	delimeter: '='
+	delimeter: '=',
+	quote: DEFAULT_QUOTE
+};
+
+const normalizeBadgeValue = (
+	value: string,
+	wasQuoted: boolean,
+	config: ParseBadgeStringOptions
+): string => {
+	const normalizedValue = wasQuoted ? value : value.trim();
+
+	return normalizedValue.replace(config.originalDelimeter, config.delimeter);
 };
 
 export const parseBadgeString = (
 	input: string,
 	config: ParseBadgeStringOptions = PARSE_CONFIG
-) => {
-	const { separator, originalDelimeter, delimeter } = config;
+): string[] => {
+	const { separator } = config;
+	const quote = config.quote ?? DEFAULT_QUOTE;
+	const result: string[] = [];
+	let current = '';
+	let isInsideQuote = false;
+	let wasQuoted = false;
+	let isAfterClosingQuote = false;
 
-	return input
-		.split(separator)
-		.map((string) => string.replace(originalDelimeter, delimeter));
+	const pushCurrent = (): void => {
+		result.push(normalizeBadgeValue(current, wasQuoted, config));
+		current = '';
+		wasQuoted = false;
+		isAfterClosingQuote = false;
+	};
+
+	for (let index = 0; index < input.length; index += 1) {
+		const char = input[index];
+		const nextChar = input[index + 1];
+
+		if (char === quote) {
+			if (isInsideQuote && nextChar === quote) {
+				current += quote;
+				index += 1;
+				continue;
+			}
+
+			if (isInsideQuote) {
+				isInsideQuote = false;
+				isAfterClosingQuote = true;
+				continue;
+			}
+
+			if (current.trim().length === 0) {
+				current = '';
+				isInsideQuote = true;
+				wasQuoted = true;
+				continue;
+			}
+		}
+
+		if (char === separator && !isInsideQuote) {
+			pushCurrent();
+			continue;
+		}
+
+		if (isAfterClosingQuote && char.trim().length === 0) continue;
+
+		isAfterClosingQuote = false;
+		current += char;
+	}
+
+	pushCurrent();
+
+	return result;
+};
+
+export const formatBadgeString = (
+	values: string[],
+	config: Pick<ParseBadgeStringOptions, 'separator' | 'quote'> = PARSE_CONFIG
+): string => {
+	const { separator } = config;
+	const quote = config.quote ?? DEFAULT_QUOTE;
+
+	return values
+		.map((value) => {
+			const needsQuotes =
+				value.includes(separator) ||
+				value.includes(quote) ||
+				value.trim() !== value;
+
+			if (!needsQuotes) return value;
+
+			return `${quote}${value.split(quote).join(`${quote}${quote}`)}${quote}`;
+		})
+		.join(`${separator} `);
 };


### PR DESCRIPTION
Before:
"test, test-1" created two badges: "test and test-1"

After:
"test, test-1" creates one badge: test, test-1 if input value is insides quotes

History context menu copy now uses the same quoting format, so copied verdicts can be pasted back into badge inputs without being split