### PR TITLE
fix(history): preserve verdict lookup type when clicking reset verdict button

### DIFF
--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.hooks.ts
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.hooks.ts
@@ -105,7 +105,7 @@ export const useHistoryGlobalSearchForm = (
 		methods.reset({
 			...methods.getValues(),
 			verdict: [],
-			verdictLookup: VERDICT_TYPE.None,
+			verdictLookup: methods.getValues().verdictLookup,
 			verdictExpr: ''
 		});
 	};


### PR DESCRIPTION
Currently when clicking "Bin" icon to reset verdict it sets type to "None" which is incorrect since it should just clear input.