### PR TITLE
refactor(log): deprecate `formatted` field in JSON log

### DIFF
--- a/libs/bublik/features/log-preview-drawer/src/new-bug.component.spec.ts
+++ b/libs/bublik/features/log-preview-drawer/src/new-bug.component.spec.ts
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+import { describe, expect, test } from 'vitest';
+
+import { formatUnixTimestampToTimezone } from '@/shared/utils';
+
+import {
+	getFormattedMarkdown,
+	type NewBugButtonProps
+} from './new-bug.component';
+
+const baseProps: NewBugButtonProps = {
+	link: 'https://example.test/run/1',
+	name: 'sample-test',
+	tags: {
+		branches: [],
+		important: [],
+		specialCategories: {}
+	}
+};
+
+describe('getFormattedMarkdown', () => {
+	test('formats log rows with top-level timestamp values', () => {
+		const timestamp = 1711228667.618432;
+		const markdown = getFormattedMarkdown({
+			...baseProps,
+			globalFilter: ['entity:user'],
+			logs: [
+				{
+					line_number: 1,
+					level: 'INFO',
+					entity_name: 'entity',
+					user_name: 'user',
+					timestamp,
+					log_content: [
+						{
+							type: 'te-log-table-content-text',
+							content: 'message'
+						}
+					]
+				}
+			]
+		});
+
+		expect(markdown).toContain(formatUnixTimestampToTimezone(timestamp));
+		expect(markdown).toContain('message');
+	});
+});

--- a/libs/bublik/features/log-preview-drawer/src/new-bug.component.tsx
+++ b/libs/bublik/features/log-preview-drawer/src/new-bug.component.tsx
@@ -3,12 +3,14 @@
 import { ComponentProps } from 'react';
 
 import {
+	getLogTimestampSeconds,
 	LogTableSchema,
 	RootBlock,
 	RunDetailsAPIResponse,
 	TreeDataAPIResponse
 } from '@/shared/types';
 import { useCopyToClipboard } from '@/shared/hooks';
