### PR TITLE
Update run results API filtering

### DIFF
--- a/libs/bublik/features/run-diff/src/lib/result-diff/result-diff.container.tsx
+++ b/libs/bublik/features/run-diff/src/lib/result-diff/result-diff.container.tsx
@@ -31,7 +31,7 @@ const getQueries = ({
 				selectors: [
 					{
 						parentId: left.parent_id ?? left.result_id,
-						startTirId: left.result_id
+						startExecSeqno: left.exec_seqno
 					}
 				],
 				testName: left.test_name,
@@ -46,7 +46,7 @@ const getQueries = ({
 				selectors: [
 					{
 						parentId: right.parent_id ?? right.result_id,
-						startTirId: right.result_id
+						startExecSeqno: right.exec_seqno
 					}
 				],
 				testName: right.test_name,

--- a/libs/bublik/features/run/src/lib/result-table/result-table.container.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.container.tsx
@@ -23,7 +23,7 @@ function getResultSelectors(row: Row<RunData | MergedRun>) {
 		: [
 				{
 					parentId: row.original.parent_id ?? row.original.result_id,
-					startTirId: row.original.result_id
+					startExecSeqno: row.original.exec_seqno
 				}
 		  ];
 }

--- a/libs/services/bublik-api/src/lib/endpoints/run-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/run-endpoints.ts
@@ -54,6 +54,29 @@ export interface Verdict {
 	comment: string;
 }
 
+export function buildResultsTableParams({
+	selector,
+	testName,
+	results,
+	resultProperties
+}: {
+	selector: ResultTableAPIQueryWithFilter['selectors'][number];
+	testName: string;
+	results: string;
+	resultProperties: string;
+}): Record<string, string | number> {
+	const params: Record<string, string | number> = {
+		parent_id: selector.parentId,
+		test_name: testName,
+		start_exec_seqno: selector.startExecSeqno
+	};
+
+	if (results) params.results = results;
+	if (resultProperties) params.result_properties = resultProperties;
+
+	return params;
+}
+
 /**
  * Merges runs based on test_id and exec_seqno
  * @param runs - Top most packages of runs that contain children
@@ -83,7 +106,7 @@ export function mergeRuns(runs: Array<[number, RunData]>): Array<MergedRun> {
 		mergedNode.parent_ids = mergeIds(parentIds);
 		mergedNode.result_selectors = nodes.map((node) => ({
 			parentId: node.parent_id ?? node.result_id,
-			startTirId: node.result_id
+			startExecSeqno: node.exec_seqno
 		}));
 		mergedNode.stats = mergeStats(nodes.map((node) => node.stats));
 
@@ -177,16 +200,12 @@ export const runEndpoints = {
 							const resultProperties = props.resultProperties.join(
 								config.queryDelimiter
 							);
-							const params: Record<string, string | number> = {
-								parent_id: selector.parentId,
-								test_name: testName,
-								start_tir_id: selector.startTirId
-							};
-
-							if (results) params.results = results;
-							if (resultProperties) {
-								params.result_properties = resultProperties;
-							}
+							const params = buildResultsTableParams({
+								selector,
+								testName,
+								results,
+								resultProperties
+							});
 
 							return fetchWithBQ({
 								url: withApiV2('/results'),

--- a/libs/shared/types/src/lib/run.ts
+++ b/libs/shared/types/src/lib/run.ts
@@ -75,7 +75,7 @@ export type RunPageParams = {
 export type ResultTableAPIQuery = {
 	selectors: {
 		parentId: number;
-		startTirId: number;
+		startExecSeqno: number;
 	}[];
 	testName: string;
 };


### PR DESCRIPTION
## Summary

- update run result selectors to use `exec_seqno` as the start marker
- send `start_exec_seqno` to `GET /api/v2/results/` instead of the removed `start_tir_id`

## Why

Backend PR ts-factory/bublik#316 changes result filtering to use execution sequence numbers so repeated same-named tests are grouped by actual run execution order instead of internal result IDs.