### PR TITLE
chore(analytics): remove logging of all events from client side

### DIFF
--- a/libs/bublik/features/analytics/src/lib/tracker.ts
+++ b/libs/bublik/features/analytics/src/lib/tracker.ts
@@ -314,7 +314,6 @@ const trackPageView = ({ path }: { path: string }) => {
 };
 
 const trackEvent = (name: string, payload?: unknown) => {
-	console.log(name, payload);
 	if (!isAnalyticsEnabled || typeof window === 'undefined') {
 		return;
 	}


### PR DESCRIPTION
Remove logging all calls to `trackEvent` so it does not spam browser console.