+import { formatUnixTimestampToTimezone } from '@/shared/utils';
 import { config } from '@/bublik/config';
 import {
 	cn,
@@ -207,7 +209,7 @@ function generateMarkdownTable<T extends Record<string, unknown>>(
 	return [header, separator, ...rows].join('\n');
 }
 
-function getFormattedMarkdown(
+export function getFormattedMarkdown(
 	options: NewBugButtonProps & { globalFilter: string[] }
 ): string {
 	const DELIMETER = '=';
@@ -393,7 +395,7 @@ function getFormattedMarkdown(
 				{
 					header: 'Timestamp',
 					accessor: 'timestamp',
-					cell: (v) => v.formatted
+					cell: (v) => formatUnixTimestampToTimezone(getLogTimestampSeconds(v))
 				},
 				{
 					header: 'Log Content',
@@ -419,7 +421,7 @@ function getFormattedMarkdown(
 
 const VERDICT_ENTTITY = 'Verdict';
 
-type BugTags = {
+export type BugTags = {
 	branches: string[];
 	important: string[];
 	revisions?: { name?: string; value: string; url?: string }[];
@@ -428,7 +430,7 @@ type BugTags = {
 	configuration?: string;
 };
 
-interface NewBugButtonProps {
+export interface NewBugButtonProps {
 	link: string;
 	path?: string;
 	name: string;

--- a/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/timestamp-delta/format-delta.spec.ts
+++ b/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/timestamp-delta/format-delta.spec.ts
@@ -1,8 +1,27 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import { createElement } from 'react';
+import { render } from '@testing-library/react';
+import type { Row } from '@tanstack/react-table';
 import { describe, test, expect } from 'vitest';
-import { formatDelta } from './timestamp-delta';
+
+import type { LogJsonTimestamp, LogTableData } from '@/shared/types';
 import { formatUnixTimestampToTimezone } from '@/shared/utils';
+
+import { DeltaContextProvider } from '../log-table.context';
+import { LOG_COLUMNS } from '../log-table.columns';
+import { formatDelta, TimestampDelta } from './timestamp-delta';
+
+function createRow(timestamp: LogJsonTimestamp) {
+	return {
+		getValue: (column: string) => {
+			if (column === LOG_COLUMNS.timestamp) return timestamp;
+
+			return undefined;
+		}
+	} as unknown as Row<LogTableData>;
+}
+
 describe('format delta', () => {
 	test('should display zero difference properly', () => {
 		expect(formatDelta(0, 0)).toBe('00:00:00.0');
@@ -54,5 +73,56 @@ describe('formatUnixTimestampToTimezone', () => {
 		const result = formatUnixTimestampToTimezone(1758662506.123456);
 		expect(result).toBeDefined();
 		expect(typeof result).toBe('string');
+	});
+});
+
+describe('TimestampDelta', () => {
+	test('should display top-level timestamp values', () => {
+		const timestamp = 1758662506.123456;
+		const row = createRow(timestamp);
+
+		const { getByText } = render(
+			createElement(
+				DeltaContextProvider,
+				{
+					value: {
+						anchorRow: row,
+						setAnchorRow: () => undefined,
+						resetAnchorRow: () => undefined
+					}
+				},
+				createElement(TimestampDelta, { data: timestamp, row })
+			)
+		);
+
+		expect(getByText(formatUnixTimestampToTimezone(timestamp))).toBeDefined();
+	});
+
+	test('should calculate deltas between legacy and top-level timestamp values', () => {
+		const anchorRow = createRow({
+			timestamp: 1758662506,
+			formatted: '00:00:00.000'
+		});
+		const row = createRow(1758662507.125);
+
+		const { getByText } = render(
+			createElement(
+				DeltaContextProvider,
+				{
+					value: {
+						anchorRow,
+						setAnchorRow: () => undefined,
+						resetAnchorRow: () => undefined
+					}
+				},
+				createElement(TimestampDelta, {
+					data: 1758662507.125,
+					row,
+					showDelta: true
+				})
+			)
+		);
+
+		expect(getByText('+ 00:00:01.125')).toBeDefined();
 	});
 });

--- a/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/timestamp-delta/timestamp-delta.tsx
+++ b/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/timestamp-delta/timestamp-delta.tsx
@@ -3,11 +3,15 @@
 import { Row } from '@tanstack/react-table';
 
 import { toast } from '@/shared/tailwind-ui';
-import { LogJsonTimestamp, LogTableData } from '@/shared/types';
+import { formatUnixTimestampToTimezone } from '@/shared/utils';
+import {
+	getLogTimestampSeconds,
+	LogJsonTimestamp,
+	LogTableData
+} from '@/shared/types';
 
 import { useDeltaContext } from '../log-table.context';
 import { LOG_COLUMNS } from '../log-table.columns';
-import { formatUnixTimestampToTimezone } from '@/shared/utils';
 
 export type TimestampDeltaProps = {
 	data: LogTableData['timestamp'];
@@ -22,17 +26,17 @@ export const TimestampDelta = (props: TimestampDeltaProps) => {
 	if (!showDelta) {
 		return (
 			<span className="inline-flex">
-				{formatUnixTimestampToTimezone(value.timestamp)}
+				{formatUnixTimestampToTimezone(getLogTimestampSeconds(value))}
 			</span>
 		);
 	}
 
-	const anchorSeconds = anchorRow.getValue<LogJsonTimestamp>(
-		LOG_COLUMNS.timestamp
-	).timestamp;
-	const compareSeconds = row.getValue<LogJsonTimestamp>(
-		LOG_COLUMNS.timestamp
-	).timestamp;
+	const anchorSeconds = getLogTimestampSeconds(
+		anchorRow.getValue<LogJsonTimestamp>(LOG_COLUMNS.timestamp)
+	);
+	const compareSeconds = getLogTimestampSeconds(
+		row.getValue<LogJsonTimestamp>(LOG_COLUMNS.timestamp)
+	);
 
 	const handleAnchroClick = () => {
 		setAnchorRow(row);

--- a/libs/bublik/features/session-log/src/lib/v1/schema.json
+++ b/libs/bublik/features/session-log/src/lib/v1/schema.json
@@ -134,6 +134,11 @@
 															"type": "string",
 															"description": "Optional objective"
 														},
+														"requirements": {
+															"type": "array",
+															"items": { "type": "string" },
+															"description": "Optional list of requirements"
+														},
 														"authors": {
 															"type": "array",
 															"items": {
@@ -218,13 +223,18 @@
 															"entity_name": { "type": "string" },
 															"user_name": { "type": "string" },
 															"timestamp": {
-																"type": "object",
-																"properties": {
-																	"timestamp": { "type": "number" },
-																	"formatted": { "type": "string" }
-																},
-																"required": ["timestamp", "formatted"],
-																"additionalProperties": false
+																"anyOf": [
+																	{ "type": "number" },
+																	{
+																		"type": "object",
+																		"properties": {
+																			"timestamp": { "type": "number" },
+																			"formatted": { "type": "string" }
+																		},
+																		"required": ["timestamp", "formatted"],
+																		"additionalProperties": false
+																	}
+																]
 															},
 															"log_content": {
 																"type": "array",

--- a/libs/shared/types/src/lib/log-json-schema/blocks.spec.ts
+++ b/libs/shared/types/src/lib/log-json-schema/blocks.spec.ts
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+import { describe, expect, test } from 'vitest';
+
+import { RootBlockSchema, type LogJsonTimestamp } from './blocks';
+
+const createRootBlock = (timestamp: LogJsonTimestamp) => ({
+	version: 'v1',
+	root: [
+		{
+			type: 'te-log',
+			content: [
+				{
+					type: 'te-log-table',
+					data: [
+						{
+							line_number: 1,
+							level: 'INFO',
+							entity_name: 'entity',
+							user_name: 'user',
+							timestamp,
+							log_content: [
+								{
+									type: 'te-log-table-content-text',
+									content: 'message'
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+});
+
+describe('RootBlockSchema log table timestamps', () => {
+	test('accepts legacy formatted timestamp values', () => {
+		const result = RootBlockSchema.safeParse(
+			createRootBlock({
+				timestamp: 1711228617.029961,
+				formatted: '21:16:57.029'
+			})
+		);
+
+		expect(result.success).toBe(true);
+	});
+
+	test('accepts top-level timestamp values', () => {
+		const result = RootBlockSchema.safeParse(
+			createRootBlock(1711228617.029961)
+		);
+
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects legacy timestamp objects without formatted values', () => {
+		const result = RootBlockSchema.safeParse(
+			createRootBlock({ timestamp: 1711228617.029961 } as LogJsonTimestamp)
+		);
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/libs/shared/types/src/lib/log-json-schema/blocks.ts
+++ b/libs/shared/types/src/lib/log-json-schema/blocks.ts
@@ -205,12 +205,19 @@ export type LogContentSnifferPacket = z.infer<
  |--------------------------------------------------
  */
 
-export const LogJsonTimestampSchema = z.object({
-	timestamp: z.number(),
-	formatted: z.string()
-});
+export const LogJsonTimestampSchema = z.union([
+	z.number(),
+	z.object({
+		timestamp: z.number(),
+		formatted: z.string()
+	})
+]);
 
 export type LogJsonTimestamp = z.infer<typeof LogJsonTimestampSchema>;
+
+export function getLogTimestampSeconds(timestamp: LogJsonTimestamp): number {
+	return typeof timestamp === 'number' ? timestamp : timestamp.timestamp;
+}
 
 export const LogTableDataBaseSchema = z
 	.object({


### PR DESCRIPTION
Deprecate the `formatted` field in JSON logs for displaying log message timestamps.

  `timestamp` is now the single source of truth and supports both payload shapes:

  - New format: `"timestamp": 1711228667.618432`
  - Legacy format: `"timestamp": { "timestamp": 1711228667.618432, "formatted": "21:17:47.618" }`

  The schema remains backward compatible with existing logs that still provide the legacy object format, while new logs can use the top-level numeric timestamp directly.
 
## Valid example #1
```json
{
  "line_number": 4,
  "level": "RING",
  "entity_name": "usecases\/tx_burst_simple",
  "user_name": "RCF RPC",
  "timestamp": {
    "timestamp": 1711228667.618432,
    "formatted": "21:17:47.618"
  },
  "log_content": [
    {
      "type": "te-log-table-content-text",
      "content": "RPC (DPDK,iut_rpcs) setlibname() -> 0 (OK)"
    }
  ]
}
```

## Valid example #2

```json
{
  "line_number": 4,
  "level": "RING",
  "entity_name": "usecases\/tx_burst_simple",
  "user_name": "RCF RPC",
  "timestamp": 1711228667.618432,
  "log_content": [
    {
      "type": "te-log-table-content-text",
      "content": "RPC (DPDK,iut_rpcs) setlibname() -> 0 (OK)"
    }
  ]
}
```