### PR TITLE
feat(runs): focus single test suite in runs progress

### DIFF
--- a/libs/bublik/features/runs/src/lib/runs-progress/runs-progress.component.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-progress/runs-progress.component.tsx
@@ -70,6 +70,7 @@ import { formatTimestampToFull } from '@/shared/utils';
 import {
 	RunsProgressFilterSummary,
 	RunsProgressGroup,
+	RunsProgressPackage,
 	RunsProgressRow,
 	RunsProgressRun,
 	RunsProgressTrendDirection
@@ -314,6 +315,9 @@ interface RunsProgressProps {
 	onTimeFrameDaysChange: (timeFrameDays: number | null) => void;
 	availableGroupKeys: string[];
 	onGroupKeyChange: (groupKey: string | null) => void;
+	packages: RunsProgressPackage[];
+	selectedPackage: string | null;
+	onSelectedPackageChange: (packageName: string | null) => void;
 	filters: RunsProgressFilterSummary[];
 	isFetching?: boolean;
 	isCapped?: boolean;
@@ -332,6 +336,9 @@ function RunsProgress(props: RunsProgressProps) {
 		onTimeFrameDaysChange,
 		availableGroupKeys,
 		onGroupKeyChange,
+		packages,
+		selectedPackage,
+		onSelectedPackageChange,
 		isFetching,
 		isCapped,
 		total,
@@ -647,6 +654,13 @@ function RunsProgress(props: RunsProgressProps) {
 							<Separator orientation="vertical" className="h-4" />
 							<Legend />
 							<Separator orientation="vertical" className="h-4" />
+							{packages.length > 1 ? (
+								<PackageMenu
+									packages={packages}
+									selectedPackage={selectedPackage}
+									onSelectedPackageChange={onSelectedPackageChange}
+								/>
+							) : null}
 							<GroupByMenu
 								groupKey={groupKey}
 								timeFrameDays={timeFrameDays}
@@ -654,13 +668,25 @@ function RunsProgress(props: RunsProgressProps) {
 								availableGroupKeys={availableGroupKeys}
 								onGroupKeyChange={onGroupKeyChange}
 							/>
-							{isCapped ? (
+							{packages.length > 1 ? (
 								<>
 									<Separator orientation="vertical" className="h-4" />
 									<span className="inline-flex items-center gap-1 text-[11px] font-medium text-text-unexpected">
 										<Icon name="InformationCircleExclamationMark" size={12} />
-										Showing the latest {cap} of {total} runs — select a date
-										range or duration to view all.
+										Runs span {packages.length} suites — showing{' '}
+										{selectedPackage} (
+										{packages.find((pkg) => pkg.name === selectedPackage)
+											?.runCount ?? 0}
+										). Narrow by a meta filter or a project.
+									</span>
+								</>
+							) : isCapped ? (
+								<>
+									<Separator orientation="vertical" className="h-4" />
+									<span className="inline-flex items-center gap-1 text-[11px] font-medium text-text-unexpected">
+										<Icon name="InformationCircleExclamationMark" size={12} />
+										Showing latest {cap} of {total} runs — pick a date range or
+										duration for all.
 									</span>
 								</>
 							) : null}
@@ -1338,6 +1364,53 @@ function GroupByMenu({
 						</DropdownMenuRadioGroup>
 					</>
 				) : null}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
+function PackageMenu({
+	packages,
+	selectedPackage,
+	onSelectedPackageChange
+}: {
+	packages: RunsProgressPackage[];
+	selectedPackage: string | null;
+	onSelectedPackageChange: (packageName: string | null) => void;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild>
+				<ButtonTw variant="secondary" size="xss" state={isOpen && 'active'}>
+					<Icon name="Folder" size={20} className="mr-1.5" />
+					{selectedPackage ?? 'Suite'}
+					<Icon name="ArrowShortSmall" className="ml-1.5" />
+				</ButtonTw>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent collisionPadding={{ right: 15 }} className="w-64">
+				<DropdownMenuLabel className="text-xs">Test Suite</DropdownMenuLabel>
+				<Separator className="h-px my-1 -mx-1" />
+				<DropdownMenuRadioGroup
+					value={selectedPackage ?? ''}
+					onValueChange={(value) => onSelectedPackageChange(value || null)}
+				>
+					{packages.map((pkg) => (
+						<DropdownMenuRadioItem
+							key={pkg.name}
+							value={pkg.name}
+							className="text-xs"
+						>
+							<span className="flex min-w-0 flex-1 items-center justify-between gap-2">
+								<span className="truncate">{pkg.name}</span>
+								<span className="shrink-0 text-text-secondary tabular-nums">
+									{pkg.runCount}
+								</span>
+							</span>
+						</DropdownMenuRadioItem>
+					))}
+				</DropdownMenuRadioGroup>
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/libs/bublik/features/runs/src/lib/runs-progress/runs-progress.container.tsx
+++ b/libs/bublik/features/runs/src/lib/runs-progress/runs-progress.container.tsx
@@ -14,9 +14,11 @@ import {
 import { useRunsProgressRuns } from './runs-progress.hooks';
 import {
 	buildFilterSummary,
+	buildPackageSummaries,
 	buildRunsProgressRows,
 	filterRunsByDateWindow,
 	getMetadataKeys,
+	getRunPackageName,
 	groupRuns,
 	sortRunsNewestFirst
 } from './runs-progress.utils';
@@ -27,6 +29,7 @@ function RunsProgressContainer() {
 	const [searchParams] = useSearchParams();
 	const [groupKey, setGroupKey] = useState<string | null>(null);
 	const [timeFrameDays, setTimeFrameDays] = useState<number | null>(null);
+	const [selectedPackage, setSelectedPackage] = useState<string | null>(null);
 	const runsQuery = useRunsProgressRuns();
 	const { query } = useRunsQuery();
 
@@ -73,9 +76,28 @@ function RunsProgressContainer() {
 		() => getMetadataKeys(sortedRuns),
 		[sortedRuns]
 	);
+
+	const packages = useMemo(
+		() => buildPackageSummaries(progressRuns),
+		[progressRuns]
+	);
+	const effectivePackage =
+		selectedPackage && packages.some((pkg) => pkg.name === selectedPackage)
+			? selectedPackage
+			: packages[0]?.name ?? null;
+	const focusedRuns = useMemo(
+		() =>
+			effectivePackage
+				? progressRuns.filter(
+						(run) => getRunPackageName(run.root) === effectivePackage
+				  )
+				: progressRuns,
+		[progressRuns, effectivePackage]
+	);
+
 	const { orderedRuns, groups, timeGroups } = useMemo(
-		() => groupRuns(progressRuns, { timeFrameDays, metaKey: groupKey }),
-		[progressRuns, timeFrameDays, groupKey]
+		() => groupRuns(focusedRuns, { timeFrameDays, metaKey: groupKey }),
+		[focusedRuns, timeFrameDays, groupKey]
 	);
 	const rows = useMemo(() => buildRunsProgressRows(orderedRuns), [orderedRuns]);
 	const filters = useMemo(
@@ -104,6 +126,9 @@ function RunsProgressContainer() {
 			onTimeFrameDaysChange={setTimeFrameDays}
 			availableGroupKeys={availableGroupKeys}
 			onGroupKeyChange={setGroupKey}
+			packages={packages}
+			selectedPackage={effectivePackage}
+			onSelectedPackageChange={setSelectedPackage}
 			filters={filters}
 			isFetching={runsQuery.isFetching || statsQuery.isFetching}
 			isCapped={runsQuery.isCapped}

--- a/libs/bublik/features/runs/src/lib/runs-progress/runs-progress.types.ts
+++ b/libs/bublik/features/runs/src/lib/runs-progress/runs-progress.types.ts
@@ -46,6 +46,11 @@ type RunsProgressGroup = {
 	runCount: number;
 };
 
+type RunsProgressPackage = {
+	name: string;
+	runCount: number;
+};
+
 type RunsProgressFilterSummary = {
 	label: string;
 	value: string;
@@ -55,6 +60,7 @@ export type {
 	RunsProgressCell,
 	RunsProgressFilterSummary,
 	RunsProgressGroup,
+	RunsProgressPackage,
 	RunsProgressRow,
 	RunsProgressRun,
 	RunsProgressTrend,

--- a/libs/bublik/features/runs/src/lib/runs-progress/runs-progress.utils.spec.ts
+++ b/libs/bublik/features/runs/src/lib/runs-progress/runs-progress.utils.spec.ts
@@ -6,6 +6,7 @@ import { NodeEntity, RunData, RunsData, RUN_STATUS } from '@/shared/types';
 
 import {
 	buildFilterSummary,
+	buildPackageSummaries,
 	buildRunsProgressRows,
 	filterChangedRows,
 	filterRunsByDateWindow,
@@ -246,6 +247,43 @@ describe('runs progress utils', () => {
 		expect(filtered[0].id).toBe('root');
 		expect(filtered[0].children).toHaveLength(1);
 		expect(filtered[0].children[0].id).toBe('changed-child');
+	});
+
+	describe('buildPackageSummaries', () => {
+		function rootNamed(name: string): RunData {
+			return { ...createRoot(), test_name: name };
+		}
+
+		it('counts runs per package, ordered by first appearance', () => {
+			expect(
+				buildPackageSummaries([
+					{
+						run: createRun(3, '2024-01-03T00:00:00Z'),
+						root: rootNamed('ipv6')
+					},
+					{
+						run: createRun(2, '2024-01-02T00:00:00Z'),
+						root: rootNamed('perf')
+					},
+					{ run: createRun(1, '2024-01-01T00:00:00Z'), root: rootNamed('ipv6') }
+				])
+			).toEqual([
+				{ name: 'ipv6', runCount: 2 },
+				{ name: 'perf', runCount: 1 }
+			]);
+		});
+
+		it('returns a single entry when every run shares a package', () => {
+			expect(
+				buildPackageSummaries([
+					{
+						run: createRun(2, '2024-01-02T00:00:00Z'),
+						root: rootNamed('ipv6')
+					},
+					{ run: createRun(1, '2024-01-01T00:00:00Z'), root: rootNamed('ipv6') }
+				])
+			).toEqual([{ name: 'ipv6', runCount: 2 }]);
+		});
 	});
 
 	it('collects distinct metadata keys sorted', () => {

--- a/libs/bublik/features/runs/src/lib/runs-progress/runs-progress.utils.ts
+++ b/libs/bublik/features/runs/src/lib/runs-progress/runs-progress.utils.ts
@@ -8,6 +8,7 @@ import { formatTimeToAPI } from '@/shared/utils';
 import {
 	RunsProgressFilterSummary,
 	RunsProgressGroup,
+	RunsProgressPackage,
 	RunsProgressRow,
 	RunsProgressRun,
 	RunsProgressTrend,
@@ -227,6 +228,22 @@ function getMetadataKeys(runs: RunsData[]): string[] {
 	});
 
 	return Array.from(keys).sort((left, right) => left.localeCompare(right));
+}
+
+function getRunPackageName(root: RunData): string {
+	return root.test_name;
+}
+
+function buildPackageSummaries(runs: RunsProgressRun[]): RunsProgressPackage[] {
+	const countByName = new Map<string, number>();
+
+	runs.forEach(({ root }) => {
+		const name = getRunPackageName(root);
+
+		countByName.set(name, (countByName.get(name) ?? 0) + 1);
+	});
+
+	return Array.from(countByName, ([name, runCount]) => ({ name, runCount }));
 }
 
 function getRunGroupValue(run: RunsData, key: string): string | null {
@@ -567,6 +584,7 @@ export type { MetricChange, MetricDelta, MetricDeltaStatus };
 
 export {
 	buildFilterSummary,
+	buildPackageSummaries,
 	buildRunsProgressRows,
 	filterChangedRows,
 	filterRunsByDateWindow,
@@ -578,6 +596,7 @@ export {
 	getMetricToneClassName,
 	getNodeStats,
 	getRunGroupValue,
+	getRunPackageName,
 	getStatsTotal,
 	getUnexpectedTotal,
 	groupRuns,


### PR DESCRIPTION
The Runs Progress grid aligns rows across runs by their root node key, so when the loaded runs span more than one test suite/package the grid rendered multiple disjoint top-level rows. Runs of suite A showed "No data" under suite B's rows and vice versa, making the side-by-side trend meaningless.

Detect distinct packages in the container (from each run's stats root, since RunsData carries no package field), auto-focus the newest run's suite, and filter both the rows and run columns down to it. Surface a header suite switcher and a hint banner pointing users to narrow further via TS_NAME meta or a project selection in the sidebar. A single-suite list is unaffected.