### PR TITLE
Fix dashboard analytics

### DIFF
--- a/apps/bublik/src/app/analytics-route-tracker.component.tsx
+++ b/apps/bublik/src/app/analytics-route-tracker.component.tsx
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import {
+	setAnalyticsEnabled,
+	trackPageView
+} from '@/bublik/features/analytics';
+import { bublikAPI } from '@/services/bublik-api';
+
+function AnalyticsRouteTracker() {
+	const location = useLocation();
+	const { data: features } = bublikAPI.useGetServerFeaturesQuery();
+	const isAnalyticsEnabled = Boolean(features?.analytics_enabled);
+
+	useEffect(() => {
+		setAnalyticsEnabled(isAnalyticsEnabled);
+	}, [isAnalyticsEnabled]);
+
+	useEffect(() => {
+		if (!isAnalyticsEnabled) return;
+
+		trackPageView({ path: location.pathname });
+	}, [isAnalyticsEnabled, location.pathname]);
+
+	return null;
+}
+
+export { AnalyticsRouteTracker };

--- a/apps/bublik/src/app/router.tsx
+++ b/apps/bublik/src/app/router.tsx
@@ -186,7 +186,7 @@ function AnalyticsRouteTracker() {
 		if (!isAnalyticsEnabled) return;
 
 		trackPageView({ path: location.pathname });
-	}, [isAnalyticsEnabled, location.key, location.pathname]);
+	}, [isAnalyticsEnabled, location.pathname]);
 
 	return null;
 }

--- a/apps/bublik/src/app/router.tsx
+++ b/apps/bublik/src/app/router.tsx
@@ -11,14 +11,10 @@ import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
 import { config } from '@/bublik/config';
-import {
-	setAnalyticsEnabled,
-	trackPageView
-} from '@/bublik/features/analytics';
 import { ErrorBoundary } from '@/shared/tailwind-ui';
-import { bublikAPI } from '@/services/bublik-api';
 
 import { AuthLayout } from '../pages/auth/auth.layout';
+import { AnalyticsRouteTracker } from './analytics-route-tracker.component';
 import { Layout } from './layout';
 import { RedirectToDashboard, RedirectToLogPage } from './redirects';
 
@@ -171,24 +167,6 @@ function LazyRoute({ children }: { children: React.ReactNode }) {
 	return (
 		<Suspense fallback={<Spinner className="h-48" />}>{children}</Suspense>
 	);
-}
-
-function AnalyticsRouteTracker() {
-	const location = useLocation();
-	const { data: features } = bublikAPI.useGetServerFeaturesQuery();
-	const isAnalyticsEnabled = Boolean(features?.analytics_enabled);
-
-	useEffect(() => {
-		setAnalyticsEnabled(isAnalyticsEnabled);
-	}, [isAnalyticsEnabled]);
-
-	useEffect(() => {
-		if (!isAnalyticsEnabled) return;
-
-		trackPageView({ path: location.pathname });
-	}, [isAnalyticsEnabled, location.pathname]);
-
-	return null;
 }
 
 /**


### PR DESCRIPTION
Remove `location.key` tracking since it's triggered on
search parameters change so it produces a lot of
excessive events.