### PR TITLE
fix(import): remove duplicated root prefix in import run requests

### DIFF
--- a/libs/services/bublik-api/src/lib/endpoints/import/import-log-endpoints.spec.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/import/import-log-endpoints.spec.ts
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+import { describe, expect, it } from 'vitest';
+
+import { ImportRunInput } from '@/shared/types';
+
+import { buildImportRunSourceUrl } from './import-log-endpoints';
+
+describe('buildImportRunSourceUrl', () => {
+	it('builds a relative API URL without duplicating the configured root URL', () => {
+		const run: ImportRunInput = {
+			url: 'https://example.test/custom/import/source/2026/04/19/run-42/',
+			range: {
+				startDate: new Date(2026, 3, 19),
+				endDate: new Date(2026, 3, 20)
+			},
+			force: true,
+			project: 7
+		};
+
+		const result = buildImportRunSourceUrl(run);
+
+		expect(result).toBe(
+			'/api/v2/importruns/source/?url=https%3A%2F%2Fexample.test%2Fcustom%2Fimport%2Fsource%2F2026%2F04%2F19%2Frun-42%2F&from=2026-04-19&to=2026-04-20&force=true&project=7'
+		);
+	});
+});

--- a/libs/services/bublik-api/src/lib/endpoints/import/import-log-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/import/import-log-endpoints.ts
@@ -14,12 +14,30 @@ import {
 	ImportTaskFiltersSchema
 } from '@/shared/types';
 import { formatTimeToAPI } from '@/shared/utils';
-import { config } from '@/bublik/config';
 
 import { BublikBaseQueryFn, withApiV2 } from '../../config';
 import { API_REDUCER_PATH } from '../../constants';
 import { BUBLIK_TAG } from '../../types';
 import { MaybePromise } from '../../utils';
+
+const buildImportRunSourceUrl = (run: ImportRunInput) => {
+	const params = new URLSearchParams();
+	params.set('url', run.url);
+	if (run.range?.startDate) {
+		params.set('from', formatTimeToAPI(run.range.startDate));
+	}
+	if (run.range?.endDate) {
+		params.set('to', formatTimeToAPI(run.range.endDate));
+	}
+	if (run.force) {
+		params.set('force', 'true');
+	}
+	if (run.project != null) {
+		params.set('project', String(run.project));
+	}
+
+	return `${withApiV2('/importruns/source/', true)}?${params.toString()}`;
+};
 
 export const importLogEventsEndpoint = {
 	endpoints: (
@@ -48,29 +66,9 @@ export const importLogEventsEndpoint = {
 		importRuns: build.mutation<ImportRunsJobResponse[], ImportRunInput[]>({
 			queryFn: async (runUrls, _api, _extraOptions, baseQuery) => {
 				const importRunPromises = runUrls.map((run) => {
-					const params = new URLSearchParams();
-					params.set('url', run.url);
-					if (run.range?.startDate) {
-						params.set('from', formatTimeToAPI(run.range.startDate));
-					}
-					if (run.range?.endDate) {
-						params.set('to', formatTimeToAPI(run.range.endDate));
-					}
-					if (run.force) {
-						params.set('force', 'true');
-					}
-					if (run.project != null) {
-						params.set('project', String(run.project));
-					}
+					const url = buildImportRunSourceUrl(run);
 
-					const url = `${withApiV2(
-						'/importruns/source/',
-						true
-					)}?${params.toString()}`;
-
-					return baseQuery(`${config.rootUrl}${url}`) as MaybePromise<
-						QueryReturnValue<unknown>
-					>;
+					return baseQuery(url) as MaybePromise<QueryReturnValue<unknown>>;
 				});
 
 				const responses = await Promise.allSettled(importRunPromises);
@@ -116,3 +114,5 @@ export const importLogEventsEndpoint = {
 		})
 	})
 };
+
+export { buildImportRunSourceUrl };


### PR DESCRIPTION
Import run requests were manually prepending config.rootUrl before calling RTK Query's baseQuery.
Since fetchBaseQuery is already configured with the same root URL, deployments under a subpath could produce duplicated prefixes such as /bublik/bublik/api/v2/...

Build the import source request as a relative API URL and let baseQuery apply the configured root once. Add a regression test that asserts the exact encoded import URL.