### PR TITLE
fix(log): fix duplicate log JSON requests

### DIFF
--- a/libs/bublik/features/log/src/lib/containers/log-container/log-container.tsx
+++ b/libs/bublik/features/log/src/lib/containers/log-container/log-container.tsx
@@ -184,7 +184,9 @@ const JsonLog = (props: JsonLogProps) => {
 	const idToFetch = isShowingRunLog
 		? { id: runId }
 		: focusId
-		? { id: focusId, page }
+		? page
+			? { id: focusId, page }
+			: { id: focusId }
 		: skipToken;
 
 	const { data, isLoading, isFetching, error } = useGetLogJsonQuery(idToFetch);

--- a/libs/services/bublik-api/src/lib/endpoints/log-endpoint.spec.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/log-endpoint.spec.ts
@@ -1,7 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
 import { describe, expect } from 'vitest';
-import { constructJsonUrl } from './log-endpoints';
+import { constructJsonUrl, normalizeLogJsonInput } from './log-endpoints';
+
 describe('constructJsonUrl', () => {
 	test('it constructs the correct URL without page', () => {
 		const inputWithoutPage = { id: '1' };
@@ -14,5 +15,25 @@ describe('constructJsonUrl', () => {
 		const result = constructJsonUrl(inputWithPage);
 		const expectedUrl = '/api/v2/logs/1/json/?page=2';
 		expect(result).toBe(expectedUrl);
+	});
+
+	test('it constructs the same URL for null and omitted page', () => {
+		const resultWithNullPage = constructJsonUrl({ id: '1', page: null });
+		const resultWithoutPage = constructJsonUrl({ id: '1' });
+
+		expect(resultWithNullPage).toBe(resultWithoutPage);
+	});
+});
+
+describe('normalizeLogJsonInput', () => {
+	test('it removes null page from log json query args', () => {
+		expect(normalizeLogJsonInput({ id: '1', page: null })).toEqual({ id: '1' });
+	});
+
+	test('it preserves actual page values', () => {
+		expect(normalizeLogJsonInput({ id: '1', page: 2 })).toEqual({
+			id: '1',
+			page: 2
+		});
 	});
 });

--- a/libs/services/bublik-api/src/lib/endpoints/log-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/log-endpoints.ts
@@ -124,6 +124,16 @@ type LogUrlResponse = {
 	attachments_url: string;
 };
 
+export const normalizeLogJsonInput = (
+	input: GetLogJsonInputs
+): GetLogJsonInputs => {
+	const page = input.page ?? undefined;
+
+	return typeof page === 'undefined'
+		? { id: input.id }
+		: { id: input.id, page };
+};
+
 export const constructJsonUrl = (input: GetLogJsonInputs): string => {
 	const PREFIX = '/api/v2';
 
@@ -136,12 +146,19 @@ export const constructJsonUrl = (input: GetLogJsonInputs): string => {
 	return result;
 };
 
-const fetchJson = async (externalUrl: string) => {
+const fetchJson = async <T = unknown>(
+	externalUrl: string,
+	signal?: AbortSignal
+): Promise<T> => {
 	const getBublikFromStatusCode = (response: Response): BublikHttpError => {
-		return { status: response.status };
+		return { status: response.status, data: response.statusText };
 	};
 
-	const options: RequestInit = { credentials: 'include', cache: 'no-store' };
+	const options: RequestInit = {
+		credentials: 'include',
+		cache: 'no-store',
+		signal
+	};
 
 	const response = await fetch(externalUrl, options);
 
@@ -191,7 +208,9 @@ export const logEndpoints = {
 						};
 					}
 
-					const attachmentsJson = await fetchJson(jsonUrl.data.attachments_url);
+					const attachmentsJson = await fetchJson<
+						z.infer<typeof AttachmentsSchema>
+					>(jsonUrl.data.attachments_url);
 
 					return {
 						data: {
@@ -218,7 +237,9 @@ export const logEndpoints = {
 			}
 		}),
 		getLogJson: build.query<RootBlock, GetLogJsonInputs>({
-			queryFn: async ({ page, id }, api, _extraOptions, baseQuery) => {
+			serializeQueryArgs: ({ queryArgs }) => normalizeLogJsonInput(queryArgs),
+			queryFn: async (input, api, _extraOptions, baseQuery) => {
+				const { page, id } = normalizeLogJsonInput(input);
 				const getUrl = constructJsonUrl({ page, id });
 
 				const jsonUrl = (await baseQuery(
@@ -238,15 +259,17 @@ export const logEndpoints = {
 
 				try {
 					const [blocksJson, artifactsAndVerdicts] = (await Promise.all([
-						fetchJson(jsonUrl.data.url),
+						fetchJson<RootBlock>(jsonUrl.data.url, api.signal),
 						baseQuery(withApiV2(`/results/${id}/artifacts_and_verdicts`))
 					])) as [RootBlock, QueryReturnValue<ResultsAndVerdictsForIteration>];
 
-					const blocksWithAddedVerdictsAndArtifacts = addArtifactsVerdicts(
-						blocksJson,
-						// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-						artifactsAndVerdicts.data!
-					);
+					if (artifactsAndVerdicts.error) {
+						console.error(artifactsAndVerdicts.error);
+					}
+
+					const blocksWithAddedVerdictsAndArtifacts = artifactsAndVerdicts.data
+						? addArtifactsVerdicts(blocksJson, artifactsAndVerdicts.data)
+						: blocksJson;
 
 					const result = fixPagesCountForAllView(
 						blocksWithAddedVerdictsAndArtifacts,


### PR DESCRIPTION
Normalize getLogJson query args so omitted and null pages share the same RTK Query cache entry, preventing the main log view and New Bug button from fetching the same node JSON twice.

Abort stale external log JSON fetches on rapid selection changes and keep log rendering resilient when artifacts/verdicts enrichment fails.