### PR TITLE
fix(log): adjust objective text wrapping in log metadata

### DIFF
--- a/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-meta/log-meta.tsx
+++ b/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-meta/log-meta.tsx
@@ -490,7 +490,7 @@ function MetaInfoItem(props: MetaInfoItemProps) {
 				<div className={cn('flex items-start gap-1 min-w-0 pr-8')}>
 					<pre
 						className={cn(
-							'text-sm text-gray-800 whitespace-pre-wrap break-all',
+							'text-sm text-gray-800 whitespace-pre-wrap break-words',
 							className
 						)}
 					>


### PR DESCRIPTION
Long objective values in session log metadata were using `break-all`, which allowed browsers to split normal words at arbitrary character positions. This made objectives difficult to read, especially when a word was broken after only one character.

Use `break-words` instead while keeping whitespace-pre-wrap, so explicit newlines are preserved and normal text wraps at word boundaries.