### PR TITLE
feat: dynamic result classification (UI)

### DIFF
--- a/apps/bublik/src/app/router.tsx
+++ b/apps/bublik/src/app/router.tsx
@@ -20,6 +20,7 @@ import { RedirectToDashboard, RedirectToLogPage } from './redirects';
 
 import { AdminAnalyticsPage } from '../pages/admin-analytics';
 import { AuthLayout } from '../pages/auth/auth.layout';
+import { AdminIssuesPage } from '../pages/admin-issues';
 import { AdminUsersPage } from '../pages/admin-users/admin-users.page';
 import { ConfigsPage } from '../pages/configs/configs.page';
 import { DashboardPageV2 } from '../pages/dashboard-page/dashboard-page-v2';
@@ -317,6 +318,10 @@ const router = createBrowserRouter(
 								{
 									path: 'analytics',
 									element: <AdminAnalyticsPage />
+								},
+								{
+									path: 'issues',
+									element: <AdminIssuesPage />
 								},
 								{
 									path: 'config',

--- a/apps/bublik/src/app/router.tsx
+++ b/apps/bublik/src/app/router.tsx
@@ -83,6 +83,12 @@ const RunReportPage = lazy(() =>
 	}))
 );
 
+const RunIssuesPage = lazy(() =>
+	import('../pages/run-issues/run-issues.page').then((module) => ({
+		default: module.RunIssuesPage
+	}))
+);
+
 function BublikCommand() {
 	const [open, setOpen] = useState(false);
 	const navigate = useNavigateWithProject();
@@ -271,6 +277,14 @@ const router = createBrowserRouter(
 							element: (
 								<LazyRoute>
 									<RunReportPage />
+								</LazyRoute>
+							)
+						},
+						{
+							path: '/runs/:runId/issues',
+							element: (
+								<LazyRoute>
+									<RunIssuesPage />
 								</LazyRoute>
 							)
 						},

--- a/apps/bublik/src/app/router.tsx
+++ b/apps/bublik/src/app/router.tsx
@@ -21,6 +21,7 @@ import { RedirectToDashboard, RedirectToLogPage } from './redirects';
 import { AdminAnalyticsPage } from '../pages/admin-analytics';
 import { AuthLayout } from '../pages/auth/auth.layout';
 import { AdminIssuesPage } from '../pages/admin-issues';
+import { IssueRulesPage } from '../pages/issue-rules';
 import { AdminUsersPage } from '../pages/admin-users/admin-users.page';
 import { ConfigsPage } from '../pages/configs/configs.page';
 import { DashboardPageV2 } from '../pages/dashboard-page/dashboard-page-v2';
@@ -336,6 +337,10 @@ const router = createBrowserRouter(
 								{
 									path: 'issues',
 									element: <AdminIssuesPage />
+								},
+								{
+									path: 'issues/:issueId',
+									element: <IssueRulesPage />
 								},
 								{
 									path: 'config',

--- a/apps/bublik/src/pages/admin-issues/admin-issues.page.tsx
+++ b/apps/bublik/src/pages/admin-issues/admin-issues.page.tsx
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { IssuesTable } from '@/bublik/features/result-classification';
+
+export const AdminIssuesPage = () => {
+	return (
+		<div className="flex flex-col p-2">
+			<header className="px-6 py-4 bg-white rounded-t-xl">
+				<h1 className="text-xl font-semibold">Issues</h1>
+			</header>
+			<main className="p-4 bg-white rounded-b-xl">
+				<IssuesTable />
+			</main>
+		</div>
+	);
+};

--- a/apps/bublik/src/pages/admin-issues/index.ts
+++ b/apps/bublik/src/pages/admin-issues/index.ts
@@ -1,0 +1,2 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+export * from './admin-issues.page';

--- a/apps/bublik/src/pages/issue-rules/index.ts
+++ b/apps/bublik/src/pages/issue-rules/index.ts
@@ -1,0 +1,2 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+export * from './issue-rules.page';

--- a/apps/bublik/src/pages/issue-rules/issue-rules.page.tsx
+++ b/apps/bublik/src/pages/issue-rules/issue-rules.page.tsx
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { useParams } from 'react-router-dom';
+
+import { IssueRulesTable } from '@/bublik/features/result-classification';
+import { useProjectSearch, LinkWithProject } from '@/bublik/features/projects';
+import { Icon } from '@/shared/tailwind-ui';
+import { BublikEmptyState } from '@/bublik/features/ui-state';
+
+export const IssueRulesPage = () => {
+	const { issueId } = useParams<{ issueId: string }>();
+	const { projectIds } = useProjectSearch();
+	const projectId = projectIds[0];
+
+	if (!issueId) {
+		return <BublikEmptyState title="No data" description="Issue ID is missing" />;
+	}
+
+	return (
+		<div className="flex flex-col p-2">
+			<header className="px-6 py-4 bg-white rounded-t-xl">
+				<LinkWithProject
+					to="/admin/issues"
+					className="inline-flex items-center gap-1 text-sm text-text-menu hover:text-primary"
+				>
+					<Icon name="ArrowShortSmall" className="rotate-90" size={14} />
+					Issues
+				</LinkWithProject>
+			</header>
+			<main className="p-4 bg-white rounded-b-xl">
+				<IssueRulesTable issueId={Number(issueId)} projectId={projectId} />
+			</main>
+		</div>
+	);
+};

--- a/apps/bublik/src/pages/issue-rules/issue-rules.page.tsx
+++ b/apps/bublik/src/pages/issue-rules/issue-rules.page.tsx
@@ -12,7 +12,9 @@ export const IssueRulesPage = () => {
 	const projectId = projectIds[0];
 
 	if (!issueId) {
-		return <BublikEmptyState title="No data" description="Issue ID is missing" />;
+		return (
+			<BublikEmptyState title="No data" description="Issue ID is missing" />
+		);
 	}
 
 	return (

--- a/apps/bublik/src/pages/run-issues/index.ts
+++ b/apps/bublik/src/pages/run-issues/index.ts
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2026 OKTET LTD */
+export { RunIssuesPage } from './run-issues.page';

--- a/apps/bublik/src/pages/run-issues/run-issues.page.tsx
+++ b/apps/bublik/src/pages/run-issues/run-issues.page.tsx
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2026 OKTET LTD */
+import { skipToken } from '@reduxjs/toolkit/query';
+import { useParams } from 'react-router-dom';
+
+import { RunIssuesTable } from '@/bublik/features/result-classification';
+import { useGetRunDetailsQuery } from '@/services/bublik-api';
+import { BublikEmptyState } from '@/bublik/features/ui-state';
+
+function RunIssuesPage() {
+	const { runId } = useParams<{ runId: string }>();
+	const { data: details } = useGetRunDetailsQuery(
+		runId ? Number(runId) : skipToken
+	);
+
+	if (!runId) {
+		return <BublikEmptyState title="No data" description="Run ID is missing" />;
+	}
+
+	return (
+		<div className="flex flex-col gap-1 p-2">
+			<RunIssuesTable runId={runId} projectId={details?.project_id} />
+		</div>
+	);
+}
+
+export { RunIssuesPage };

--- a/apps/bublik/src/pages/run-page/run-page.tsx
+++ b/apps/bublik/src/pages/run-page/run-page.tsx
@@ -71,6 +71,12 @@ const RunHeader = ({ runId }: RunHeaderProps) => {
 							Log
 						</LinkWithProject>
 					</ButtonTw>
+					<ButtonTw asChild variant="secondary" size="xss">
+						<LinkWithProject to={`/runs/${runId}/issues`}>
+							<Icon name="TriangleExclamationMark" className="mr-1.5" />
+							Issues
+						</LinkWithProject>
+					</ButtonTw>
 					<NewBugContainer runId={Number(runId)} resultId={Number(runId)} />
 					<CopyShortUrlButtonContainer />
 				</div>

--- a/libs/bublik/features/admin-users/src/lib/sidebar/admin-sidebar-nav.tsx
+++ b/libs/bublik/features/admin-users/src/lib/sidebar/admin-sidebar-nav.tsx
@@ -58,6 +58,19 @@ export function AdminSidebarNav() {
 					</SidebarNavSubmenuItemContainer.Label>
 				</SidebarNavSubmenuItemContainer>
 				<SidebarNavSubmenuItemContainer
+					to="/admin/issues"
+					pattern={{ path: '/admin/issues' }}
+					linkComponent={LinkWithProject}
+				>
+					<SidebarNavSubmenuItemContainer.Icon
+						name="TriangleExclamationMark"
+						size={24}
+					/>
+					<SidebarNavSubmenuItemContainer.Label>
+						Issues
+					</SidebarNavSubmenuItemContainer.Label>
+				</SidebarNavSubmenuItemContainer>
+				<SidebarNavSubmenuItemContainer
 					to="/admin/import"
 					pattern={{ path: '/admin/import' }}
 					linkComponent={LinkWithProject}

--- a/libs/bublik/features/history/src/lib/history-filter-legend/history-filter-legend.container.utils.ts
+++ b/libs/bublik/features/history/src/lib/history-filter-legend/history-filter-legend.container.utils.ts
@@ -131,6 +131,18 @@ export const getLegendItems = (search: HistoryAPIQuery): LegendItem[] => {
 			iconSize: 24,
 			label: 'Parameters Expression',
 			value: state.testArgExpr
+		},
+		{
+			iconName: 'PaperShort',
+			iconSize: 24,
+			label: 'Categories',
+			value: state.categories
+		},
+		{
+			iconName: 'TriangleExclamationMark',
+			iconSize: 24,
+			label: 'Untriaged Unexpected',
+			value: state.untriaged ? 'Yes' : undefined
 		}
 	];
 

--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.component.tsx
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.component.tsx
@@ -18,7 +18,8 @@ import {
 	TestSection,
 	RunSection,
 	ResultSection,
-	VerdictSection
+	VerdictSection,
+	ClassificationSection
 } from './sections';
 
 export interface GlobalSearchFormProps {
@@ -72,6 +73,7 @@ export const GlobalSearchForm = (props: GlobalSearchFormProps) => {
 						<VerdictSection
 							onResetVerdictSectionClick={form.resetVerdictSection}
 						/>
+						<ClassificationSection />
 						<StickySubmit
 							onResetClick={form.resetForm}
 							isScrollable={isVisible}

--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.types.ts
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.types.ts
@@ -46,6 +46,9 @@ export interface HistoryGlobalSearchFormValues {
 	labels: BadgeItem[];
 	labelExpr: string;
 	verdictLookup: VERDICT_TYPE;
+	/* Classification section */
+	categories: string[];
+	untriaged: boolean;
 }
 
 export const defaultValues: HistoryGlobalSearchFormValues = {
@@ -68,5 +71,7 @@ export const defaultValues: HistoryGlobalSearchFormValues = {
 	verdictExpr: '',
 	revisionExpr: '',
 	testArgExpr: '',
-	labelExpr: ''
+	labelExpr: '',
+	categories: [],
+	untriaged: false
 };

--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.utils.ts
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.utils.ts
@@ -162,6 +162,8 @@ export const getInitialGlobalSearch = (
 		),
 		results: split(queryResults, HISTORY_CONSTANTS.results),
 		verdictLookup: queryVerdictLookup || HISTORY_CONSTANTS.verdict,
-		verdict: valuesToBadges(queryVerdict, [])
+		verdict: valuesToBadges(queryVerdict, []),
+		categories: split(historyQuery.categories, []),
+		untriaged: historyQuery.untriaged === 'true'
 	};
 };

--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/classification-section.tsx
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/classification-section.tsx
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+import { useFormContext } from 'react-hook-form';
+
+import { CheckboxField } from '@/shared/tailwind-ui';
+
+import { FormSection, FormSectionSubheader } from '../components';
+import { HistoryGlobalSearchFormValues } from '../global-search-form.types';
+
+/** Mirrors the backend IssueCategory values (Plan 2). */
+const CATEGORY_OPTIONS: { value: string; label: string }[] = [
+	{ value: 'product-defect', label: 'Product defect' },
+	{ value: 'test-bug', label: 'Test/automation bug' },
+	{ value: 'env', label: 'Environment / infra' },
+	{ value: 'known-issue', label: 'Known issue' },
+	{ value: 'flaky', label: 'Flaky / intermittent' },
+	{ value: 'to-investigate', label: 'To investigate' }
+];
+
+export const ClassificationSection = () => {
+	const { control } = useFormContext<HistoryGlobalSearchFormValues>();
+
+	return (
+		<FormSection>
+			<FormSection.Bar className="bg-bg-warning" />
+			<div className="mb-5">
+				<FormSection.Header className="mb-0" name="Classification" />
+				<FormSectionSubheader name="Triage state" />
+				<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+					<CheckboxField
+						iconName="TriangleExclamationMark"
+						iconSize={16}
+						name="untriaged"
+						label="Untriaged unexpected only"
+						control={control}
+					/>
+				</div>
+			</div>
+			<div>
+				<FormSectionSubheader name="Category" />
+				<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+					{CATEGORY_OPTIONS.map((option) => (
+						<CheckboxField
+							key={option.value}
+							iconName="TriangleQuestionMark"
+							iconSize={16}
+							name="categories"
+							value={option.value}
+							label={option.label}
+							control={control}
+						/>
+					))}
+				</div>
+			</div>
+		</FormSection>
+	);
+};

--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/index.ts
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/sections/index.ts
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+export * from './classification-section';
 export * from './result-section';
 export * from './run-section';
 export * from './test-section';

--- a/libs/bublik/features/history/src/lib/history-linear/column-components/index.ts
+++ b/libs/bublik/features/history/src/lib/history-linear/column-components/index.ts
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+export * from './issue-badges';
 export * from './run-time';
 export * from './links';

--- a/libs/bublik/features/history/src/lib/history-linear/column-components/issue-badges/index.ts
+++ b/libs/bublik/features/history/src/lib/history-linear/column-components/issue-badges/index.ts
@@ -1,0 +1,2 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+export * from './issue-badges';

--- a/libs/bublik/features/history/src/lib/history-linear/column-components/issue-badges/issue-badges.tsx
+++ b/libs/bublik/features/history/src/lib/history-linear/column-components/issue-badges/issue-badges.tsx
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import type { ResultIssueRef } from '@/shared/types';
+import { Badge } from '@/shared/tailwind-ui';
+
+export interface IssueBadgesProps {
+	issues?: ResultIssueRef[];
+}
+
+/** Issue key + category badges for classifications stamped on a result,
+ * shown under the obtained result. */
+export function IssueBadges({ issues }: IssueBadgesProps) {
+	if (!issues || issues.length === 0) return null;
+
+	return (
+		<div className="flex flex-wrap gap-1 mt-1">
+			{issues.map((issue) => (
+				<Badge
+					key={issue.rule_id}
+					variant={issue.expected ? 'expected' : 'unexpected'}
+					title={issue.issue_title}
+				>
+					{(issue.bug_key ?? `#${issue.issue_id}`) + ' · ' + issue.category}
+				</Badge>
+			))}
+		</div>
+	);
+}

--- a/libs/bublik/features/history/src/lib/history-linear/column-components/issue-badges/issue-badges.tsx
+++ b/libs/bublik/features/history/src/lib/history-linear/column-components/issue-badges/issue-badges.tsx
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import type { ResultIssueRef } from '@/shared/types';
 import { Badge } from '@/shared/tailwind-ui';
+import { expectedBadge } from '@/bublik/features/result-classification';
 
 export interface IssueBadgesProps {
 	issues?: ResultIssueRef[];
@@ -16,7 +17,7 @@ export function IssueBadges({ issues }: IssueBadgesProps) {
 			{issues.map((issue) => (
 				<Badge
 					key={issue.rule_id}
-					variant={issue.expected ? 'expected' : 'unexpected'}
+					variant={expectedBadge(issue.expected).variant}
 					title={issue.issue_title}
 				>
 					{(issue.bug_key ?? `#${issue.issue_id}`) + ' · ' + issue.category}

--- a/libs/bublik/features/history/src/lib/history-linear/history-linear.columns.tsx
+++ b/libs/bublik/features/history/src/lib/history-linear/history-linear.columns.tsx
@@ -22,7 +22,7 @@ import {
 	onBadgeClick,
 	onResultTypeClick
 } from './history-linear.utils';
-import { Links, RunTime, RunTimeProps } from './column-components';
+import { IssueBadges, Links, RunTime, RunTimeProps } from './column-components';
 import { HistoryLinearGlobalFilter } from './history-linear.types';
 import { HistoryContextMenuContainer } from '../history-context-menu';
 
@@ -143,26 +143,29 @@ export const columns: ColumnDef<HistoryDataLinear>[] = [
 				globalFilter.resultType === result;
 
 			return (
-				<HistoryContextMenuContainer
-					badges={verdicts.map((verdict) => ({ payload: verdict }))}
-					label="verdicts"
-					filterKey="verdicts"
-					resultType={result}
-					isNotExpected={isNotExpected}
-				>
-					<VerdictList
-						variant={VerdictVariant.Obtained}
-						result={result}
-						verdicts={verdicts}
-						selectedVerdicts={cell.table.getState().globalFilter['verdicts']}
-						onVerdictClick={onBadgeClick(cell, 'verdicts')}
-						onResultClick={(resultType) =>
-							onResultTypeClick(cell)(resultType, isNotExpected)
-						}
+				<div className="flex flex-col">
+					<HistoryContextMenuContainer
+						badges={verdicts.map((verdict) => ({ payload: verdict }))}
+						label="verdicts"
+						filterKey="verdicts"
+						resultType={result}
 						isNotExpected={isNotExpected}
-						isResultSelected={isResultSelected}
-					/>
-				</HistoryContextMenuContainer>
+					>
+						<VerdictList
+							variant={VerdictVariant.Obtained}
+							result={result}
+							verdicts={verdicts}
+							selectedVerdicts={cell.table.getState().globalFilter['verdicts']}
+							onVerdictClick={onBadgeClick(cell, 'verdicts')}
+							onResultClick={(resultType) =>
+								onResultTypeClick(cell)(resultType, isNotExpected)
+							}
+							isNotExpected={isNotExpected}
+							isResultSelected={isResultSelected}
+						/>
+					</HistoryContextMenuContainer>
+					<IssueBadges issues={cell.row.original.issues} />
+				</div>
 			);
 		}
 	},

--- a/libs/bublik/features/history/src/lib/slice/history-slice.ts
+++ b/libs/bublik/features/history/src/lib/slice/history-slice.ts
@@ -57,7 +57,10 @@ export const DEFAULT_SEARCH_FORM_STATE: HistorySliceState['searchForm'] = {
 	revisionExpr: '',
 	testArgExpr: '',
 	verdictExpr: '',
-	branchExpr: ''
+	branchExpr: '',
+	/* Classification section */
+	categories: [],
+	untriaged: false
 };
 
 const initialState: HistorySliceState = {

--- a/libs/bublik/features/history/src/lib/slice/history-slice.types.ts
+++ b/libs/bublik/features/history/src/lib/slice/history-slice.types.ts
@@ -58,4 +58,7 @@ export type HistoryStateSearch = {
 	revisionExpr: string;
 	testArgExpr: string;
 	labelExpr: string;
+	/* Classification section */
+	categories: string[];
+	untriaged: boolean;
 };

--- a/libs/bublik/features/history/src/lib/slice/history-slice.utils.ts
+++ b/libs/bublik/features/history/src/lib/slice/history-slice.utils.ts
@@ -84,7 +84,10 @@ export const queryToHistorySearchState = (
 		results: withDefault(parseArray(query.resultStatuses), []),
 		/* Verdict section */
 		verdictLookup: withDefault(query.verdictLookup, VERDICT_TYPE.String),
-		verdict: withDefault(parseArray(query.verdict), [])
+		verdict: withDefault(parseArray(query.verdict), []),
+		/* Classification section */
+		categories: withDefault(parseArray(query.categories), []),
+		untriaged: query.untriaged === 'true'
 	};
 };
 
@@ -115,7 +118,10 @@ export const historySearchStateToForm = (
 		results: state.results,
 		/* Verdict section */
 		verdictLookup: state.verdictLookup,
-		verdict: arrayToBadgeItem(state.verdict)
+		verdict: arrayToBadgeItem(state.verdict),
+		/* Classification section */
+		categories: state.categories,
+		untriaged: state.untriaged
 	};
 };
 
@@ -147,6 +153,10 @@ export function searchQueryToBackendQuery(
 		/* Verdict section */
 		verdictLookup: query.verdictLookup,
 		verdict: query.verdict,
+		/* Classification section */
+		categories: query.categories,
+		issue: query.issue,
+		untriaged: query.untriaged,
 		page: query.page,
 		pageSize: query.pageSize,
 		projects: query.project ? [Number(query.project)] : undefined
@@ -181,7 +191,10 @@ export const historySearchStateToQuery = (
 		results: withDefault(arrayToString(state.results), ''),
 		/* Verdict section */
 		verdictLookup: state.verdictLookup,
-		verdict: withDefault(arrayToString(state.verdict), '')
+		verdict: withDefault(arrayToString(state.verdict), ''),
+		/* Classification section */
+		categories: withDefault(arrayToString(state.categories), ''),
+		untriaged: state.untriaged ? 'true' : undefined
 	};
 };
 
@@ -218,6 +231,9 @@ export const formToSearchState = (
 		results: form.results,
 		/* Verdict section */
 		verdictLookup: form.verdictLookup,
-		verdict: badgeItemToArray(form.verdict)
+		verdict: badgeItemToArray(form.verdict),
+		/* Classification section */
+		categories: form.categories ?? [],
+		untriaged: form.untriaged ?? false
 	};
 };

--- a/libs/bublik/features/result-classification/.babelrc
+++ b/libs/bublik/features/result-classification/.babelrc
@@ -1,0 +1,12 @@
+{
+	"presets": [
+		[
+			"@nx/react/babel",
+			{
+				"runtime": "automatic",
+				"useBuiltIns": "usage"
+			}
+		]
+	],
+	"plugins": []
+}

--- a/libs/bublik/features/result-classification/.eslintrc.json
+++ b/libs/bublik/features/result-classification/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+	"extends": ["plugin:@nx/react", "../../../../.eslintrc.json"],
+	"ignorePatterns": [
+		"!**/*",
+		"**/vite.config.*.timestamp*",
+		"**/vitest.config.*.timestamp*"
+	],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		}
+	]
+}

--- a/libs/bublik/features/result-classification/project.json
+++ b/libs/bublik/features/result-classification/project.json
@@ -1,0 +1,21 @@
+{
+	"name": "bublik-features-result-classification",
+	"$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "libs/bublik/features/result-classification/src",
+	"projectType": "library",
+	"tags": [],
+	"targets": {
+		"lint": {
+			"executor": "@nx/eslint:lint"
+		},
+		"test": {
+			"executor": "@nx/vitest:test",
+			"outputs": [
+				"{workspaceRoot}/coverage/libs/bublik/features/result-classification"
+			],
+			"options": {
+				"passWithNoTests": true
+			}
+		}
+	}
+}

--- a/libs/bublik/features/result-classification/src/index.ts
+++ b/libs/bublik/features/result-classification/src/index.ts
@@ -6,3 +6,4 @@ export {
 	categoryBadgeVariant
 } from './lib/category';
 export { IssuesTable } from './lib/issues-table';
+export { RunIssuesTable } from './lib/run-issues-table';

--- a/libs/bublik/features/result-classification/src/index.ts
+++ b/libs/bublik/features/result-classification/src/index.ts
@@ -5,3 +5,4 @@ export {
 	defaultExpectedFor,
 	categoryBadgeVariant
 } from './lib/category';
+export { IssuesTable } from './lib/issues-table';

--- a/libs/bublik/features/result-classification/src/index.ts
+++ b/libs/bublik/features/result-classification/src/index.ts
@@ -12,3 +12,4 @@ export { IssuePicker } from './lib/issue-picker';
 export type { IssuePickerProps } from './lib/issue-picker';
 export { issueTag } from './lib/issue-picker.utils';
 export * from './lib/issue-rules-table';
+export * from './lib/expected';

--- a/libs/bublik/features/result-classification/src/index.ts
+++ b/libs/bublik/features/result-classification/src/index.ts
@@ -8,3 +8,6 @@ export {
 export { IssuesTable } from './lib/issues-table';
 export { RunIssuesTable } from './lib/run-issues-table';
 export { RunIssueResults } from './lib/run-issue-results';
+export { IssuePicker } from './lib/issue-picker';
+export type { IssuePickerProps } from './lib/issue-picker';
+export { issueTag } from './lib/issue-picker.utils';

--- a/libs/bublik/features/result-classification/src/index.ts
+++ b/libs/bublik/features/result-classification/src/index.ts
@@ -11,3 +11,4 @@ export { RunIssueResults } from './lib/run-issue-results';
 export { IssuePicker } from './lib/issue-picker';
 export type { IssuePickerProps } from './lib/issue-picker';
 export { issueTag } from './lib/issue-picker.utils';
+export * from './lib/issue-rules-table';

--- a/libs/bublik/features/result-classification/src/index.ts
+++ b/libs/bublik/features/result-classification/src/index.ts
@@ -7,3 +7,4 @@ export {
 } from './lib/category';
 export { IssuesTable } from './lib/issues-table';
 export { RunIssuesTable } from './lib/run-issues-table';
+export { RunIssueResults } from './lib/run-issue-results';

--- a/libs/bublik/features/result-classification/src/index.ts
+++ b/libs/bublik/features/result-classification/src/index.ts
@@ -1,0 +1,7 @@
+export { ClassifyPopover } from './lib/classify-popover';
+export type { ClassifyPopoverProps } from './lib/classify-popover';
+export {
+	CATEGORY_OPTIONS,
+	defaultExpectedFor,
+	categoryBadgeVariant
+} from './lib/category';

--- a/libs/bublik/features/result-classification/src/index.ts
+++ b/libs/bublik/features/result-classification/src/index.ts
@@ -8,6 +8,7 @@ export {
 export { IssuesTable } from './lib/issues-table';
 export { RunIssuesTable } from './lib/run-issues-table';
 export { RunIssueResults } from './lib/run-issue-results';
+export { IssueResults } from './lib/issue-results';
 export { IssuePicker } from './lib/issue-picker';
 export type { IssuePickerProps } from './lib/issue-picker';
 export { issueTag } from './lib/issue-picker.utils';

--- a/libs/bublik/features/result-classification/src/lib/category.spec.ts
+++ b/libs/bublik/features/result-classification/src/lib/category.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { CATEGORY_OPTIONS, defaultExpectedFor } from './category';
+
+describe('category', () => {
+	it('has six options', () => {
+		expect(CATEGORY_OPTIONS).toHaveLength(6);
+	});
+	it('defaults expected per category', () => {
+		expect(defaultExpectedFor('known-issue')).toBe(true);
+		expect(defaultExpectedFor('product-defect')).toBe(false);
+	});
+});

--- a/libs/bublik/features/result-classification/src/lib/category.ts
+++ b/libs/bublik/features/result-classification/src/lib/category.ts
@@ -1,15 +1,17 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import type { IssueCategory } from '@/shared/types';
 
-export const CATEGORY_OPTIONS: { value: IssueCategory; displayValue: string }[] =
-	[
-		{ value: 'product-defect', displayValue: 'Product defect' },
-		{ value: 'test-bug', displayValue: 'Test/automation bug' },
-		{ value: 'env', displayValue: 'Environment / infra' },
-		{ value: 'known-issue', displayValue: 'Known issue' },
-		{ value: 'flaky', displayValue: 'Flaky / intermittent' },
-		{ value: 'to-investigate', displayValue: 'To investigate' }
-	];
+export const CATEGORY_OPTIONS: {
+	value: IssueCategory;
+	displayValue: string;
+}[] = [
+	{ value: 'product-defect', displayValue: 'Product defect' },
+	{ value: 'test-bug', displayValue: 'Test/automation bug' },
+	{ value: 'env', displayValue: 'Environment / infra' },
+	{ value: 'known-issue', displayValue: 'Known issue' },
+	{ value: 'flaky', displayValue: 'Flaky / intermittent' },
+	{ value: 'to-investigate', displayValue: 'To investigate' }
+];
 
 const EXPECTED_BY_CATEGORY: Record<IssueCategory, boolean> = {
 	'known-issue': true,

--- a/libs/bublik/features/result-classification/src/lib/category.ts
+++ b/libs/bublik/features/result-classification/src/lib/category.ts
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import type { IssueCategory } from '@/shared/types';
+
+export const CATEGORY_OPTIONS: { value: IssueCategory; displayValue: string }[] =
+	[
+		{ value: 'product-defect', displayValue: 'Product defect' },
+		{ value: 'test-bug', displayValue: 'Test/automation bug' },
+		{ value: 'env', displayValue: 'Environment / infra' },
+		{ value: 'known-issue', displayValue: 'Known issue' },
+		{ value: 'flaky', displayValue: 'Flaky / intermittent' },
+		{ value: 'to-investigate', displayValue: 'To investigate' }
+	];
+
+const EXPECTED_BY_CATEGORY: Record<IssueCategory, boolean> = {
+	'known-issue': true,
+	env: true,
+	'test-bug': true,
+	flaky: true,
+	'product-defect': false,
+	'to-investigate': false
+};
+
+export function defaultExpectedFor(category: IssueCategory): boolean {
+	return EXPECTED_BY_CATEGORY[category];
+}
+
+/** Badge variant for a category's expected disposition. */
+export function categoryBadgeVariant(
+	expected: boolean
+): 'expected' | 'unexpected' {
+	return expected ? 'expected' : 'unexpected';
+}

--- a/libs/bublik/features/result-classification/src/lib/classify-drawer.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-drawer.tsx
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { ButtonTw, DrawerContent, DrawerRoot, Icon } from '@/shared/tailwind-ui';
+
+import {
+	ClassifyFields,
+	buildSubmitHandler,
+	type ClassifyForm
+} from './classify-form';
+import { MatchScope } from './match-scope';
+
+export interface ClassifyDrawerProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	form: ClassifyForm;
+	projectId?: number;
+	submit: Parameters<typeof buildSubmitHandler>[0];
+}
+
+export function ClassifyDrawer({
+	open,
+	onOpenChange,
+	form,
+	projectId,
+	submit
+}: ClassifyDrawerProps) {
+	const onSubmit = buildSubmitHandler(submit, () => onOpenChange(false));
+
+	return (
+		<DrawerRoot open={open} onOpenChange={onOpenChange}>
+			<DrawerContent className="w-[28rem] max-w-[90vw] flex flex-col">
+				<div className="flex items-center justify-between px-5 py-4 border-b border-border-primary">
+					<span className="text-base font-semibold">Classify failure</span>
+					<button
+						type="button"
+						onClick={() => onOpenChange(false)}
+						className="grid place-items-center w-7 h-7 rounded hover:bg-primary-wash"
+						aria-label="Close"
+					>
+						<Icon name="CrossSimple" size={16} />
+					</button>
+				</div>
+
+				<form
+					onSubmit={form.handleSubmit(onSubmit)}
+					className="flex flex-col gap-4 p-5 overflow-y-auto"
+				>
+					<ClassifyFields form={form} projectId={projectId} />
+
+					<div className="pt-2 border-t border-border-primary">
+						<MatchScope form={form} />
+					</div>
+
+					<ButtonTw
+						type="submit"
+						variant="primary"
+						size="md"
+						rounded="lg"
+						className="justify-center w-full"
+					>
+						{form.formState.isSubmitting ? (
+							<Icon name="ProgressIndicator" size={18} className="animate-spin" />
+						) : (
+							'Classify'
+						)}
+					</ButtonTw>
+				</form>
+			</DrawerContent>
+		</DrawerRoot>
+	);
+}

--- a/libs/bublik/features/result-classification/src/lib/classify-drawer.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-drawer.tsx
@@ -1,5 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { ButtonTw, DrawerContent, DrawerRoot, Icon } from '@/shared/tailwind-ui';
+import {
+	ButtonTw,
+	DrawerContent,
+	DrawerRoot,
+	Icon
+} from '@/shared/tailwind-ui';
 
 import {
 	ClassifyFields,
@@ -63,7 +68,11 @@ export function ClassifyDrawer({
 						className="justify-center w-full"
 					>
 						{form.formState.isSubmitting ? (
-							<Icon name="ProgressIndicator" size={18} className="animate-spin" />
+							<Icon
+								name="ProgressIndicator"
+								size={18}
+								className="animate-spin"
+							/>
 						) : (
 							'Classify'
 						)}

--- a/libs/bublik/features/result-classification/src/lib/classify-drawer.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-drawer.tsx
@@ -31,7 +31,7 @@ export function ClassifyDrawer({
 		<DrawerRoot open={open} onOpenChange={onOpenChange}>
 			<DrawerContent
 				portal
-				className="z-[100] w-[28rem] max-w-[90vw] flex flex-col"
+				className="z-[55] w-[28rem] max-w-[90vw] flex flex-col"
 			>
 				<div className="flex items-center justify-between px-5 py-4 border-b border-border-primary">
 					<span className="text-base font-semibold">Classify failure</span>

--- a/libs/bublik/features/result-classification/src/lib/classify-drawer.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-drawer.tsx
@@ -25,9 +25,14 @@ export function ClassifyDrawer({
 }: ClassifyDrawerProps) {
 	const onSubmit = buildSubmitHandler(submit, () => onOpenChange(false));
 
+	// Modal (like the History drawer) traps focus; portal layers the panel above
+	// the table so clicks land inside, not on rows behind.
 	return (
 		<DrawerRoot open={open} onOpenChange={onOpenChange}>
-			<DrawerContent className="w-[28rem] max-w-[90vw] flex flex-col">
+			<DrawerContent
+				portal
+				className="z-[100] w-[28rem] max-w-[90vw] flex flex-col"
+			>
 				<div className="flex items-center justify-between px-5 py-4 border-b border-border-primary">
 					<span className="text-base font-semibold">Classify failure</span>
 					<button

--- a/libs/bublik/features/result-classification/src/lib/classify-form.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-form.tsx
@@ -61,7 +61,10 @@ export function buildSubmitHandler(
 		const issue =
 			values.mode === 'existing' && values.issueId
 				? values.issueId
-				: { title: values.title || 'Untitled', bug_key: values.bugKey || undefined };
+				: {
+						title: values.title || 'Untitled',
+						bug_key: values.bugKey || undefined
+				  };
 		await submit({
 			issue,
 			category,
@@ -69,8 +72,8 @@ export function buildSubmitHandler(
 				values.expected === 'expected'
 					? true
 					: values.expected === 'unexpected'
-						? false
-						: null,
+					? false
+					: null,
 			scope: values.scope as ClassifyScope,
 			matcher: {
 				matchParameters: values.matchParameters,
@@ -114,7 +117,11 @@ export function ClassifyFields({
 
 			{mode === 'new' ? (
 				<>
-					<Input label="Title" placeholder="Short label" {...register('title')} />
+					<Input
+						label="Title"
+						placeholder="Short label"
+						{...register('title')}
+					/>
 					<Input
 						label="Bug key (optional)"
 						placeholder="ref://JIRA/ISSUE-123"

--- a/libs/bublik/features/result-classification/src/lib/classify-form.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-form.tsx
@@ -6,7 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Input, SelectInput } from '@/shared/tailwind-ui';
 import type { ClassifyScope, IssueCategory } from '@/shared/types';
 
-import { CATEGORY_OPTIONS, defaultExpectedFor } from './category';
+import { CATEGORY_OPTIONS } from './category';
 import { IssuePicker } from './issue-picker';
 import { DEFAULT_MATCH_FLAGS } from './match-scope.utils';
 
@@ -17,6 +17,7 @@ export const ClassifyFormSchema = z.object({
 	bugKey: z.string().optional(),
 	category: z.string().min(1, { message: 'Category is required' }),
 	scope: z.enum(['future', 'oneoff']),
+	expected: z.enum(['expected', 'unexpected', 'none']),
 	matchParameters: z.boolean(),
 	matchVerdicts: z.boolean(),
 	matchImportantTags: z.boolean(),
@@ -34,6 +35,7 @@ export function useClassifyForm(): ClassifyForm {
 			mode: 'new',
 			category: 'known-issue',
 			scope: 'future',
+			expected: 'expected',
 			...DEFAULT_MATCH_FLAGS
 		}
 	});
@@ -43,7 +45,7 @@ export function buildSubmitHandler(
 	submit: (input: {
 		issue: number | { title: string; bug_key?: string };
 		category: IssueCategory;
-		expected: boolean;
+		expected: boolean | null;
 		scope: ClassifyScope;
 		matcher: {
 			matchParameters: boolean;
@@ -63,7 +65,12 @@ export function buildSubmitHandler(
 		await submit({
 			issue,
 			category,
-			expected: defaultExpectedFor(category),
+			expected:
+				values.expected === 'expected'
+					? true
+					: values.expected === 'unexpected'
+						? false
+						: null,
 			scope: values.scope as ClassifyScope,
 			matcher: {
 				matchParameters: values.matchParameters,
@@ -138,6 +145,24 @@ export function ClassifyFields({
 						onValueChange={field.onChange}
 						name={field.name}
 						options={CATEGORY_OPTIONS}
+					/>
+				)}
+			/>
+
+			<Controller
+				control={control}
+				name="expected"
+				render={({ field }) => (
+					<SelectInput
+						label="Expected"
+						value={field.value}
+						onValueChange={field.onChange}
+						name={field.name}
+						options={[
+							{ value: 'expected', displayValue: 'Expected' },
+							{ value: 'unexpected', displayValue: 'Unexpected' },
+							{ value: 'none', displayValue: 'None' }
+						]}
 					/>
 				)}
 			/>

--- a/libs/bublik/features/result-classification/src/lib/classify-form.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-form.tsx
@@ -35,7 +35,7 @@ export function useClassifyForm(): ClassifyForm {
 			mode: 'new',
 			category: 'known-issue',
 			scope: 'future',
-			expected: 'expected',
+			expected: 'none',
 			...DEFAULT_MATCH_FLAGS
 		}
 	});
@@ -159,9 +159,9 @@ export function ClassifyFields({
 						onValueChange={field.onChange}
 						name={field.name}
 						options={[
+							{ value: 'none', displayValue: "Don't change" },
 							{ value: 'expected', displayValue: 'Expected' },
-							{ value: 'unexpected', displayValue: 'Unexpected' },
-							{ value: 'none', displayValue: 'None' }
+							{ value: 'unexpected', displayValue: 'Unexpected' }
 						]}
 					/>
 				)}

--- a/libs/bublik/features/result-classification/src/lib/classify-form.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-form.tsx
@@ -1,0 +1,163 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { Controller, useForm, type UseFormReturn } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { Input, SelectInput } from '@/shared/tailwind-ui';
+import type { ClassifyScope, IssueCategory } from '@/shared/types';
+
+import { CATEGORY_OPTIONS, defaultExpectedFor } from './category';
+import { IssuePicker } from './issue-picker';
+import { DEFAULT_MATCH_FLAGS } from './match-scope.utils';
+
+export const ClassifyFormSchema = z.object({
+	mode: z.enum(['new', 'existing']),
+	issueId: z.coerce.number().optional(),
+	title: z.string().optional(),
+	bugKey: z.string().optional(),
+	category: z.string().min(1, { message: 'Category is required' }),
+	scope: z.enum(['future', 'oneoff']),
+	matchParameters: z.boolean(),
+	matchVerdicts: z.boolean(),
+	matchImportantTags: z.boolean(),
+	matchAllTags: z.boolean()
+});
+
+export type ClassifyFormValues = z.infer<typeof ClassifyFormSchema>;
+
+export type ClassifyForm = UseFormReturn<ClassifyFormValues>;
+
+export function useClassifyForm(): ClassifyForm {
+	return useForm<ClassifyFormValues>({
+		resolver: zodResolver(ClassifyFormSchema),
+		defaultValues: {
+			mode: 'new',
+			category: 'known-issue',
+			scope: 'future',
+			...DEFAULT_MATCH_FLAGS
+		}
+	});
+}
+
+export function buildSubmitHandler(
+	submit: (input: {
+		issue: number | { title: string; bug_key?: string };
+		category: IssueCategory;
+		expected: boolean;
+		scope: ClassifyScope;
+		matcher: {
+			matchParameters: boolean;
+			matchVerdicts: boolean;
+			matchImportantTags: boolean;
+			matchAllTags: boolean;
+		};
+	}) => Promise<unknown> | undefined,
+	onDone: () => void
+) {
+	return async (values: ClassifyFormValues) => {
+		const category = values.category as IssueCategory;
+		const issue =
+			values.mode === 'existing' && values.issueId
+				? values.issueId
+				: { title: values.title || 'Untitled', bug_key: values.bugKey || undefined };
+		await submit({
+			issue,
+			category,
+			expected: defaultExpectedFor(category),
+			scope: values.scope as ClassifyScope,
+			matcher: {
+				matchParameters: values.matchParameters,
+				matchVerdicts: values.matchVerdicts,
+				matchImportantTags: values.matchImportantTags,
+				matchAllTags: values.matchAllTags
+			}
+		});
+		onDone();
+	};
+}
+
+export function ClassifyFields({
+	form,
+	projectId
+}: {
+	form: ClassifyForm;
+	projectId?: number;
+}) {
+	const { register, control, watch } = form;
+	const mode = watch('mode');
+
+	return (
+		<>
+			<Controller
+				control={control}
+				name="mode"
+				render={({ field }) => (
+					<SelectInput
+						label="Issue"
+						value={field.value}
+						onValueChange={field.onChange}
+						name={field.name}
+						options={[
+							{ value: 'new', displayValue: 'New issue' },
+							{ value: 'existing', displayValue: 'Existing issue' }
+						]}
+					/>
+				)}
+			/>
+
+			{mode === 'new' ? (
+				<>
+					<Input label="Title" placeholder="Short label" {...register('title')} />
+					<Input
+						label="Bug key (optional)"
+						placeholder="ref://JIRA/ISSUE-123"
+						{...register('bugKey')}
+					/>
+				</>
+			) : (
+				<Controller
+					control={control}
+					name="issueId"
+					render={({ field }) => (
+						<IssuePicker
+							projectId={projectId}
+							value={field.value}
+							onChange={(id) => field.onChange(id)}
+						/>
+					)}
+				/>
+			)}
+
+			<Controller
+				control={control}
+				name="category"
+				render={({ field }) => (
+					<SelectInput
+						label="Category"
+						value={field.value}
+						onValueChange={field.onChange}
+						name={field.name}
+						options={CATEGORY_OPTIONS}
+					/>
+				)}
+			/>
+
+			<Controller
+				control={control}
+				name="scope"
+				render={({ field }) => (
+					<SelectInput
+						label="Apply to"
+						value={field.value}
+						onValueChange={field.onChange}
+						name={field.name}
+						options={[
+							{ value: 'future', displayValue: 'This + future matching runs' },
+							{ value: 'oneoff', displayValue: 'Just this result' }
+						]}
+					/>
+				)}
+			/>
+		</>
+	);
+}

--- a/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
@@ -1,0 +1,185 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import {
+	ButtonTw,
+	Icon,
+	Input,
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+	SelectInput
+} from '@/shared/tailwind-ui';
+import type { ClassifyScope, Issue, IssueCategory } from '@/shared/types';
+
+import { CATEGORY_OPTIONS, defaultExpectedFor } from './category';
+import { useClassify } from './use-classify';
+
+const Schema = z.object({
+	mode: z.enum(['new', 'existing']),
+	issueId: z.coerce.number().optional(),
+	title: z.string().optional(),
+	bugKey: z.string().optional(),
+	category: z.string().min(1, { message: 'Category is required' }),
+	scope: z.enum(['future', 'oneoff'])
+});
+
+type FormValues = z.infer<typeof Schema>;
+
+export interface ClassifyPopoverProps {
+	resultId: number;
+}
+
+export function ClassifyPopover({ resultId }: ClassifyPopoverProps) {
+	const [open, setOpen] = useState(false);
+	const { issues, submit } = useClassify(resultId);
+
+	const { register, control, handleSubmit, watch, formState } =
+		useForm<FormValues>({
+			resolver: zodResolver(Schema),
+			defaultValues: { mode: 'new', category: 'known-issue', scope: 'future' }
+		});
+	const mode = watch('mode');
+
+	async function onSubmit(values: FormValues) {
+		const category = values.category as IssueCategory;
+		const issue =
+			values.mode === 'existing' && values.issueId
+				? values.issueId
+				: { title: values.title || 'Untitled', bug_key: values.bugKey || undefined };
+		await submit({
+			issue,
+			category,
+			expected: defaultExpectedFor(category),
+			scope: values.scope as ClassifyScope
+		});
+		setOpen(false);
+	}
+
+	const issueOptions = (issues.data ?? []).map((i: Issue) => ({
+		value: String(i.id),
+		displayValue: i.title
+	}));
+
+	return (
+		<Popover open={open} onOpenChange={setOpen} modal>
+			<PopoverTrigger asChild>
+				<ButtonTw variant="secondary" size="xss">
+					<Icon name="TriangleExclamationMark" size={18} className="mr-1" />
+					Classify
+				</ButtonTw>
+			</PopoverTrigger>
+			<PopoverContent sideOffset={8}>
+				<form
+					onSubmit={handleSubmit(onSubmit)}
+					className="min-w-[320px] p-4 bg-white rounded-md shadow-popover flex flex-col gap-4"
+				>
+					<span className="text-[0.875rem] font-semibold">
+						Classify failure
+					</span>
+
+					<Controller
+						control={control}
+						name="mode"
+						render={({ field }) => (
+							<SelectInput
+								label="Issue"
+								value={field.value}
+								onValueChange={field.onChange}
+								name={field.name}
+								options={[
+									{ value: 'new', displayValue: 'New issue' },
+									{ value: 'existing', displayValue: 'Existing issue' }
+								]}
+							/>
+						)}
+					/>
+
+					{mode === 'new' ? (
+						<>
+							<Input
+								label="Title"
+								placeholder="Short label"
+								{...register('title')}
+							/>
+							<Input
+								label="Bug key (optional)"
+								placeholder="ref://JIRA/ISSUE-123"
+								{...register('bugKey')}
+							/>
+						</>
+					) : (
+						<Controller
+							control={control}
+							name="issueId"
+							render={({ field }) => (
+								<SelectInput
+									label="Pick issue"
+									value={field.value ? String(field.value) : ''}
+									onValueChange={(v) => field.onChange(Number(v))}
+									name={field.name}
+									options={issueOptions}
+								/>
+							)}
+						/>
+					)}
+
+					<Controller
+						control={control}
+						name="category"
+						render={({ field }) => (
+							<SelectInput
+								label="Category"
+								value={field.value}
+								onValueChange={field.onChange}
+								name={field.name}
+								options={CATEGORY_OPTIONS}
+							/>
+						)}
+					/>
+
+					<Controller
+						control={control}
+						name="scope"
+						render={({ field }) => (
+							<SelectInput
+								label="Apply to"
+								value={field.value}
+								onValueChange={field.onChange}
+								name={field.name}
+								options={[
+									{
+										value: 'future',
+										displayValue: 'This + future matching runs'
+									},
+									{ value: 'oneoff', displayValue: 'Just this result' }
+								]}
+							/>
+						)}
+					/>
+
+					<ButtonTw
+						type="submit"
+						variant="primary"
+						size="md"
+						rounded="lg"
+						className="justify-center w-full"
+					>
+						{formState.isSubmitting ? (
+							<Icon
+								name="ProgressIndicator"
+								size={18}
+								className="animate-spin"
+							/>
+						) : (
+							'Classify'
+						)}
+					</ButtonTw>
+				</form>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
@@ -67,6 +67,8 @@ export function ClassifyPopover({ resultId, projectId }: ClassifyPopoverProps) {
 
 	return (
 		<>
+			{/* Modal traps focus (like the History drawer); portal layers the
+			    content above the table so clicks land inside, not on rows behind. */}
 			<Popover open={open} onOpenChange={setOpen} modal>
 				<PopoverTrigger asChild>
 					<ButtonTw
@@ -79,7 +81,10 @@ export function ClassifyPopover({ resultId, projectId }: ClassifyPopoverProps) {
 						Classify
 					</ButtonTw>
 				</PopoverTrigger>
-				<PopoverContent sideOffset={8}>
+				{/* Above the z-50 crowd (tooltips/other popovers also portal to body
+				    at z-50); otherwise a later z-50 portal paints over the popover and
+				    clicks on it read as outside -> dismiss. */}
+				<PopoverContent sideOffset={8} portal className="z-[100]">
 					<form
 						onSubmit={form.handleSubmit(onSubmit)}
 						className="min-w-[320px] p-4 bg-white rounded-md shadow-popover flex flex-col gap-4"

--- a/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
@@ -35,7 +35,7 @@ export interface ClassifyPopoverProps {
 
 export function ClassifyPopover({ resultId }: ClassifyPopoverProps) {
 	const [open, setOpen] = useState(false);
-	const { issues, submit } = useClassify(resultId);
+	const { issues, submit, canClassify } = useClassify(resultId);
 
 	const { register, control, handleSubmit, watch, formState } =
 		useForm<FormValues>({
@@ -67,7 +67,12 @@ export function ClassifyPopover({ resultId }: ClassifyPopoverProps) {
 	return (
 		<Popover open={open} onOpenChange={setOpen} modal>
 			<PopoverTrigger asChild>
-				<ButtonTw variant="secondary" size="xss">
+				<ButtonTw
+					variant="secondary"
+					size="xss"
+					disabled={!canClassify}
+					title={!canClassify ? 'Select a project first' : undefined}
+				>
 					<Icon name="TriangleExclamationMark" size={18} className="mr-1" />
 					Classify
 				</ButtonTw>

--- a/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
@@ -13,9 +13,10 @@ import {
 	PopoverTrigger,
 	SelectInput
 } from '@/shared/tailwind-ui';
-import type { ClassifyScope, Issue, IssueCategory } from '@/shared/types';
+import type { ClassifyScope, IssueCategory } from '@/shared/types';
 
 import { CATEGORY_OPTIONS, defaultExpectedFor } from './category';
+import { IssuePicker } from './issue-picker';
 import { useClassify } from './use-classify';
 
 const Schema = z.object({
@@ -38,7 +39,7 @@ export interface ClassifyPopoverProps {
 
 export function ClassifyPopover({ resultId, projectId }: ClassifyPopoverProps) {
 	const [open, setOpen] = useState(false);
-	const { issues, submit, canClassify } = useClassify(resultId, projectId);
+	const { submit, canClassify } = useClassify(resultId, projectId);
 
 	const { register, control, handleSubmit, watch, formState } =
 		useForm<FormValues>({
@@ -61,11 +62,6 @@ export function ClassifyPopover({ resultId, projectId }: ClassifyPopoverProps) {
 		});
 		setOpen(false);
 	}
-
-	const issueOptions = (issues.data ?? []).map((i: Issue) => ({
-		value: String(i.id),
-		displayValue: i.title
-	}));
 
 	return (
 		<Popover open={open} onOpenChange={setOpen} modal>
@@ -124,12 +120,10 @@ export function ClassifyPopover({ resultId, projectId }: ClassifyPopoverProps) {
 							control={control}
 							name="issueId"
 							render={({ field }) => (
-								<SelectInput
-									label="Pick issue"
-									value={field.value ? String(field.value) : ''}
-									onValueChange={(v) => field.onChange(Number(v))}
-									name={field.name}
-									options={issueOptions}
+								<IssuePicker
+									projectId={projectId}
+									value={field.value}
+									onChange={(id) => field.onChange(id)}
 								/>
 							)}
 						/>

--- a/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
@@ -31,11 +31,14 @@ type FormValues = z.infer<typeof Schema>;
 
 export interface ClassifyPopoverProps {
 	resultId: number;
+	/** Project the result belongs to. On a run page this comes from the result
+	 * itself, so classify works regardless of the global project selector. */
+	projectId?: number;
 }
 
-export function ClassifyPopover({ resultId }: ClassifyPopoverProps) {
+export function ClassifyPopover({ resultId, projectId }: ClassifyPopoverProps) {
 	const [open, setOpen] = useState(false);
-	const { issues, submit, canClassify } = useClassify(resultId);
+	const { issues, submit, canClassify } = useClassify(resultId, projectId);
 
 	const { register, control, handleSubmit, watch, formState } =
 		useForm<FormValues>({

--- a/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
@@ -27,10 +27,19 @@ export interface ClassifyPopoverProps {
 	projectId?: number;
 }
 
-function MatchingSummary({ control }: { control: Control<ClassifyFormValues> }) {
+function MatchingSummary({
+	control
+}: {
+	control: Control<ClassifyFormValues>;
+}) {
 	const flags = useWatch({
 		control,
-		name: ['matchParameters', 'matchVerdicts', 'matchImportantTags', 'matchAllTags']
+		name: [
+			'matchParameters',
+			'matchVerdicts',
+			'matchImportantTags',
+			'matchAllTags'
+		]
 	});
 	const current = {
 		matchParameters: flags[0],
@@ -90,7 +99,9 @@ export function ClassifyPopover({ resultId, projectId }: ClassifyPopoverProps) {
 						onSubmit={form.handleSubmit(onSubmit)}
 						className="min-w-[320px] p-4 bg-white rounded-md shadow-popover flex flex-col gap-4"
 					>
-						<span className="text-[0.875rem] font-semibold">Classify failure</span>
+						<span className="text-[0.875rem] font-semibold">
+							Classify failure
+						</span>
 
 						<ClassifyFields form={form} projectId={projectId} />
 
@@ -115,7 +126,11 @@ export function ClassifyPopover({ resultId, projectId }: ClassifyPopoverProps) {
 							className="justify-center w-full"
 						>
 							{form.formState.isSubmitting ? (
-								<Icon name="ProgressIndicator" size={18} className="animate-spin" />
+								<Icon
+									name="ProgressIndicator"
+									size={18}
+									className="animate-spin"
+								/>
 							) : (
 								'Classify'
 							)}

--- a/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
@@ -81,10 +81,11 @@ export function ClassifyPopover({ resultId, projectId }: ClassifyPopoverProps) {
 						Classify
 					</ButtonTw>
 				</PopoverTrigger>
-				{/* Above the z-50 crowd (tooltips/other popovers also portal to body
-				    at z-50); otherwise a later z-50 portal paints over the popover and
-				    clicks on it read as outside -> dismiss. */}
-				<PopoverContent sideOffset={8} portal className="z-[100]">
+				{/* z-[55] sits above the z-50 tooltip/popover layer (else a later
+				    z-50 portal paints over us and clicks read as outside -> dismiss)
+				    but below the nested SelectInput dropdown (z-[60]) so its options
+				    open in front of the popover instead of behind it. */}
+				<PopoverContent sideOffset={8} portal className="z-[55]">
 					<form
 						onSubmit={form.handleSubmit(onSubmit)}
 						className="min-w-[320px] p-4 bg-white rounded-md shadow-popover flex flex-col gap-4"

--- a/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
+++ b/libs/bublik/features/result-classification/src/lib/classify-popover.tsx
@@ -1,34 +1,24 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
-import { z } from 'zod';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { useWatch, type Control } from 'react-hook-form';
 
 import {
 	ButtonTw,
 	Icon,
-	Input,
 	Popover,
 	PopoverContent,
-	PopoverTrigger,
-	SelectInput
+	PopoverTrigger
 } from '@/shared/tailwind-ui';
-import type { ClassifyScope, IssueCategory } from '@/shared/types';
 
-import { CATEGORY_OPTIONS, defaultExpectedFor } from './category';
-import { IssuePicker } from './issue-picker';
+import {
+	ClassifyFields,
+	buildSubmitHandler,
+	useClassifyForm,
+	type ClassifyFormValues
+} from './classify-form';
+import { ClassifyDrawer } from './classify-drawer';
+import { chipsForFlags, presetForFlags } from './match-scope.utils';
 import { useClassify } from './use-classify';
-
-const Schema = z.object({
-	mode: z.enum(['new', 'existing']),
-	issueId: z.coerce.number().optional(),
-	title: z.string().optional(),
-	bugKey: z.string().optional(),
-	category: z.string().min(1, { message: 'Category is required' }),
-	scope: z.enum(['future', 'oneoff'])
-});
-
-type FormValues = z.infer<typeof Schema>;
 
 export interface ClassifyPopoverProps {
 	resultId: number;
@@ -37,151 +27,104 @@ export interface ClassifyPopoverProps {
 	projectId?: number;
 }
 
+function MatchingSummary({ control }: { control: Control<ClassifyFormValues> }) {
+	const flags = useWatch({
+		control,
+		name: ['matchParameters', 'matchVerdicts', 'matchImportantTags', 'matchAllTags']
+	});
+	const current = {
+		matchParameters: flags[0],
+		matchVerdicts: flags[1],
+		matchImportantTags: flags[2],
+		matchAllTags: flags[3]
+	};
+	return (
+		<div className="flex flex-col gap-1 px-3 py-2 rounded bg-primary-wash/60">
+			<span className="text-xs font-semibold text-text-menu">
+				Matching ({presetForFlags(current)})
+			</span>
+			<div className="flex flex-wrap gap-1">
+				{chipsForFlags(current).map((chip) => (
+					<span
+						key={chip}
+						className="px-1.5 py-0.5 text-[0.6875rem] rounded bg-white border border-border-primary"
+					>
+						{chip}
+					</span>
+				))}
+			</div>
+		</div>
+	);
+}
+
 export function ClassifyPopover({ resultId, projectId }: ClassifyPopoverProps) {
 	const [open, setOpen] = useState(false);
+	const [drawerOpen, setDrawerOpen] = useState(false);
 	const { submit, canClassify } = useClassify(resultId, projectId);
+	const form = useClassifyForm();
 
-	const { register, control, handleSubmit, watch, formState } =
-		useForm<FormValues>({
-			resolver: zodResolver(Schema),
-			defaultValues: { mode: 'new', category: 'known-issue', scope: 'future' }
-		});
-	const mode = watch('mode');
-
-	async function onSubmit(values: FormValues) {
-		const category = values.category as IssueCategory;
-		const issue =
-			values.mode === 'existing' && values.issueId
-				? values.issueId
-				: { title: values.title || 'Untitled', bug_key: values.bugKey || undefined };
-		await submit({
-			issue,
-			category,
-			expected: defaultExpectedFor(category),
-			scope: values.scope as ClassifyScope
-		});
-		setOpen(false);
-	}
+	const onSubmit = buildSubmitHandler(submit, () => setOpen(false));
 
 	return (
-		<Popover open={open} onOpenChange={setOpen} modal>
-			<PopoverTrigger asChild>
-				<ButtonTw
-					variant="secondary"
-					size="xss"
-					disabled={!canClassify}
-					title={!canClassify ? 'Select a project first' : undefined}
-				>
-					<Icon name="TriangleExclamationMark" size={18} className="mr-1" />
-					Classify
-				</ButtonTw>
-			</PopoverTrigger>
-			<PopoverContent sideOffset={8}>
-				<form
-					onSubmit={handleSubmit(onSubmit)}
-					className="min-w-[320px] p-4 bg-white rounded-md shadow-popover flex flex-col gap-4"
-				>
-					<span className="text-[0.875rem] font-semibold">
-						Classify failure
-					</span>
-
-					<Controller
-						control={control}
-						name="mode"
-						render={({ field }) => (
-							<SelectInput
-								label="Issue"
-								value={field.value}
-								onValueChange={field.onChange}
-								name={field.name}
-								options={[
-									{ value: 'new', displayValue: 'New issue' },
-									{ value: 'existing', displayValue: 'Existing issue' }
-								]}
-							/>
-						)}
-					/>
-
-					{mode === 'new' ? (
-						<>
-							<Input
-								label="Title"
-								placeholder="Short label"
-								{...register('title')}
-							/>
-							<Input
-								label="Bug key (optional)"
-								placeholder="ref://JIRA/ISSUE-123"
-								{...register('bugKey')}
-							/>
-						</>
-					) : (
-						<Controller
-							control={control}
-							name="issueId"
-							render={({ field }) => (
-								<IssuePicker
-									projectId={projectId}
-									value={field.value}
-									onChange={(id) => field.onChange(id)}
-								/>
-							)}
-						/>
-					)}
-
-					<Controller
-						control={control}
-						name="category"
-						render={({ field }) => (
-							<SelectInput
-								label="Category"
-								value={field.value}
-								onValueChange={field.onChange}
-								name={field.name}
-								options={CATEGORY_OPTIONS}
-							/>
-						)}
-					/>
-
-					<Controller
-						control={control}
-						name="scope"
-						render={({ field }) => (
-							<SelectInput
-								label="Apply to"
-								value={field.value}
-								onValueChange={field.onChange}
-								name={field.name}
-								options={[
-									{
-										value: 'future',
-										displayValue: 'This + future matching runs'
-									},
-									{ value: 'oneoff', displayValue: 'Just this result' }
-								]}
-							/>
-						)}
-					/>
-
+		<>
+			<Popover open={open} onOpenChange={setOpen} modal>
+				<PopoverTrigger asChild>
 					<ButtonTw
-						type="submit"
-						variant="primary"
-						size="md"
-						rounded="lg"
-						className="justify-center w-full"
+						variant="secondary"
+						size="xss"
+						disabled={!canClassify}
+						title={!canClassify ? 'Select a project first' : undefined}
 					>
-						{formState.isSubmitting ? (
-							<Icon
-								name="ProgressIndicator"
-								size={18}
-								className="animate-spin"
-							/>
-						) : (
-							'Classify'
-						)}
+						<Icon name="TriangleExclamationMark" size={18} className="mr-1" />
+						Classify
 					</ButtonTw>
-				</form>
-			</PopoverContent>
-		</Popover>
+				</PopoverTrigger>
+				<PopoverContent sideOffset={8}>
+					<form
+						onSubmit={form.handleSubmit(onSubmit)}
+						className="min-w-[320px] p-4 bg-white rounded-md shadow-popover flex flex-col gap-4"
+					>
+						<span className="text-[0.875rem] font-semibold">Classify failure</span>
+
+						<ClassifyFields form={form} projectId={projectId} />
+
+						<MatchingSummary control={form.control} />
+
+						<button
+							type="button"
+							onClick={() => {
+								setOpen(false);
+								setDrawerOpen(true);
+							}}
+							className="self-start text-xs font-medium text-primary hover:underline"
+						>
+							Customize match rules →
+						</button>
+
+						<ButtonTw
+							type="submit"
+							variant="primary"
+							size="md"
+							rounded="lg"
+							className="justify-center w-full"
+						>
+							{form.formState.isSubmitting ? (
+								<Icon name="ProgressIndicator" size={18} className="animate-spin" />
+							) : (
+								'Classify'
+							)}
+						</ButtonTw>
+					</form>
+				</PopoverContent>
+			</Popover>
+
+			<ClassifyDrawer
+				open={drawerOpen}
+				onOpenChange={setDrawerOpen}
+				form={form}
+				projectId={projectId}
+				submit={submit}
+			/>
+		</>
 	);
 }

--- a/libs/bublik/features/result-classification/src/lib/expected.spec.ts
+++ b/libs/bublik/features/result-classification/src/lib/expected.spec.ts
@@ -5,7 +5,10 @@ import { expectedBadge } from './expected';
 
 describe('expectedBadge', () => {
 	it('maps true to expected', () => {
-		expect(expectedBadge(true)).toEqual({ variant: 'expected', label: 'Expected' });
+		expect(expectedBadge(true)).toEqual({
+			variant: 'expected',
+			label: 'Expected'
+		});
 	});
 	it('maps false to unexpected', () => {
 		expect(expectedBadge(false)).toEqual({
@@ -14,7 +17,10 @@ describe('expectedBadge', () => {
 		});
 	});
 	it('maps null/undefined to none (transparent)', () => {
-		expect(expectedBadge(null)).toEqual({ variant: 'transparent', label: 'None' });
+		expect(expectedBadge(null)).toEqual({
+			variant: 'transparent',
+			label: 'None'
+		});
 		expect(expectedBadge(undefined)).toEqual({
 			variant: 'transparent',
 			label: 'None'

--- a/libs/bublik/features/result-classification/src/lib/expected.spec.ts
+++ b/libs/bublik/features/result-classification/src/lib/expected.spec.ts
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from 'vitest';
+
+import { expectedBadge } from './expected';
+
+describe('expectedBadge', () => {
+	it('maps true to expected', () => {
+		expect(expectedBadge(true)).toEqual({ variant: 'expected', label: 'Expected' });
+	});
+	it('maps false to unexpected', () => {
+		expect(expectedBadge(false)).toEqual({
+			variant: 'unexpected',
+			label: 'Unexpected'
+		});
+	});
+	it('maps null/undefined to none (transparent)', () => {
+		expect(expectedBadge(null)).toEqual({ variant: 'transparent', label: 'None' });
+		expect(expectedBadge(undefined)).toEqual({
+			variant: 'transparent',
+			label: 'None'
+		});
+	});
+});

--- a/libs/bublik/features/result-classification/src/lib/expected.ts
+++ b/libs/bublik/features/result-classification/src/lib/expected.ts
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+export interface ExpectedBadge {
+	variant: 'expected' | 'unexpected' | 'transparent';
+	label: string;
+}
+
+/** Disposition badge for a tri-state expected flag.
+ * true = expected (green), false = unexpected (red), null = none (neutral). */
+export function expectedBadge(expected: boolean | null | undefined): ExpectedBadge {
+	if (expected === true) return { variant: 'expected', label: 'Expected' };
+	if (expected === false) return { variant: 'unexpected', label: 'Unexpected' };
+	return { variant: 'transparent', label: 'None' };
+}

--- a/libs/bublik/features/result-classification/src/lib/expected.ts
+++ b/libs/bublik/features/result-classification/src/lib/expected.ts
@@ -7,7 +7,9 @@ export interface ExpectedBadge {
 
 /** Disposition badge for a tri-state expected flag.
  * true = expected (green), false = unexpected (red), null = none (neutral). */
-export function expectedBadge(expected: boolean | null | undefined): ExpectedBadge {
+export function expectedBadge(
+	expected: boolean | null | undefined
+): ExpectedBadge {
 	if (expected === true) return { variant: 'expected', label: 'Expected' };
 	if (expected === false) return { variant: 'unexpected', label: 'Unexpected' };
 	return { variant: 'transparent', label: 'None' };

--- a/libs/bublik/features/result-classification/src/lib/issue-picker.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issue-picker.tsx
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { useEffect, useState } from 'react';
+
+import { useGetIssuePickerQuery } from '@/services/bublik-api';
+import {
+	ButtonTw,
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+	Icon,
+	Popover,
+	PopoverContent,
+	PopoverTrigger
+} from '@/shared/tailwind-ui';
+
+import { issueTag } from './issue-picker.utils';
+
+function useDebouncedValue<T>(value: T, delayMs: number): T {
+	const [debounced, setDebounced] = useState(value);
+	useEffect(() => {
+		const id = setTimeout(() => setDebounced(value), delayMs);
+		return () => clearTimeout(id);
+	}, [value, delayMs]);
+	return debounced;
+}
+
+export interface IssuePickerProps {
+	projectId?: number;
+	value?: number;
+	onChange: (id: number) => void;
+}
+
+export function IssuePicker({ projectId, value, onChange }: IssuePickerProps) {
+	const [open, setOpen] = useState(false);
+	const [query, setQuery] = useState('');
+	const search = useDebouncedValue(query, 250);
+
+	const { data, isFetching, isError } = useGetIssuePickerQuery({
+		projectId,
+		search: search || undefined
+	});
+	const options = data ?? [];
+	const selected = options.find((o) => o.id === value);
+
+	return (
+		<Popover open={open} onOpenChange={setOpen} modal>
+			<PopoverTrigger asChild>
+				<ButtonTw
+					type="button"
+					variant="secondary"
+					size="xss"
+					className="justify-between w-full"
+				>
+					<span className="truncate">
+						{selected
+							? `${issueTag(selected)}: ${selected.title}`
+							: value
+								? `#${value}`
+								: 'Search issue…'}
+					</span>
+					<Icon name="ArrowShortSmall" size={16} className="ml-1 -rotate-90" />
+				</ButtonTw>
+			</PopoverTrigger>
+			<PopoverContent sideOffset={6} className="p-0 w-[320px]">
+				<Command shouldFilter={false}>
+					<CommandInput
+						value={query}
+						onValueChange={setQuery}
+						placeholder="Search by key or title…"
+					/>
+					<CommandList>
+						{isFetching ? (
+							<div className="py-4 text-xs text-center text-text-menu">Loading…</div>
+						) : null}
+						{isError ? (
+							<div className="py-4 text-xs text-center text-text-menu">
+								Couldn't load issues
+							</div>
+						) : null}
+						{!isFetching && !isError && options.length === 0 ? (
+							<CommandEmpty>
+								{search ? 'No matches' : 'No issues yet — create one'}
+							</CommandEmpty>
+						) : null}
+						<CommandGroup>
+							{options.map((o) => (
+								<CommandItem
+									key={o.id}
+									value={String(o.id)}
+									onSelect={() => {
+										onChange(o.id);
+										setOpen(false);
+									}}
+								>
+									<span className="mr-1 font-medium">{issueTag(o)}:</span>
+									<span className="truncate">{o.title}</span>
+								</CommandItem>
+							))}
+						</CommandGroup>
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/libs/bublik/features/result-classification/src/lib/issue-picker.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issue-picker.tsx
@@ -45,7 +45,9 @@ export function IssuePicker({ projectId, value, onChange }: IssuePickerProps) {
 			/>
 			<div className="overflow-y-auto max-h-48">
 				{isFetching ? (
-					<div className="py-3 text-xs text-center text-text-menu">Loading…</div>
+					<div className="py-3 text-xs text-center text-text-menu">
+						Loading…
+					</div>
 				) : null}
 				{isError ? (
 					<div className="py-3 text-xs text-center text-text-menu">

--- a/libs/bublik/features/result-classification/src/lib/issue-picker.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issue-picker.tsx
@@ -3,17 +3,13 @@ import { useEffect, useState } from 'react';
 
 import { useGetIssuePickerQuery } from '@/services/bublik-api';
 import {
-	ButtonTw,
 	Command,
 	CommandEmpty,
 	CommandGroup,
 	CommandInput,
 	CommandItem,
 	CommandList,
-	Icon,
-	Popover,
-	PopoverContent,
-	PopoverTrigger
+	cn
 } from '@/shared/tailwind-ui';
 
 import { issueTag } from './issue-picker.utils';
@@ -33,8 +29,9 @@ export interface IssuePickerProps {
 	onChange: (id: number) => void;
 }
 
+// Rendered inline (not in a nested Popover) so selecting an option doesn't get
+// treated as an outside-click by the surrounding classify popover.
 export function IssuePicker({ projectId, value, onChange }: IssuePickerProps) {
-	const [open, setOpen] = useState(false);
 	const [query, setQuery] = useState('');
 	const search = useDebouncedValue(query, 250);
 
@@ -43,66 +40,48 @@ export function IssuePicker({ projectId, value, onChange }: IssuePickerProps) {
 		search: search || undefined
 	});
 	const options = data ?? [];
-	const selected = options.find((o) => o.id === value);
 
 	return (
-		<Popover open={open} onOpenChange={setOpen} modal>
-			<PopoverTrigger asChild>
-				<ButtonTw
-					type="button"
-					variant="secondary"
-					size="xss"
-					className="justify-between w-full"
-				>
-					<span className="truncate">
-						{selected
-							? `${issueTag(selected)}: ${selected.title}`
-							: value
-								? `#${value}`
-								: 'Search issue…'}
-					</span>
-					<Icon name="ArrowShortSmall" size={16} className="ml-1 -rotate-90" />
-				</ButtonTw>
-			</PopoverTrigger>
-			<PopoverContent sideOffset={6} className="p-0 w-[320px]">
-				<Command shouldFilter={false}>
-					<CommandInput
-						value={query}
-						onValueChange={setQuery}
-						placeholder="Search by key or title…"
-					/>
-					<CommandList>
-						{isFetching ? (
-							<div className="py-4 text-xs text-center text-text-menu">Loading…</div>
-						) : null}
-						{isError ? (
-							<div className="py-4 text-xs text-center text-text-menu">
-								Couldn't load issues
-							</div>
-						) : null}
-						{!isFetching && !isError && options.length === 0 ? (
-							<CommandEmpty>
-								{search ? 'No matches' : 'No issues yet — create one'}
-							</CommandEmpty>
-						) : null}
-						<CommandGroup>
-							{options.map((o) => (
-								<CommandItem
-									key={o.id}
-									value={String(o.id)}
-									onSelect={() => {
-										onChange(o.id);
-										setOpen(false);
-									}}
-								>
-									<span className="mr-1 font-medium">{issueTag(o)}:</span>
-									<span className="truncate">{o.title}</span>
-								</CommandItem>
-							))}
-						</CommandGroup>
-					</CommandList>
-				</Command>
-			</PopoverContent>
-		</Popover>
+		<Command
+			shouldFilter={false}
+			className="border border-border-primary rounded-md"
+		>
+			<CommandInput
+				value={query}
+				onValueChange={setQuery}
+				placeholder="Search by key or title…"
+			/>
+			<CommandList className="max-h-48">
+				{isFetching ? (
+					<div className="py-3 text-xs text-center text-text-menu">Loading…</div>
+				) : null}
+				{isError ? (
+					<div className="py-3 text-xs text-center text-text-menu">
+						Couldn't load issues
+					</div>
+				) : null}
+				{!isFetching && !isError && options.length === 0 ? (
+					<CommandEmpty>
+						{search ? 'No matches' : 'No issues yet — create one'}
+					</CommandEmpty>
+				) : null}
+				<CommandGroup>
+					{options.map((o) => (
+						<CommandItem
+							key={o.id}
+							value={String(o.id)}
+							onSelect={() => onChange(o.id)}
+							className={cn(
+								'cursor-pointer',
+								value === o.id && 'bg-primary-wash font-semibold'
+							)}
+						>
+							<span className="mr-1 font-medium">{issueTag(o)}:</span>
+							<span className="truncate">{o.title}</span>
+						</CommandItem>
+					))}
+				</CommandGroup>
+			</CommandList>
+		</Command>
 	);
 }

--- a/libs/bublik/features/result-classification/src/lib/issue-picker.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issue-picker.tsx
@@ -2,15 +2,7 @@
 import { useEffect, useState } from 'react';
 
 import { useGetIssuePickerQuery } from '@/services/bublik-api';
-import {
-	Command,
-	CommandEmpty,
-	CommandGroup,
-	CommandInput,
-	CommandItem,
-	CommandList,
-	cn
-} from '@/shared/tailwind-ui';
+import { cn } from '@/shared/tailwind-ui';
 
 import { issueTag } from './issue-picker.utils';
 
@@ -29,8 +21,9 @@ export interface IssuePickerProps {
 	onChange: (id: number) => void;
 }
 
-// Rendered inline (not in a nested Popover) so selecting an option doesn't get
-// treated as an outside-click by the surrounding classify popover.
+// Plain input + button list (no cmdk / nested Popover): cmdk's focus handling
+// and a nested Popover both made the surrounding classify popover dismiss on
+// select. type="button" also stops the list from submitting the classify form.
 export function IssuePicker({ projectId, value, onChange }: IssuePickerProps) {
 	const [query, setQuery] = useState('');
 	const search = useDebouncedValue(query, 250);
@@ -42,16 +35,15 @@ export function IssuePicker({ projectId, value, onChange }: IssuePickerProps) {
 	const options = data ?? [];
 
 	return (
-		<Command
-			shouldFilter={false}
-			className="border border-border-primary rounded-md"
-		>
-			<CommandInput
+		<div className="flex flex-col overflow-hidden border rounded-md border-border-primary">
+			<input
+				type="text"
 				value={query}
-				onValueChange={setQuery}
-				placeholder="Search by key or title…"
+				onChange={(e) => setQuery(e.target.value)}
+				placeholder="Search issue by key or title…"
+				className="px-3 py-2 text-sm border-b outline-none border-border-primary placeholder:text-text-menu"
 			/>
-			<CommandList className="max-h-48">
+			<div className="overflow-y-auto max-h-48">
 				{isFetching ? (
 					<div className="py-3 text-xs text-center text-text-menu">Loading…</div>
 				) : null}
@@ -61,27 +53,25 @@ export function IssuePicker({ projectId, value, onChange }: IssuePickerProps) {
 					</div>
 				) : null}
 				{!isFetching && !isError && options.length === 0 ? (
-					<CommandEmpty>
+					<div className="py-3 text-xs text-center text-text-menu">
 						{search ? 'No matches' : 'No issues yet — create one'}
-					</CommandEmpty>
+					</div>
 				) : null}
-				<CommandGroup>
-					{options.map((o) => (
-						<CommandItem
-							key={o.id}
-							value={String(o.id)}
-							onSelect={() => onChange(o.id)}
-							className={cn(
-								'cursor-pointer',
-								value === o.id && 'bg-primary-wash font-semibold'
-							)}
-						>
-							<span className="mr-1 font-medium">{issueTag(o)}:</span>
-							<span className="truncate">{o.title}</span>
-						</CommandItem>
-					))}
-				</CommandGroup>
-			</CommandList>
-		</Command>
+				{options.map((o) => (
+					<button
+						type="button"
+						key={o.id}
+						onClick={() => onChange(o.id)}
+						className={cn(
+							'flex w-full items-center px-3 py-2 text-sm text-left hover:bg-primary-wash',
+							value === o.id && 'bg-primary-wash font-semibold'
+						)}
+					>
+						<span className="mr-1 font-medium">{issueTag(o)}:</span>
+						<span className="truncate">{o.title}</span>
+					</button>
+				))}
+			</div>
+		</div>
 	);
 }

--- a/libs/bublik/features/result-classification/src/lib/issue-picker.utils.spec.ts
+++ b/libs/bublik/features/result-classification/src/lib/issue-picker.utils.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { issueTag } from './issue-picker.utils';
+
+describe('issueTag', () => {
+	it('prefers the bug key', () => {
+		expect(issueTag({ id: 1, key: 'ISSUE-7', category: 'flaky' })).toBe('ISSUE-7');
+	});
+	it('falls back to category', () => {
+		expect(issueTag({ id: 1, key: null, category: 'known-issue' })).toBe('known-issue');
+	});
+	it('falls back to #id', () => {
+		expect(issueTag({ id: 42, key: null, category: null })).toBe('#42');
+	});
+});

--- a/libs/bublik/features/result-classification/src/lib/issue-picker.utils.spec.ts
+++ b/libs/bublik/features/result-classification/src/lib/issue-picker.utils.spec.ts
@@ -3,10 +3,14 @@ import { issueTag } from './issue-picker.utils';
 
 describe('issueTag', () => {
 	it('prefers the bug key', () => {
-		expect(issueTag({ id: 1, key: 'ISSUE-7', category: 'flaky' })).toBe('ISSUE-7');
+		expect(issueTag({ id: 1, key: 'ISSUE-7', category: 'flaky' })).toBe(
+			'ISSUE-7'
+		);
 	});
 	it('falls back to category', () => {
-		expect(issueTag({ id: 1, key: null, category: 'known-issue' })).toBe('known-issue');
+		expect(issueTag({ id: 1, key: null, category: 'known-issue' })).toBe(
+			'known-issue'
+		);
 	});
 	it('falls back to #id', () => {
 		expect(issueTag({ id: 42, key: null, category: null })).toBe('#42');

--- a/libs/bublik/features/result-classification/src/lib/issue-picker.utils.ts
+++ b/libs/bublik/features/result-classification/src/lib/issue-picker.utils.ts
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import type { IssueCategory } from '@/shared/types';
+
+/** Display tag for an issue option: bug key, else category, else #id. */
+export function issueTag(o: {
+	id: number;
+	key: string | null;
+	category: IssueCategory | null;
+}): string {
+	return o.key ?? o.category ?? `#${o.id}`;
+}

--- a/libs/bublik/features/result-classification/src/lib/issue-results.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issue-results.tsx
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { useGetIssueResultsQuery } from '@/services/bublik-api';
+import { routes } from '@/router';
+import { LinkWithProject } from '@/bublik/features/projects';
+import { Badge, Icon, Skeleton } from '@/shared/tailwind-ui';
+import { BublikErrorState } from '@/bublik/features/ui-state';
+
+import { expectedBadge } from './expected';
+
+interface IssueResultsProps {
+	issueId: number;
+	projectId?: number;
+}
+
+/** Consolidated list of every result classified under an issue, across all of
+ * its rules/tests. Newest run first (ordering done server-side). */
+export function IssueResults({ issueId, projectId }: IssueResultsProps) {
+	const { data, isLoading, error } = useGetIssueResultsQuery({
+		issueId,
+		projectId,
+		limit: 50
+	});
+
+	if (isLoading) {
+		return (
+			<div className="flex flex-col gap-1 py-2">
+				{Array.from({ length: 4 }, () => 0).map((_, idx) => (
+					<Skeleton key={idx} className="h-8 rounded-md" />
+				))}
+			</div>
+		);
+	}
+
+	if (error) return <BublikErrorState error={error} className="py-4" />;
+
+	const results = data ?? [];
+	if (results.length === 0) {
+		return (
+			<div className="px-4 py-3 text-sm text-text-menu">
+				No results classified under this issue yet
+			</div>
+		);
+	}
+
+	return (
+		<ul className="flex flex-col gap-0.5">
+			{results.map((row) => (
+				<li
+					key={row.result_id}
+					className="flex items-center gap-3 px-2 py-1 text-sm rounded hover:bg-primary-wash"
+				>
+					<span className="font-medium text-text-primary">{row.name ?? '-'}</span>
+					{row.path.length ? (
+						<span className="text-xs text-text-menu">{row.path.join(' / ')}</span>
+					) : null}
+					{row.category ? <Badge>{row.category}</Badge> : null}
+					{row.expected !== undefined ? (
+						<Badge variant={expectedBadge(row.expected).variant}>
+							{expectedBadge(row.expected).label}
+						</Badge>
+					) : null}
+					{row.obtained_result ? (
+						<Badge variant="unexpected">{row.obtained_result}</Badge>
+					) : null}
+					{row.verdicts.length ? (
+						<span className="text-text-menu">{row.verdicts.join(', ')}</span>
+					) : null}
+					{row.run_id ? (
+						<LinkWithProject
+							to={routes.log({ runId: row.run_id, focusId: row.result_id })}
+							className="inline-flex items-center gap-1 ml-auto hover:text-primary hover:underline"
+						>
+							<Icon name="BoxArrowRight" size={14} />
+							Log
+						</LinkWithProject>
+					) : null}
+				</li>
+			))}
+		</ul>
+	);
+}

--- a/libs/bublik/features/result-classification/src/lib/issue-results.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issue-results.tsx
@@ -49,9 +49,13 @@ export function IssueResults({ issueId, projectId }: IssueResultsProps) {
 					key={row.result_id}
 					className="flex items-center gap-3 px-2 py-1 text-sm rounded hover:bg-primary-wash"
 				>
-					<span className="font-medium text-text-primary">{row.name ?? '-'}</span>
+					<span className="font-medium text-text-primary">
+						{row.name ?? '-'}
+					</span>
 					{row.path.length ? (
-						<span className="text-xs text-text-menu">{row.path.join(' / ')}</span>
+						<span className="text-xs text-text-menu">
+							{row.path.join(' / ')}
+						</span>
 					) : null}
 					{row.category ? <Badge>{row.category}</Badge> : null}
 					{row.expected !== undefined ? (

--- a/libs/bublik/features/result-classification/src/lib/issue-rule-results.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issue-rule-results.tsx
@@ -1,0 +1,71 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { useGetIssueRuleResultsQuery } from '@/services/bublik-api';
+import { routes } from '@/router';
+import { LinkWithProject } from '@/bublik/features/projects';
+import { Badge, Icon, Skeleton } from '@/shared/tailwind-ui';
+import { BublikErrorState } from '@/bublik/features/ui-state';
+
+interface IssueRuleResultsProps {
+	ruleId: number;
+	projectId?: number;
+}
+
+export function IssueRuleResults({ ruleId, projectId }: IssueRuleResultsProps) {
+	const { data, isLoading, error } = useGetIssueRuleResultsQuery({
+		ruleId,
+		projectId,
+		limit: 20
+	});
+
+	if (isLoading) {
+		return (
+			<div className="flex flex-col gap-1 py-2">
+				{Array.from({ length: 3 }, () => 0).map((_, idx) => (
+					<Skeleton key={idx} className="h-8 rounded-md" />
+				))}
+			</div>
+		);
+	}
+
+	if (error) return <BublikErrorState error={error} className="py-4" />;
+
+	const results = data ?? [];
+	if (results.length === 0) {
+		return (
+			<div className="px-4 py-3 text-sm text-text-menu">
+				No results classified by this rule yet
+			</div>
+		);
+	}
+
+	return (
+		<ul className="flex flex-col gap-0.5 px-4 py-3">
+			{results.map((row) => (
+				<li
+					key={row.result_id}
+					className="flex items-center gap-3 px-2 py-1 text-sm rounded hover:bg-primary-wash"
+				>
+					<span className="font-medium text-text-primary">{row.name ?? '-'}</span>
+					{row.path.length ? (
+						<span className="text-xs text-text-menu">{row.path.join(' / ')}</span>
+					) : null}
+					{row.obtained_result ? (
+						<Badge variant="unexpected">{row.obtained_result}</Badge>
+					) : null}
+					{row.verdicts.length ? (
+						<span className="text-text-menu">{row.verdicts.join(', ')}</span>
+					) : null}
+					{row.run_id ? (
+						<LinkWithProject
+							to={routes.log({ runId: row.run_id, focusId: row.result_id })}
+							className="inline-flex items-center gap-1 ml-auto hover:text-primary hover:underline"
+						>
+							<Icon name="BoxArrowRight" size={14} />
+							Log
+						</LinkWithProject>
+					) : null}
+				</li>
+			))}
+		</ul>
+	);
+}

--- a/libs/bublik/features/result-classification/src/lib/issue-rule-results.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issue-rule-results.tsx
@@ -45,9 +45,13 @@ export function IssueRuleResults({ ruleId, projectId }: IssueRuleResultsProps) {
 					key={row.result_id}
 					className="flex items-center gap-3 px-2 py-1 text-sm rounded hover:bg-primary-wash"
 				>
-					<span className="font-medium text-text-primary">{row.name ?? '-'}</span>
+					<span className="font-medium text-text-primary">
+						{row.name ?? '-'}
+					</span>
 					{row.path.length ? (
-						<span className="text-xs text-text-menu">{row.path.join(' / ')}</span>
+						<span className="text-xs text-text-menu">
+							{row.path.join(' / ')}
+						</span>
 					) : null}
 					{row.obtained_result ? (
 						<Badge variant="unexpected">{row.obtained_result}</Badge>

--- a/libs/bublik/features/result-classification/src/lib/issue-rule-row.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issue-rule-row.tsx
@@ -1,0 +1,123 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { useState } from 'react';
+
+import {
+	getErrorMessage,
+	useActivateRuleMutation,
+	useDeactivateRuleMutation
+} from '@/services/bublik-api';
+import { Badge, ButtonTw, Icon, cn, toast } from '@/shared/tailwind-ui';
+import type { IssueRule } from '@/shared/types';
+
+import { CATEGORY_OPTIONS } from './category';
+import { chipsForFlags } from './match-scope.utils';
+import { IssueRuleResults } from './issue-rule-results';
+
+function categoryLabel(category: string): string {
+	return CATEGORY_OPTIONS.find((c) => c.value === category)?.displayValue ?? category;
+}
+
+function notifyError(err: unknown) {
+	const m = getErrorMessage(err);
+	return `${m.title}\n${m.description}`;
+}
+
+const cellClassName =
+	'px-4 py-2 text-sm border-t border-b border-transparent first:border-l last:border-r first:rounded-l last:rounded-r group-hover:border-primary group-hover:first:border-primary group-hover:last:border-primary';
+
+export interface IssueRuleRowProps {
+	rule: IssueRule;
+	projectId?: number;
+}
+
+export function IssueRuleRow({ rule, projectId }: IssueRuleRowProps) {
+	const [expanded, setExpanded] = useState(false);
+	const [activate, activateState] = useActivateRuleMutation();
+	const [deactivate, deactivateState] = useDeactivateRuleMutation();
+	const isBusy = activateState.isLoading || deactivateState.isLoading;
+
+	function toggleActive() {
+		const action = rule.active ? deactivate : activate;
+		const promise = action({ ruleId: rule.id, projectId }).unwrap();
+		toast.promise(promise, {
+			loading: rule.active ? 'Disabling rule...' : 'Enabling rule...',
+			success: rule.active ? 'Rule disabled' : 'Rule enabled',
+			error: notifyError,
+			position: 'top-center'
+		});
+	}
+
+	const chips = chipsForFlags({
+		matchParameters: rule.match_parameters,
+		matchVerdicts: rule.match_verdicts,
+		matchImportantTags: rule.match_important_tags,
+		matchAllTags: rule.match_all_tags
+	});
+
+	return (
+		<>
+			<tr className="group">
+				<td className={cn(cellClassName, 'font-medium text-text-primary')}>
+					{rule.test_name}
+				</td>
+				<td className={cellClassName}>{categoryLabel(rule.category)}</td>
+				<td className={cellClassName}>
+					<Badge variant={rule.expected ? 'expected' : 'unexpected'}>
+						{rule.expected ? 'Expected' : 'Unexpected'}
+					</Badge>
+				</td>
+				<td className={cellClassName}>
+					<div className="flex flex-wrap gap-1">
+						{chips.map((chip) => (
+							<span
+								key={chip}
+								className="px-1.5 py-0.5 text-[0.6875rem] rounded bg-primary-wash border border-border-primary"
+							>
+								{chip}
+							</span>
+						))}
+					</div>
+				</td>
+				<td className={cellClassName}>
+					<Badge variant={rule.active ? 'expected' : 'unexpected'}>
+						{rule.active ? 'Active' : 'Inactive'}
+					</Badge>
+				</td>
+				<td className={cn(cellClassName, 'text-right')}>
+					<div className="inline-flex items-center gap-2">
+						<ButtonTw
+							variant={rule.active ? 'destruction-secondary' : 'secondary'}
+							size="xss"
+							state={isBusy ? 'loading' : 'default'}
+							onClick={toggleActive}
+						>
+							{rule.active ? 'Disable' : 'Enable'}
+						</ButtonTw>
+						<button
+							type="button"
+							onClick={() => setExpanded((v) => !v)}
+							className="inline-flex items-center gap-1 hover:text-primary"
+							aria-expanded={expanded}
+						>
+							Failures
+							<Icon
+								name="ArrowShortSmall"
+								className={cn(
+									'grid place-items-center transition-transform',
+									expanded ? 'rotate-360' : '-rotate-90'
+								)}
+							/>
+						</button>
+					</div>
+				</td>
+			</tr>
+			{expanded ? (
+				<tr>
+					<td colSpan={6} className="border-b border-border-primary bg-primary-wash/40">
+						<IssueRuleResults ruleId={rule.id} projectId={projectId} />
+					</td>
+				</tr>
+			) : null}
+		</>
+	);
+}

--- a/libs/bublik/features/result-classification/src/lib/issue-rule-row.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issue-rule-row.tsx
@@ -10,6 +10,7 @@ import { Badge, ButtonTw, Icon, cn, toast } from '@/shared/tailwind-ui';
 import type { IssueRule } from '@/shared/types';
 
 import { CATEGORY_OPTIONS } from './category';
+import { expectedBadge } from './expected';
 import { chipsForFlags } from './match-scope.utils';
 import { IssueRuleResults } from './issue-rule-results';
 
@@ -53,6 +54,7 @@ export function IssueRuleRow({ rule, projectId }: IssueRuleRowProps) {
 		matchImportantTags: rule.match_important_tags,
 		matchAllTags: rule.match_all_tags
 	});
+	const exp = expectedBadge(rule.expected);
 
 	return (
 		<>
@@ -62,9 +64,7 @@ export function IssueRuleRow({ rule, projectId }: IssueRuleRowProps) {
 				</td>
 				<td className={cellClassName}>{categoryLabel(rule.category)}</td>
 				<td className={cellClassName}>
-					<Badge variant={rule.expected ? 'expected' : 'unexpected'}>
-						{rule.expected ? 'Expected' : 'Unexpected'}
-					</Badge>
+					<Badge variant={exp.variant}>{exp.label}</Badge>
 				</td>
 				<td className={cellClassName}>
 					<div className="flex flex-wrap gap-1">

--- a/libs/bublik/features/result-classification/src/lib/issue-rule-row.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issue-rule-row.tsx
@@ -15,7 +15,9 @@ import { chipsForFlags } from './match-scope.utils';
 import { IssueRuleResults } from './issue-rule-results';
 
 function categoryLabel(category: string): string {
-	return CATEGORY_OPTIONS.find((c) => c.value === category)?.displayValue ?? category;
+	return (
+		CATEGORY_OPTIONS.find((c) => c.value === category)?.displayValue ?? category
+	);
 }
 
 function notifyError(err: unknown) {
@@ -113,7 +115,10 @@ export function IssueRuleRow({ rule, projectId }: IssueRuleRowProps) {
 			</tr>
 			{expanded ? (
 				<tr>
-					<td colSpan={6} className="border-b border-border-primary bg-primary-wash/40">
+					<td
+						colSpan={6}
+						className="border-b border-border-primary bg-primary-wash/40"
+					>
 						<IssueRuleResults ruleId={rule.id} projectId={projectId} />
 					</td>
 				</tr>

--- a/libs/bublik/features/result-classification/src/lib/issue-rules-table.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issue-rules-table.tsx
@@ -90,11 +90,6 @@ export function IssueRulesTable({ issueId, projectId }: IssueRulesTableProps) {
 				) : null}
 			</div>
 
-			<section className="flex flex-col gap-2">
-				<h2 className={sectionHeaderClassName}>Results</h2>
-				<IssueResults issueId={issueId} projectId={projectId} />
-			</section>
-
 			<h2 className={sectionHeaderClassName}>Rules</h2>
 			{rules.length === 0 ? (
 				<BublikEmptyState
@@ -123,6 +118,11 @@ export function IssueRulesTable({ issueId, projectId }: IssueRulesTableProps) {
 					</table>
 				</div>
 			)}
+
+			<section className="flex flex-col gap-2">
+				<h2 className={sectionHeaderClassName}>Results</h2>
+				<IssueResults issueId={issueId} projectId={projectId} />
+			</section>
 		</div>
 	);
 }

--- a/libs/bublik/features/result-classification/src/lib/issue-rules-table.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issue-rules-table.tsx
@@ -10,6 +10,10 @@ import { Badge, ButtonTw, Icon, Skeleton, toast } from '@/shared/tailwind-ui';
 import { BublikEmptyState, BublikErrorState } from '@/bublik/features/ui-state';
 
 import { IssueRuleRow } from './issue-rule-row';
+import { IssueResults } from './issue-results';
+
+const sectionHeaderClassName =
+	'text-xs font-bold tracking-wider uppercase text-text-menu';
 
 function notifyError(err: unknown) {
 	const m = getErrorMessage(err);
@@ -86,6 +90,12 @@ export function IssueRulesTable({ issueId, projectId }: IssueRulesTableProps) {
 				) : null}
 			</div>
 
+			<section className="flex flex-col gap-2">
+				<h2 className={sectionHeaderClassName}>Results</h2>
+				<IssueResults issueId={issueId} projectId={projectId} />
+			</section>
+
+			<h2 className={sectionHeaderClassName}>Rules</h2>
 			{rules.length === 0 ? (
 				<BublikEmptyState
 					title="No rules"

--- a/libs/bublik/features/result-classification/src/lib/issue-rules-table.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issue-rules-table.tsx
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import {
+	getErrorMessage,
+	useCloseIssueMutation,
+	useGetIssueQuery,
+	useGetIssueRulesQuery,
+	useReopenIssueMutation
+} from '@/services/bublik-api';
+import { Badge, ButtonTw, Icon, Skeleton, toast } from '@/shared/tailwind-ui';
+import { BublikEmptyState, BublikErrorState } from '@/bublik/features/ui-state';
+
+import { IssueRuleRow } from './issue-rule-row';
+
+function notifyError(err: unknown) {
+	const m = getErrorMessage(err);
+	return `${m.title}\n${m.description}`;
+}
+
+const headerClassName =
+	'px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-left uppercase';
+
+export interface IssueRulesTableProps {
+	issueId: number;
+	projectId?: number;
+}
+
+export function IssueRulesTable({ issueId, projectId }: IssueRulesTableProps) {
+	const issueQuery = useGetIssueQuery({ issueId, projectId });
+	const rulesQuery = useGetIssueRulesQuery({ projectId, issue: issueId });
+	const [closeIssue, closeState] = useCloseIssueMutation();
+	const [reopenIssue, reopenState] = useReopenIssueMutation();
+
+	const issue = issueQuery.data;
+	const isOpen = issue?.state === 'open';
+	const isBusy = closeState.isLoading || reopenState.isLoading;
+
+	function handleToggleState() {
+		if (!issue) return;
+		const action = isOpen ? closeIssue : reopenIssue;
+		const promise = action({ issueId: issue.id, projectId }).unwrap();
+		toast.promise(promise, {
+			loading: isOpen ? 'Closing issue...' : 'Reopening issue...',
+			success: isOpen ? 'Issue closed' : 'Issue reopened',
+			error: notifyError,
+			position: 'top-center'
+		});
+	}
+
+	if (issueQuery.isLoading || rulesQuery.isLoading) {
+		return (
+			<div className="flex flex-col gap-1 mt-1">
+				{Array.from({ length: 8 }, () => 0).map((_, idx) => (
+					<Skeleton key={idx} className="h-10 rounded-md" />
+				))}
+			</div>
+		);
+	}
+
+	if (issueQuery.error) {
+		return <BublikErrorState error={issueQuery.error} className="h-[60vh]" />;
+	}
+
+	const rules = rulesQuery.data ?? [];
+
+	return (
+		<div className="flex flex-col gap-4">
+			<div className="flex items-center gap-3">
+				<Icon name="TriangleExclamationMark" size={18} />
+				<h1 className="text-lg font-semibold">{issue?.title ?? `Issue #${issueId}`}</h1>
+				{issue?.issue_ext?.key ? (
+					<span className="text-sm text-text-menu">{issue.issue_ext.key}</span>
+				) : null}
+				<Badge variant={isOpen ? 'unexpected' : 'expected'}>
+					{isOpen ? 'Open' : 'Closed'}
+				</Badge>
+				{issue ? (
+					<ButtonTw
+						variant={isOpen ? 'destruction-secondary' : 'secondary'}
+						size="xss"
+						state={isBusy ? 'loading' : 'default'}
+						className="ml-auto"
+						onClick={handleToggleState}
+					>
+						{isOpen ? 'Close issue' : 'Reopen issue'}
+					</ButtonTw>
+				) : null}
+			</div>
+
+			{rules.length === 0 ? (
+				<BublikEmptyState
+					title="No rules"
+					description="This issue has no rules in the active project"
+					className="h-[40vh]"
+				/>
+			) : (
+				<div className="overflow-x-auto">
+					<table className="min-w-full border-separate table-fixed border-spacing-y-1">
+						<thead className="bg-white">
+							<tr className="h-8.5">
+								<th className={headerClassName}>Test</th>
+								<th className={headerClassName}>Category</th>
+								<th className={headerClassName}>Expected</th>
+								<th className={headerClassName}>Match scope</th>
+								<th className={headerClassName}>State</th>
+								<th className={`${headerClassName} text-right`}>Actions</th>
+							</tr>
+						</thead>
+						<tbody className="bg-white">
+							{rules.map((rule) => (
+								<IssueRuleRow key={rule.id} rule={rule} projectId={projectId} />
+							))}
+						</tbody>
+					</table>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/libs/bublik/features/result-classification/src/lib/issue-rules-table.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issue-rules-table.tsx
@@ -70,7 +70,9 @@ export function IssueRulesTable({ issueId, projectId }: IssueRulesTableProps) {
 		<div className="flex flex-col gap-4">
 			<div className="flex items-center gap-3">
 				<Icon name="TriangleExclamationMark" size={18} />
-				<h1 className="text-lg font-semibold">{issue?.title ?? `Issue #${issueId}`}</h1>
+				<h1 className="text-lg font-semibold">
+					{issue?.title ?? `Issue #${issueId}`}
+				</h1>
 				{issue?.issue_ext?.key ? (
 					<span className="text-sm text-text-menu">{issue.issue_ext.key}</span>
 				) : null}

--- a/libs/bublik/features/result-classification/src/lib/issues-table.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issues-table.tsx
@@ -5,7 +5,7 @@ import {
 	useGetIssuesQuery,
 	useReopenIssueMutation
 } from '@/services/bublik-api';
-import { useProjectSearch } from '@/bublik/features/projects';
+import { useProjectSearch, LinkWithProject } from '@/bublik/features/projects';
 import { Badge, ButtonTw, Icon, Skeleton, toast } from '@/shared/tailwind-ui';
 import { BublikEmptyState, BublikErrorState } from '@/bublik/features/ui-state';
 import type { Issue } from '@/shared/types';
@@ -50,7 +50,12 @@ function IssueRow({ issue, projectId }: IssueRowProps) {
 	return (
 		<tr className="group">
 			<td className="px-4 py-2 text-sm font-medium border-t border-b border-transparent text-text-primary first:border-l last:border-r first:rounded-l last:rounded-r group-hover:border-primary group-hover:first:border-primary group-hover:last:border-primary">
-				<span className="font-medium">{issue.title}</span>
+				<LinkWithProject
+					to={`/admin/issues/${issue.id}`}
+					className="font-medium hover:text-primary hover:underline"
+				>
+					{issue.title}
+				</LinkWithProject>
 				{issue.issue_ext?.key ? (
 					<span className="ml-2 text-text-menu text-xs">
 						{issue.issue_ext.key}

--- a/libs/bublik/features/result-classification/src/lib/issues-table.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issues-table.tsx
@@ -68,25 +68,33 @@ function IssueRow({ issue, projectId }: IssueRowProps) {
 				</Badge>
 			</td>
 			<td className="px-4 py-2 text-sm text-right border-t border-b border-transparent last:border-r last:rounded-r group-hover:border-primary group-hover:last:border-primary">
-				{isOpen ? (
-					<ButtonTw
-						variant="destruction-secondary"
-						size="xss"
-						state={isBusy ? 'loading' : 'default'}
-						onClick={handleClose}
-					>
-						Close
+				<div className="flex items-center justify-end gap-2">
+					<ButtonTw asChild variant="secondary" size="xss">
+						<LinkWithProject to={`/admin/issues/${issue.id}`}>
+							<Icon name="Paper" size={14} className="mr-1.5" />
+							Results
+						</LinkWithProject>
 					</ButtonTw>
-				) : (
-					<ButtonTw
-						variant="secondary"
-						size="xss"
-						state={isBusy ? 'loading' : 'default'}
-						onClick={handleReopen}
-					>
-						Reopen
-					</ButtonTw>
-				)}
+					{isOpen ? (
+						<ButtonTw
+							variant="destruction-secondary"
+							size="xss"
+							state={isBusy ? 'loading' : 'default'}
+							onClick={handleClose}
+						>
+							Close
+						</ButtonTw>
+					) : (
+						<ButtonTw
+							variant="secondary"
+							size="xss"
+							state={isBusy ? 'loading' : 'default'}
+							onClick={handleReopen}
+						>
+							Reopen
+						</ButtonTw>
+					)}
+				</div>
 			</td>
 		</tr>
 	);
@@ -142,7 +150,7 @@ export function IssuesTable() {
 						<th className="w-32 px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-left uppercase">
 							State
 						</th>
-						<th className="w-32 px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-right uppercase">
+						<th className="w-52 px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-right uppercase">
 							Actions
 						</th>
 					</tr>

--- a/libs/bublik/features/result-classification/src/lib/issues-table.tsx
+++ b/libs/bublik/features/result-classification/src/lib/issues-table.tsx
@@ -1,0 +1,153 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import {
+	getErrorMessage,
+	useCloseIssueMutation,
+	useGetIssuesQuery,
+	useReopenIssueMutation
+} from '@/services/bublik-api';
+import { useProjectSearch } from '@/bublik/features/projects';
+import { Badge, ButtonTw, Icon, Skeleton, toast } from '@/shared/tailwind-ui';
+import { BublikEmptyState, BublikErrorState } from '@/bublik/features/ui-state';
+import type { Issue } from '@/shared/types';
+
+function notifyError(err: unknown) {
+	const m = getErrorMessage(err);
+	return `${m.title}\n${m.description}`;
+}
+
+interface IssueRowProps {
+	issue: Issue;
+	projectId?: number;
+}
+
+function IssueRow({ issue, projectId }: IssueRowProps) {
+	const [closeIssue, closeState] = useCloseIssueMutation();
+	const [reopenIssue, reopenState] = useReopenIssueMutation();
+
+	const isOpen = issue.state === 'open';
+	const isBusy = closeState.isLoading || reopenState.isLoading;
+
+	function handleClose() {
+		const promise = closeIssue({ issueId: issue.id, projectId }).unwrap();
+		toast.promise(promise, {
+			loading: 'Closing issue...',
+			success: 'Issue closed',
+			error: notifyError,
+			position: 'top-center'
+		});
+	}
+
+	function handleReopen() {
+		const promise = reopenIssue({ issueId: issue.id, projectId }).unwrap();
+		toast.promise(promise, {
+			loading: 'Reopening issue...',
+			success: 'Issue reopened',
+			error: notifyError,
+			position: 'top-center'
+		});
+	}
+
+	return (
+		<tr className="group">
+			<td className="px-4 py-2 text-sm font-medium border-t border-b border-transparent text-text-primary first:border-l last:border-r first:rounded-l last:rounded-r group-hover:border-primary group-hover:first:border-primary group-hover:last:border-primary">
+				<span className="font-medium">{issue.title}</span>
+				{issue.issue_ext?.key ? (
+					<span className="ml-2 text-text-menu text-xs">
+						{issue.issue_ext.key}
+					</span>
+				) : null}
+			</td>
+			<td className="px-4 py-2 text-sm border-t border-b border-transparent group-hover:border-primary">
+				<Badge variant={isOpen ? 'unexpected' : 'expected'}>
+					{isOpen ? 'Open' : 'Closed'}
+				</Badge>
+			</td>
+			<td className="px-4 py-2 text-sm text-right border-t border-b border-transparent last:border-r last:rounded-r group-hover:border-primary group-hover:last:border-primary">
+				{isOpen ? (
+					<ButtonTw
+						variant="destruction-secondary"
+						size="xss"
+						state={isBusy ? 'loading' : 'default'}
+						onClick={handleClose}
+					>
+						Close
+					</ButtonTw>
+				) : (
+					<ButtonTw
+						variant="secondary"
+						size="xss"
+						state={isBusy ? 'loading' : 'default'}
+						onClick={handleReopen}
+					>
+						Reopen
+					</ButtonTw>
+				)}
+			</td>
+		</tr>
+	);
+}
+
+function IssuesTableLoading() {
+	return (
+		<div className="flex flex-col gap-1 mt-1">
+			{Array.from({ length: 10 }, () => 0).map((_, idx) => (
+				<Skeleton key={idx} className="h-10 rounded-md" />
+			))}
+		</div>
+	);
+}
+
+export function IssuesTable() {
+	const { projectIds } = useProjectSearch();
+	const projectId = projectIds[0];
+
+	const { data, isLoading, error } = useGetIssuesQuery(
+		projectId ? { projectId } : {}
+	);
+
+	if (isLoading) return <IssuesTableLoading />;
+
+	if (error) {
+		return <BublikErrorState error={error} className="h-[calc(100vh-256px)]" />;
+	}
+
+	const issues = data ?? [];
+
+	if (issues.length === 0) {
+		return (
+			<BublikEmptyState
+				title="No issues"
+				description="No issues found for the active project"
+				className="h-[calc(100vh-256px)]"
+			/>
+		);
+	}
+
+	return (
+		<div className="overflow-x-auto">
+			<table className="min-w-full border-separate table-fixed border-spacing-y-1">
+				<thead className="bg-white">
+					<tr className="h-8.5">
+						<th className="px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-left uppercase">
+							<span className="inline-flex items-center gap-1">
+								<Icon name="TriangleExclamationMark" size={14} />
+								Issue
+							</span>
+						</th>
+						<th className="w-32 px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-left uppercase">
+							State
+						</th>
+						<th className="w-32 px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-right uppercase">
+							Actions
+						</th>
+					</tr>
+				</thead>
+				<tbody className="bg-white">
+					{issues.map((issue) => (
+						<IssueRow key={issue.id} issue={issue} projectId={projectId} />
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}

--- a/libs/bublik/features/result-classification/src/lib/match-scope.tsx
+++ b/libs/bublik/features/result-classification/src/lib/match-scope.tsx
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { useWatch } from 'react-hook-form';
+
+import { Checkbox, RadioGroup, RadioGroupItemWithLabel } from '@/shared/tailwind-ui';
+
+import type { ClassifyForm } from './classify-form';
+import {
+	PRESETS,
+	applyMutualExclusion,
+	presetForFlags,
+	type MatchFlags
+} from './match-scope.utils';
+
+function writeFlags(form: ClassifyForm, flags: MatchFlags) {
+	form.setValue('matchParameters', flags.matchParameters, { shouldDirty: true });
+	form.setValue('matchVerdicts', flags.matchVerdicts, { shouldDirty: true });
+	form.setValue('matchImportantTags', flags.matchImportantTags, {
+		shouldDirty: true
+	});
+	form.setValue('matchAllTags', flags.matchAllTags, { shouldDirty: true });
+}
+
+export function MatchScope({ form }: { form: ClassifyForm }) {
+	const flags = useWatch({
+		control: form.control,
+		name: ['matchParameters', 'matchVerdicts', 'matchImportantTags', 'matchAllTags']
+	});
+	const current: MatchFlags = {
+		matchParameters: flags[0],
+		matchVerdicts: flags[1],
+		matchImportantTags: flags[2],
+		matchAllTags: flags[3]
+	};
+	const preset = presetForFlags(current);
+
+	const toggle = (key: keyof MatchFlags, checked: boolean) => {
+		writeFlags(form, applyMutualExclusion({ ...current, [key]: checked }, key));
+	};
+
+	return (
+		<div className="flex flex-col gap-4">
+			<div className="flex flex-col gap-2">
+				<span className="text-[0.8125rem] font-semibold">Match scope</span>
+				<p className="text-xs text-text-menu">
+					A classification auto-applies to future results that match the test
+					path plus the dimensions below.
+				</p>
+			</div>
+
+			<RadioGroup
+				value={preset === 'Custom' ? '' : preset}
+				onValueChange={(label) => {
+					const hit = PRESETS.find((p) => p.label === label);
+					if (hit) writeFlags(form, hit.flags);
+				}}
+				className="flex flex-col gap-1.5"
+			>
+				{PRESETS.map((p) => (
+					<RadioGroupItemWithLabel
+						key={p.label}
+						id={`preset-${p.label}`}
+						value={p.label}
+						label={p.label}
+					/>
+				))}
+			</RadioGroup>
+
+			<div className="flex flex-col gap-2 pt-2 border-t border-border-primary">
+				<span className="text-xs font-semibold text-text-menu">
+					Advanced ({preset})
+				</span>
+				<div className="flex items-center gap-2 opacity-60">
+					<Checkbox checked disabled />
+					<span className="text-sm">Test path (always)</span>
+				</div>
+				<label className="flex items-center gap-2 text-sm cursor-pointer">
+					<Checkbox
+						checked={current.matchParameters}
+						onCheckedChange={(c) => toggle('matchParameters', c === true)}
+					/>
+					Parameters
+				</label>
+				<label className="flex items-center gap-2 text-sm cursor-pointer">
+					<Checkbox
+						checked={current.matchVerdicts}
+						onCheckedChange={(c) => toggle('matchVerdicts', c === true)}
+					/>
+					Verdicts
+				</label>
+				<label className="flex items-center gap-2 text-sm cursor-pointer">
+					<Checkbox
+						checked={current.matchImportantTags}
+						onCheckedChange={(c) => toggle('matchImportantTags', c === true)}
+					/>
+					Important tags
+				</label>
+				<label className="flex items-center gap-2 text-sm cursor-pointer">
+					<Checkbox
+						checked={current.matchAllTags}
+						onCheckedChange={(c) => toggle('matchAllTags', c === true)}
+					/>
+					All tags
+				</label>
+			</div>
+		</div>
+	);
+}

--- a/libs/bublik/features/result-classification/src/lib/match-scope.tsx
+++ b/libs/bublik/features/result-classification/src/lib/match-scope.tsx
@@ -1,7 +1,11 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { useWatch } from 'react-hook-form';
 
-import { Checkbox, RadioGroup, RadioGroupItemWithLabel } from '@/shared/tailwind-ui';
+import {
+	Checkbox,
+	RadioGroup,
+	RadioGroupItemWithLabel
+} from '@/shared/tailwind-ui';
 
 import type { ClassifyForm } from './classify-form';
 import {
@@ -12,7 +16,9 @@ import {
 } from './match-scope.utils';
 
 function writeFlags(form: ClassifyForm, flags: MatchFlags) {
-	form.setValue('matchParameters', flags.matchParameters, { shouldDirty: true });
+	form.setValue('matchParameters', flags.matchParameters, {
+		shouldDirty: true
+	});
 	form.setValue('matchVerdicts', flags.matchVerdicts, { shouldDirty: true });
 	form.setValue('matchImportantTags', flags.matchImportantTags, {
 		shouldDirty: true
@@ -23,7 +29,12 @@ function writeFlags(form: ClassifyForm, flags: MatchFlags) {
 export function MatchScope({ form }: { form: ClassifyForm }) {
 	const flags = useWatch({
 		control: form.control,
-		name: ['matchParameters', 'matchVerdicts', 'matchImportantTags', 'matchAllTags']
+		name: [
+			'matchParameters',
+			'matchVerdicts',
+			'matchImportantTags',
+			'matchAllTags'
+		]
 	});
 	const current: MatchFlags = {
 		matchParameters: flags[0],

--- a/libs/bublik/features/result-classification/src/lib/match-scope.utils.spec.ts
+++ b/libs/bublik/features/result-classification/src/lib/match-scope.utils.spec.ts
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from 'vitest';
+
+import {
+	PRESETS,
+	applyMutualExclusion,
+	chipsForFlags,
+	presetForFlags
+} from './match-scope.utils';
+
+describe('match-scope.utils', () => {
+	it('round-trips every preset', () => {
+		for (const preset of PRESETS) {
+			expect(presetForFlags(preset.flags)).toBe(preset.label);
+		}
+	});
+
+	it('returns Custom for a non-preset combo', () => {
+		expect(
+			presetForFlags({
+				matchParameters: false,
+				matchVerdicts: false,
+				matchImportantTags: true,
+				matchAllTags: true
+			})
+		).toBe('Custom');
+	});
+
+	it('lists Path plus active dimensions as chips', () => {
+		expect(
+			chipsForFlags({
+				matchParameters: true,
+				matchVerdicts: true,
+				matchImportantTags: true,
+				matchAllTags: false
+			})
+		).toEqual(['Path', 'Params', 'Verdicts', 'Important tags']);
+		expect(
+			chipsForFlags({
+				matchParameters: false,
+				matchVerdicts: false,
+				matchImportantTags: false,
+				matchAllTags: false
+			})
+		).toEqual(['Path']);
+	});
+
+	it('mutual exclusion: checking all-tags unchecks important-tags', () => {
+		const next = applyMutualExclusion(
+			{
+				matchParameters: true,
+				matchVerdicts: true,
+				matchImportantTags: true,
+				matchAllTags: true
+			},
+			'matchAllTags'
+		);
+		expect(next.matchAllTags).toBe(true);
+		expect(next.matchImportantTags).toBe(false);
+	});
+
+	it('mutual exclusion: checking important-tags unchecks all-tags', () => {
+		const next = applyMutualExclusion(
+			{
+				matchParameters: false,
+				matchVerdicts: false,
+				matchImportantTags: true,
+				matchAllTags: true
+			},
+			'matchImportantTags'
+		);
+		expect(next.matchImportantTags).toBe(true);
+		expect(next.matchAllTags).toBe(false);
+	});
+});

--- a/libs/bublik/features/result-classification/src/lib/match-scope.utils.ts
+++ b/libs/bublik/features/result-classification/src/lib/match-scope.utils.ts
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+export interface MatchFlags {
+	matchParameters: boolean;
+	matchVerdicts: boolean;
+	matchImportantTags: boolean;
+	matchAllTags: boolean;
+}
+
+export const DEFAULT_MATCH_FLAGS: MatchFlags = {
+	matchParameters: true,
+	matchVerdicts: true,
+	matchImportantTags: true,
+	matchAllTags: false
+};
+
+export interface Preset {
+	label: string;
+	flags: MatchFlags;
+}
+
+// Narrow -> wide. Test path is always implied (every rule matches on path).
+export const PRESETS: Preset[] = [
+	{
+		label: 'Path only',
+		flags: { matchParameters: false, matchVerdicts: false, matchImportantTags: false, matchAllTags: false }
+	},
+	{
+		label: 'Path + Verdicts',
+		flags: { matchParameters: false, matchVerdicts: true, matchImportantTags: false, matchAllTags: false }
+	},
+	{
+		label: 'Path + Parameters',
+		flags: { matchParameters: true, matchVerdicts: false, matchImportantTags: false, matchAllTags: false }
+	},
+	{
+		label: 'Path + Parameters + Verdicts',
+		flags: { matchParameters: true, matchVerdicts: true, matchImportantTags: false, matchAllTags: false }
+	},
+	{
+		label: 'Path + Parameters + Verdicts + Important tags',
+		flags: { matchParameters: true, matchVerdicts: true, matchImportantTags: true, matchAllTags: false }
+	},
+	{
+		label: 'Path + Parameters + Verdicts + All tags',
+		flags: { matchParameters: true, matchVerdicts: true, matchImportantTags: false, matchAllTags: true }
+	}
+];
+
+export const DEFAULT_PRESET_LABEL = 'Path + Parameters + Verdicts + Important tags';
+
+function flagsEqual(a: MatchFlags, b: MatchFlags): boolean {
+	return (
+		a.matchParameters === b.matchParameters &&
+		a.matchVerdicts === b.matchVerdicts &&
+		a.matchImportantTags === b.matchImportantTags &&
+		a.matchAllTags === b.matchAllTags
+	);
+}
+
+/** Preset label for a flag combo, or 'Custom' if it matches no preset. */
+export function presetForFlags(flags: MatchFlags): string {
+	const hit = PRESETS.find((p) => flagsEqual(p.flags, flags));
+	return hit ? hit.label : 'Custom';
+}
+
+/** 'Path' plus a chip per active dimension, in a stable order. */
+export function chipsForFlags(flags: MatchFlags): string[] {
+	const chips = ['Path'];
+	if (flags.matchParameters) chips.push('Params');
+	if (flags.matchVerdicts) chips.push('Verdicts');
+	if (flags.matchImportantTags) chips.push('Important tags');
+	if (flags.matchAllTags) chips.push('All tags');
+	return chips;
+}
+
+/**
+ * Enforce the important/all-tags mutual exclusion after `changed` was toggled
+ * on. Returns a new MatchFlags; non-tag changes pass through unchanged.
+ */
+export function applyMutualExclusion(
+	flags: MatchFlags,
+	changed: keyof MatchFlags
+): MatchFlags {
+	if (changed === 'matchAllTags' && flags.matchAllTags) {
+		return { ...flags, matchImportantTags: false };
+	}
+	if (changed === 'matchImportantTags' && flags.matchImportantTags) {
+		return { ...flags, matchAllTags: false };
+	}
+	return flags;
+}

--- a/libs/bublik/features/result-classification/src/lib/match-scope.utils.ts
+++ b/libs/bublik/features/result-classification/src/lib/match-scope.utils.ts
@@ -23,27 +23,57 @@ export interface Preset {
 export const PRESETS: Preset[] = [
 	{
 		label: 'Path only',
-		flags: { matchParameters: false, matchVerdicts: false, matchImportantTags: false, matchAllTags: false }
+		flags: {
+			matchParameters: false,
+			matchVerdicts: false,
+			matchImportantTags: false,
+			matchAllTags: false
+		}
 	},
 	{
 		label: 'Path + Verdicts',
-		flags: { matchParameters: false, matchVerdicts: true, matchImportantTags: false, matchAllTags: false }
+		flags: {
+			matchParameters: false,
+			matchVerdicts: true,
+			matchImportantTags: false,
+			matchAllTags: false
+		}
 	},
 	{
 		label: 'Path + Parameters',
-		flags: { matchParameters: true, matchVerdicts: false, matchImportantTags: false, matchAllTags: false }
+		flags: {
+			matchParameters: true,
+			matchVerdicts: false,
+			matchImportantTags: false,
+			matchAllTags: false
+		}
 	},
 	{
 		label: 'Path + Parameters + Verdicts',
-		flags: { matchParameters: true, matchVerdicts: true, matchImportantTags: false, matchAllTags: false }
+		flags: {
+			matchParameters: true,
+			matchVerdicts: true,
+			matchImportantTags: false,
+			matchAllTags: false
+		}
 	},
 	{
 		label: 'Path + Parameters + Verdicts + Important tags',
-		flags: { matchParameters: true, matchVerdicts: true, matchImportantTags: true, matchAllTags: false }
+		flags: {
+			matchParameters: true,
+			matchVerdicts: true,
+			matchImportantTags: true,
+			matchAllTags: false
+		}
 	},
 	{
 		label: 'Path + Parameters + Verdicts + All tags',
-		flags: { matchParameters: true, matchVerdicts: true, matchImportantTags: false, matchAllTags: true }
+		flags: {
+			matchParameters: true,
+			matchVerdicts: true,
+			matchImportantTags: false,
+			matchAllTags: true
+		}
 	}
 ];
 

--- a/libs/bublik/features/result-classification/src/lib/match-scope.utils.ts
+++ b/libs/bublik/features/result-classification/src/lib/match-scope.utils.ts
@@ -47,8 +47,6 @@ export const PRESETS: Preset[] = [
 	}
 ];
 
-export const DEFAULT_PRESET_LABEL = 'Path + Parameters + Verdicts + Important tags';
-
 function flagsEqual(a: MatchFlags, b: MatchFlags): boolean {
 	return (
 		a.matchParameters === b.matchParameters &&

--- a/libs/bublik/features/result-classification/src/lib/run-issue-results.tsx
+++ b/libs/bublik/features/result-classification/src/lib/run-issue-results.tsx
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { useGetRunIssueResultsQuery } from '@/services/bublik-api';
+import { routes } from '@/router';
+import { LinkWithProject } from '@/bublik/features/projects';
+import { Badge, Icon, Skeleton } from '@/shared/tailwind-ui';
+import { BublikErrorState } from '@/bublik/features/ui-state';
+import type { RunIssueResultRow } from '@/shared/types';
+
+interface RunIssueResultsProps {
+	runId: number | string;
+	issueId: number;
+	projectId?: number;
+}
+
+function groupByPath(
+	rows: RunIssueResultRow[]
+): { path: string; rows: RunIssueResultRow[] }[] {
+	const groups = new Map<string, RunIssueResultRow[]>();
+
+	for (const row of rows) {
+		const key = row.path.join(' / ');
+		const existing = groups.get(key);
+		if (existing) existing.push(row);
+		else groups.set(key, [row]);
+	}
+
+	return Array.from(groups.entries()).map(([path, groupRows]) => ({
+		path,
+		rows: groupRows
+	}));
+}
+
+export function RunIssueResults({
+	runId,
+	issueId,
+	projectId
+}: RunIssueResultsProps) {
+	const { data, isLoading, error } = useGetRunIssueResultsQuery({
+		runId,
+		issueId,
+		projectId
+	});
+
+	if (isLoading) {
+		return (
+			<div className="flex flex-col gap-1 py-2">
+				{Array.from({ length: 3 }, () => 0).map((_, idx) => (
+					<Skeleton key={idx} className="h-8 rounded-md" />
+				))}
+			</div>
+		);
+	}
+
+	if (error) {
+		return <BublikErrorState error={error} className="py-4" />;
+	}
+
+	const results = data ?? [];
+
+	if (results.length === 0) {
+		return <div className="px-4 py-3 text-sm text-text-menu">No results</div>;
+	}
+
+	const groups = groupByPath(results);
+
+	return (
+		<div className="flex flex-col gap-3 px-4 py-3">
+			{groups.map((group) => (
+				<div key={group.path} className="flex flex-col gap-1">
+					<div className="flex items-center gap-1 text-[0.6875rem] font-bold tracking-wider uppercase text-text-menu">
+						<Icon name="Folder" size={14} />
+						{group.path || '(root)'}
+					</div>
+					<ul className="flex flex-col gap-0.5">
+						{group.rows.map((row) => (
+							<li
+								key={row.result_id}
+								className="flex items-center gap-3 px-2 py-1 text-sm rounded hover:bg-primary-wash"
+							>
+								<span className="font-medium text-text-primary">
+									{row.name ?? '-'}
+								</span>
+								{row.obtained_result ? (
+									<Badge variant="unexpected">{row.obtained_result}</Badge>
+								) : null}
+								{row.verdicts.length ? (
+									<span className="text-text-menu">
+										{row.verdicts.join(', ')}
+									</span>
+								) : null}
+								<LinkWithProject
+									to={routes.log({ runId, focusId: row.result_id })}
+									className="inline-flex items-center gap-1 ml-auto hover:text-primary hover:underline"
+								>
+									<Icon name="BoxArrowRight" size={14} />
+									Log
+								</LinkWithProject>
+							</li>
+						))}
+					</ul>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/libs/bublik/features/result-classification/src/lib/run-issues-table.tsx
+++ b/libs/bublik/features/result-classification/src/lib/run-issues-table.tsx
@@ -37,7 +37,10 @@ function RunIssueTableRow({
 	return (
 		<>
 			<tr className="group">
-				<td className={cn(cellClassName, 'text-text-menu')}>
+				<td
+					className={cn(cellClassName, 'text-text-menu truncate')}
+					title={issue.bug_key ?? `#${issue.issue_id}`}
+				>
 					{issue.bug_key ?? `#${issue.issue_id}`}
 				</td>
 				<td className={cn(cellClassName, 'font-medium text-text-primary')}>
@@ -138,7 +141,7 @@ export function RunIssuesTable({ runId, projectId }: RunIssuesTableProps) {
 			<table className="min-w-full border-separate table-fixed border-spacing-y-1">
 				<thead className="bg-white">
 					<tr className="h-8.5">
-						<th className={headerClassName}>
+						<th className={cn(headerClassName, 'w-32')}>
 							<span className="inline-flex items-center gap-1">
 								<Icon name="TriangleExclamationMark" size={14} />
 								Issue

--- a/libs/bublik/features/result-classification/src/lib/run-issues-table.tsx
+++ b/libs/bublik/features/result-classification/src/lib/run-issues-table.tsx
@@ -38,10 +38,15 @@ function RunIssueTableRow({
 		<>
 			<tr className="group">
 				<td
-					className={cn(cellClassName, 'text-text-menu truncate')}
-					title={issue.bug_key ?? `#${issue.issue_id}`}
+					className={cn(cellClassName, 'truncate')}
+					title={`Manage rules for ${issue.bug_key ?? `#${issue.issue_id}`}`}
 				>
-					{issue.bug_key ?? `#${issue.issue_id}`}
+					<LinkWithProject
+						to={`/admin/issues/${issue.issue_id}`}
+						className="text-text-menu hover:text-primary hover:underline"
+					>
+						{issue.bug_key ?? `#${issue.issue_id}`}
+					</LinkWithProject>
 				</td>
 				<td className={cn(cellClassName, 'font-medium text-text-primary')}>
 					<LinkWithProject

--- a/libs/bublik/features/result-classification/src/lib/run-issues-table.tsx
+++ b/libs/bublik/features/result-classification/src/lib/run-issues-table.tsx
@@ -37,8 +37,8 @@ function RunIssueTableRow({
 	const aggregate = dispositions.includes(true)
 		? true
 		: dispositions.includes(false)
-			? false
-			: null;
+		? false
+		: null;
 	const badge = expectedBadge(aggregate);
 
 	return (

--- a/libs/bublik/features/result-classification/src/lib/run-issues-table.tsx
+++ b/libs/bublik/features/result-classification/src/lib/run-issues-table.tsx
@@ -22,6 +22,9 @@ interface RunIssueRowProps {
 	onToggle: () => void;
 }
 
+const cellClassName =
+	'px-4 py-2 text-sm border-t border-b border-transparent first:border-l last:border-r first:rounded-l last:rounded-r group-hover:border-primary group-hover:first:border-primary group-hover:last:border-primary';
+
 function RunIssueTableRow({
 	issue,
 	runId,
@@ -29,69 +32,59 @@ function RunIssueTableRow({
 	isExpanded,
 	onToggle
 }: RunIssueRowProps) {
-	const categories = issue.categories.map((c) => c.category).join(', ');
 	const isExpected = issue.categories.some((c) => c.expected);
 
 	return (
 		<>
-		<tr className="group">
-			<td className="px-4 py-2 text-sm font-medium border-t border-b border-transparent text-text-primary first:border-l last:border-r first:rounded-l last:rounded-r group-hover:border-primary group-hover:first:border-primary group-hover:last:border-primary">
-				<LinkWithProject
-					to={`/history?issue=${issue.issue_id}`}
-					className="font-medium hover:text-primary hover:underline"
-				>
-					{issue.title}
-				</LinkWithProject>
-			</td>
-			<td className="px-4 py-2 text-sm border-t border-b border-transparent group-hover:border-primary">
-				{categories || '-'}
-			</td>
-			<td className="px-4 py-2 text-sm border-t border-b border-transparent group-hover:border-primary">
-				<Badge variant={isExpected ? 'expected' : 'unexpected'}>
-					{isExpected ? 'Expected' : 'Unexpected'}
-				</Badge>
-			</td>
-			<td className="px-4 py-2 text-sm text-right border-t border-b border-transparent group-hover:border-primary">
-				<button
-					type="button"
-					onClick={onToggle}
-					className="inline-flex items-center gap-1 ml-auto hover:text-primary"
-					aria-expanded={isExpanded}
-				>
-					{issue.result_count}
-					<Icon
-						name="ArrowShortSmall"
-						className={cn(
-							'grid place-items-center transition-transform',
-							isExpanded ? 'rotate-360' : '-rotate-90'
-						)}
-					/>
-				</button>
-			</td>
-			<td className="px-4 py-2 text-sm border-t border-b border-transparent group-hover:border-primary">
-				<Badge variant={issue.state === 'open' ? 'unexpected' : 'expected'}>
-					{issue.state === 'open' ? 'Open' : 'Closed'}
-				</Badge>
-			</td>
-			<td className="px-4 py-2 text-sm border-t border-b border-transparent last:border-r last:rounded-r group-hover:border-primary group-hover:last:border-primary">
-				{issue.bug_key ? (
-					<span className="text-text-menu">{issue.bug_key}</span>
-				) : (
-					'-'
-				)}
-			</td>
-		</tr>
-		{isExpanded ? (
-			<tr>
-				<td colSpan={6} className="border-b border-border-primary bg-primary-wash/40">
-					<RunIssueResults
-						runId={runId}
-						issueId={issue.issue_id}
-						projectId={projectId}
-					/>
+			<tr className="group">
+				<td className={cn(cellClassName, 'text-text-menu')}>
+					{issue.bug_key ?? `#${issue.issue_id}`}
+				</td>
+				<td className={cn(cellClassName, 'font-medium text-text-primary')}>
+					<LinkWithProject
+						to={`/history?issue=${issue.issue_id}`}
+						className="font-medium hover:text-primary hover:underline"
+					>
+						{issue.title}
+					</LinkWithProject>
+				</td>
+				<td className={cellClassName}>
+					<Badge variant={isExpected ? 'expected' : 'unexpected'}>
+						{isExpected ? 'Expected' : 'Unexpected'}
+					</Badge>
+				</td>
+				<td className={cn(cellClassName, 'text-right')}>
+					<button
+						type="button"
+						onClick={onToggle}
+						className="inline-flex items-center gap-1 ml-auto hover:text-primary"
+						aria-expanded={isExpanded}
+					>
+						{issue.result_count}
+						<Icon
+							name="ArrowShortSmall"
+							className={cn(
+								'grid place-items-center transition-transform',
+								isExpanded ? 'rotate-360' : '-rotate-90'
+							)}
+						/>
+					</button>
 				</td>
 			</tr>
-		) : null}
+			{isExpanded ? (
+				<tr>
+					<td
+						colSpan={4}
+						className="border-b border-border-primary bg-primary-wash/40"
+					>
+						<RunIssueResults
+							runId={runId}
+							issueId={issue.issue_id}
+							projectId={projectId}
+						/>
+					</td>
+				</tr>
+			) : null}
 		</>
 	);
 }
@@ -105,6 +98,9 @@ function RunIssuesTableLoading() {
 		</div>
 	);
 }
+
+const headerClassName =
+	'px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-left uppercase';
 
 export function RunIssuesTable({ runId, projectId }: RunIssuesTableProps) {
 	const { data, isLoading, error } = useGetRunIssuesQuery({ runId, projectId });
@@ -142,27 +138,15 @@ export function RunIssuesTable({ runId, projectId }: RunIssuesTableProps) {
 			<table className="min-w-full border-separate table-fixed border-spacing-y-1">
 				<thead className="bg-white">
 					<tr className="h-8.5">
-						<th className="px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-left uppercase">
+						<th className={headerClassName}>
 							<span className="inline-flex items-center gap-1">
 								<Icon name="TriangleExclamationMark" size={14} />
-								Title
+								Issue
 							</span>
 						</th>
-						<th className="px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-left uppercase">
-							Category
-						</th>
-						<th className="w-32 px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-left uppercase">
-							Expected
-						</th>
-						<th className="w-24 px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-right uppercase">
-							Results
-						</th>
-						<th className="w-24 px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-left uppercase">
-							State
-						</th>
-						<th className="px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-left uppercase">
-							Bug
-						</th>
+						<th className={headerClassName}>Title</th>
+						<th className={cn(headerClassName, 'w-32')}>Expected</th>
+						<th className={cn(headerClassName, 'w-24 text-right')}>Results</th>
 					</tr>
 				</thead>
 				<tbody className="bg-white">

--- a/libs/bublik/features/result-classification/src/lib/run-issues-table.tsx
+++ b/libs/bublik/features/result-classification/src/lib/run-issues-table.tsx
@@ -1,9 +1,13 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+import { useState } from 'react';
+
 import { useGetRunIssuesQuery } from '@/services/bublik-api';
 import { LinkWithProject } from '@/bublik/features/projects';
-import { Badge, Icon, Skeleton } from '@/shared/tailwind-ui';
+import { Badge, Icon, Skeleton, cn } from '@/shared/tailwind-ui';
 import { BublikEmptyState, BublikErrorState } from '@/bublik/features/ui-state';
 import type { RunIssueRow } from '@/shared/types';
+
+import { RunIssueResults } from './run-issue-results';
 
 interface RunIssuesTableProps {
 	runId: number | string;
@@ -12,13 +16,24 @@ interface RunIssuesTableProps {
 
 interface RunIssueRowProps {
 	issue: RunIssueRow;
+	runId: number | string;
+	projectId?: number;
+	isExpanded: boolean;
+	onToggle: () => void;
 }
 
-function RunIssueTableRow({ issue }: RunIssueRowProps) {
+function RunIssueTableRow({
+	issue,
+	runId,
+	projectId,
+	isExpanded,
+	onToggle
+}: RunIssueRowProps) {
 	const categories = issue.categories.map((c) => c.category).join(', ');
 	const isExpected = issue.categories.some((c) => c.expected);
 
 	return (
+		<>
 		<tr className="group">
 			<td className="px-4 py-2 text-sm font-medium border-t border-b border-transparent text-text-primary first:border-l last:border-r first:rounded-l last:rounded-r group-hover:border-primary group-hover:first:border-primary group-hover:last:border-primary">
 				<LinkWithProject
@@ -37,7 +52,21 @@ function RunIssueTableRow({ issue }: RunIssueRowProps) {
 				</Badge>
 			</td>
 			<td className="px-4 py-2 text-sm text-right border-t border-b border-transparent group-hover:border-primary">
-				{issue.result_count}
+				<button
+					type="button"
+					onClick={onToggle}
+					className="inline-flex items-center gap-1 ml-auto hover:text-primary"
+					aria-expanded={isExpanded}
+				>
+					{issue.result_count}
+					<Icon
+						name="ArrowShortSmall"
+						className={cn(
+							'grid place-items-center transition-transform',
+							isExpanded ? 'rotate-360' : '-rotate-90'
+						)}
+					/>
+				</button>
 			</td>
 			<td className="px-4 py-2 text-sm border-t border-b border-transparent group-hover:border-primary">
 				<Badge variant={issue.state === 'open' ? 'unexpected' : 'expected'}>
@@ -52,6 +81,18 @@ function RunIssueTableRow({ issue }: RunIssueRowProps) {
 				)}
 			</td>
 		</tr>
+		{isExpanded ? (
+			<tr>
+				<td colSpan={6} className="border-b border-border-primary bg-primary-wash/40">
+					<RunIssueResults
+						runId={runId}
+						issueId={issue.issue_id}
+						projectId={projectId}
+					/>
+				</td>
+			</tr>
+		) : null}
+		</>
 	);
 }
 
@@ -67,6 +108,16 @@ function RunIssuesTableLoading() {
 
 export function RunIssuesTable({ runId, projectId }: RunIssuesTableProps) {
 	const { data, isLoading, error } = useGetRunIssuesQuery({ runId, projectId });
+	const [expanded, setExpanded] = useState<Set<number>>(new Set());
+
+	const toggleExpanded = (issueId: number) => {
+		setExpanded((prev) => {
+			const next = new Set(prev);
+			if (next.has(issueId)) next.delete(issueId);
+			else next.add(issueId);
+			return next;
+		});
+	};
 
 	if (isLoading) return <RunIssuesTableLoading />;
 
@@ -116,7 +167,14 @@ export function RunIssuesTable({ runId, projectId }: RunIssuesTableProps) {
 				</thead>
 				<tbody className="bg-white">
 					{issues.map((issue) => (
-						<RunIssueTableRow key={issue.issue_id} issue={issue} />
+						<RunIssueTableRow
+							key={issue.issue_id}
+							issue={issue}
+							runId={runId}
+							projectId={projectId}
+							isExpanded={expanded.has(issue.issue_id)}
+							onToggle={() => toggleExpanded(issue.issue_id)}
+						/>
 					))}
 				</tbody>
 			</table>

--- a/libs/bublik/features/result-classification/src/lib/run-issues-table.tsx
+++ b/libs/bublik/features/result-classification/src/lib/run-issues-table.tsx
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { useGetRunIssuesQuery } from '@/services/bublik-api';
+import { LinkWithProject } from '@/bublik/features/projects';
+import { Badge, Icon, Skeleton } from '@/shared/tailwind-ui';
+import { BublikEmptyState, BublikErrorState } from '@/bublik/features/ui-state';
+import type { RunIssueRow } from '@/shared/types';
+
+interface RunIssuesTableProps {
+	runId: number | string;
+	projectId?: number;
+}
+
+interface RunIssueRowProps {
+	issue: RunIssueRow;
+}
+
+function RunIssueTableRow({ issue }: RunIssueRowProps) {
+	const categories = issue.categories.map((c) => c.category).join(', ');
+	const isExpected = issue.categories.some((c) => c.expected);
+
+	return (
+		<tr className="group">
+			<td className="px-4 py-2 text-sm font-medium border-t border-b border-transparent text-text-primary first:border-l last:border-r first:rounded-l last:rounded-r group-hover:border-primary group-hover:first:border-primary group-hover:last:border-primary">
+				<LinkWithProject
+					to={`/history?issue=${issue.issue_id}`}
+					className="font-medium hover:text-primary hover:underline"
+				>
+					{issue.title}
+				</LinkWithProject>
+			</td>
+			<td className="px-4 py-2 text-sm border-t border-b border-transparent group-hover:border-primary">
+				{categories || '-'}
+			</td>
+			<td className="px-4 py-2 text-sm border-t border-b border-transparent group-hover:border-primary">
+				<Badge variant={isExpected ? 'expected' : 'unexpected'}>
+					{isExpected ? 'Expected' : 'Unexpected'}
+				</Badge>
+			</td>
+			<td className="px-4 py-2 text-sm text-right border-t border-b border-transparent group-hover:border-primary">
+				{issue.result_count}
+			</td>
+			<td className="px-4 py-2 text-sm border-t border-b border-transparent group-hover:border-primary">
+				<Badge variant={issue.state === 'open' ? 'unexpected' : 'expected'}>
+					{issue.state === 'open' ? 'Open' : 'Closed'}
+				</Badge>
+			</td>
+			<td className="px-4 py-2 text-sm border-t border-b border-transparent last:border-r last:rounded-r group-hover:border-primary group-hover:last:border-primary">
+				{issue.bug_key ? (
+					<span className="text-text-menu">{issue.bug_key}</span>
+				) : (
+					'-'
+				)}
+			</td>
+		</tr>
+	);
+}
+
+function RunIssuesTableLoading() {
+	return (
+		<div className="flex flex-col gap-1 mt-1">
+			{Array.from({ length: 10 }, () => 0).map((_, idx) => (
+				<Skeleton key={idx} className="h-10 rounded-md" />
+			))}
+		</div>
+	);
+}
+
+export function RunIssuesTable({ runId, projectId }: RunIssuesTableProps) {
+	const { data, isLoading, error } = useGetRunIssuesQuery({ runId, projectId });
+
+	if (isLoading) return <RunIssuesTableLoading />;
+
+	if (error) {
+		return <BublikErrorState error={error} className="h-[calc(100vh-256px)]" />;
+	}
+
+	const issues = data ?? [];
+
+	if (issues.length === 0) {
+		return (
+			<BublikEmptyState
+				title="No issues"
+				description="No issues classified in this run"
+				className="h-[calc(100vh-256px)]"
+			/>
+		);
+	}
+
+	return (
+		<div className="overflow-x-auto">
+			<table className="min-w-full border-separate table-fixed border-spacing-y-1">
+				<thead className="bg-white">
+					<tr className="h-8.5">
+						<th className="px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-left uppercase">
+							<span className="inline-flex items-center gap-1">
+								<Icon name="TriangleExclamationMark" size={14} />
+								Title
+							</span>
+						</th>
+						<th className="px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-left uppercase">
+							Category
+						</th>
+						<th className="w-32 px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-left uppercase">
+							Expected
+						</th>
+						<th className="w-24 px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-right uppercase">
+							Results
+						</th>
+						<th className="w-24 px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-left uppercase">
+							State
+						</th>
+						<th className="px-4 py-2 font-bold text-[0.6875rem] leading-[0.875rem] tracking-wider text-left uppercase">
+							Bug
+						</th>
+					</tr>
+				</thead>
+				<tbody className="bg-white">
+					{issues.map((issue) => (
+						<RunIssueTableRow key={issue.issue_id} issue={issue} />
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}

--- a/libs/bublik/features/result-classification/src/lib/run-issues-table.tsx
+++ b/libs/bublik/features/result-classification/src/lib/run-issues-table.tsx
@@ -7,6 +7,7 @@ import { Badge, Icon, Skeleton, cn } from '@/shared/tailwind-ui';
 import { BublikEmptyState, BublikErrorState } from '@/bublik/features/ui-state';
 import type { RunIssueRow } from '@/shared/types';
 
+import { expectedBadge } from './expected';
 import { RunIssueResults } from './run-issue-results';
 
 interface RunIssuesTableProps {
@@ -32,7 +33,13 @@ function RunIssueTableRow({
 	isExpanded,
 	onToggle
 }: RunIssueRowProps) {
-	const isExpected = issue.categories.some((c) => c.expected);
+	const dispositions = issue.categories.map((c) => c.expected);
+	const aggregate = dispositions.includes(true)
+		? true
+		: dispositions.includes(false)
+			? false
+			: null;
+	const badge = expectedBadge(aggregate);
 
 	return (
 		<>
@@ -57,9 +64,7 @@ function RunIssueTableRow({
 					</LinkWithProject>
 				</td>
 				<td className={cellClassName}>
-					<Badge variant={isExpected ? 'expected' : 'unexpected'}>
-						{isExpected ? 'Expected' : 'Unexpected'}
-					</Badge>
+					<Badge variant={badge.variant}>{badge.label}</Badge>
 				</td>
 				<td className={cn(cellClassName, 'text-right')}>
 					<button

--- a/libs/bublik/features/result-classification/src/lib/use-classify.ts
+++ b/libs/bublik/features/result-classification/src/lib/use-classify.ts
@@ -14,9 +14,15 @@ export function useClassify(resultId: number) {
 	const issues = useGetIssuesQuery(projectId ? { projectId } : {});
 	const [classify, mutationState] = useClassifyResultMutation();
 
+	const canClassify = projectId !== undefined;
+
 	async function submit(
 		input: Omit<ClassifyRequest, 'resultId' | 'projectId'>
 	) {
+		if (projectId === undefined) {
+			toast.error('Select a project first', { position: 'top-center' });
+			return;
+		}
 		const promise = classify({ resultId, projectId, ...input }).unwrap();
 		toast.promise(promise, {
 			loading: 'Classifying result...',
@@ -30,5 +36,5 @@ export function useClassify(resultId: number) {
 		return promise;
 	}
 
-	return { issues, submit, isLoading: mutationState.isLoading };
+	return { issues, submit, canClassify, isLoading: mutationState.isLoading };
 }

--- a/libs/bublik/features/result-classification/src/lib/use-classify.ts
+++ b/libs/bublik/features/result-classification/src/lib/use-classify.ts
@@ -8,9 +8,11 @@ import { useProjectSearch } from '@/bublik/features/projects';
 import { toast } from '@/shared/tailwind-ui';
 import type { ClassifyRequest } from '@/shared/types';
 
-export function useClassify(resultId: number) {
+export function useClassify(resultId: number, projectIdParam?: number) {
 	const { projectIds } = useProjectSearch();
-	const projectId = projectIds[0];
+	// Prefer the project the result belongs to (run page); fall back to the
+	// global project selector.
+	const projectId = projectIdParam ?? projectIds[0];
 	const issues = useGetIssuesQuery(projectId ? { projectId } : {});
 	const [classify, mutationState] = useClassifyResultMutation();
 

--- a/libs/bublik/features/result-classification/src/lib/use-classify.ts
+++ b/libs/bublik/features/result-classification/src/lib/use-classify.ts
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import {
+	getErrorMessage,
+	useClassifyResultMutation,
+	useGetIssuesQuery
+} from '@/services/bublik-api';
+import { useProjectSearch } from '@/bublik/features/projects';
+import { toast } from '@/shared/tailwind-ui';
+import type { ClassifyRequest } from '@/shared/types';
+
+export function useClassify(resultId: number) {
+	const { projectIds } = useProjectSearch();
+	const projectId = projectIds[0];
+	const issues = useGetIssuesQuery(projectId ? { projectId } : {});
+	const [classify, mutationState] = useClassifyResultMutation();
+
+	async function submit(
+		input: Omit<ClassifyRequest, 'resultId' | 'projectId'>
+	) {
+		const promise = classify({ resultId, projectId, ...input }).unwrap();
+		toast.promise(promise, {
+			loading: 'Classifying result...',
+			success: 'Result classified',
+			error: (err: unknown) => {
+				const m = getErrorMessage(err);
+				return `${m.title}\n${m.description}`;
+			},
+			position: 'top-center'
+		});
+		return promise;
+	}
+
+	return { issues, submit, isLoading: mutationState.isLoading };
+}

--- a/libs/bublik/features/result-classification/tsconfig.json
+++ b/libs/bublik/features/result-classification/tsconfig.json
@@ -1,0 +1,31 @@
+{
+	"extends": "../../../../tsconfig.base.json",
+	"compilerOptions": {
+		"target": "ESNext",
+		"useDefineForClassFields": true,
+		"module": "ESNext",
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
+		"allowJs": false,
+		"skipLibCheck": true,
+		"esModuleInterop": false,
+		"allowSyntheticDefaultImports": true,
+		"strict": true,
+
+		"moduleResolution": "Node",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"jsx": "react-jsx",
+		"types": ["vite/client", "vitest"]
+	},
+	"files": [],
+	"include": ["src"],
+	"references": [
+		{
+			"path": "./tsconfig.lib.json"
+		},
+		{
+			"path": "./tsconfig.spec.json"
+		}
+	]
+}

--- a/libs/bublik/features/result-classification/tsconfig.lib.json
+++ b/libs/bublik/features/result-classification/tsconfig.lib.json
@@ -1,0 +1,23 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../../dist/out-tsc",
+		"types": ["node"]
+	},
+	"files": [
+		"../../../../node_modules/@nx/react/typings/cssmodule.d.ts",
+		"../../../../node_modules/@nx/react/typings/image.d.ts"
+	],
+	"exclude": [
+		"jest.config.ts",
+		"**/*.spec.ts",
+		"**/*.test.ts",
+		"**/*.spec.tsx",
+		"**/*.test.tsx",
+		"**/*.spec.js",
+		"**/*.test.js",
+		"**/*.spec.jsx",
+		"**/*.test.jsx"
+	],
+	"include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+}

--- a/libs/bublik/features/result-classification/tsconfig.spec.json
+++ b/libs/bublik/features/result-classification/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"types": ["vitest/globals", "node"]
+	},
+	"include": [
+		"vite.config.mts",
+		"src/**/*.test.ts",
+		"src/**/*.spec.ts",
+		"src/**/*.test.tsx",
+		"src/**/*.spec.tsx",
+		"src/**/*.test.js",
+		"src/**/*.spec.js",
+		"src/**/*.test.jsx",
+		"src/**/*.spec.jsx",
+		"src/**/*.d.ts"
+	]
+}

--- a/libs/bublik/features/result-classification/vite.config.mts
+++ b/libs/bublik/features/result-classification/vite.config.mts
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import viteTsConfigPaths from 'vite-tsconfig-paths';
+import dts from 'vite-plugin-dts';
+import { join } from 'path';
+
+export default defineConfig({
+	plugins: [
+		dts({
+			tsConfigFilePath: join(__dirname, 'tsconfig.lib.json'),
+			// Faster builds by skipping tests. Set this to false to enable type checking.
+			skipDiagnostics: true
+		}),
+		react(),
+		viteTsConfigPaths({
+			root: '../../../../'
+		})
+	],
+
+	// Uncomment this if you are using workers.
+	// worker: {
+	//  plugins: [
+	//    viteTsConfigPaths({
+	//      root: '../../../../',
+	//    }),
+	//  ],
+	// },
+
+	// Configuration for building your library.
+	// See: https://vitejs.dev/guide/build.html#library-mode
+	build: {
+		lib: {
+			// Could also be a dictionary or array of multiple entry points.
+			entry: 'src/index.ts',
+			name: 'bublik-features-result-classification',
+			fileName: 'index',
+			// Change this to the formats you want to support.
+			// Don't forgot to update your package.json as well.
+			formats: ['es', 'cjs']
+		},
+		rollupOptions: {
+			// External packages that should not be bundled into your library.
+			external: ['react', 'react-dom', 'react/jsx-runtime']
+		}
+	},
+
+	test: {
+		reporters: ['default'],
+		globals: true,
+		environment: 'jsdom',
+		include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}']
+	}
+});

--- a/libs/bublik/features/run/src/lib/result-table/result-table.columns.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.columns.tsx
@@ -12,7 +12,10 @@ import { createNextState } from '@reduxjs/toolkit';
 import { RESULT_PROPERTIES, RESULT_TYPE, RunDataResults } from '@/shared/types';
 import { config } from '@/bublik/config';
 import { ResultLinksContainer } from '@/bublik/features/result-links';
-import { ClassifyPopover } from '@/bublik/features/result-classification';
+import {
+	ClassifyPopover,
+	expectedBadge
+} from '@/bublik/features/result-classification';
 import {
 	Badge,
 	Icon,
@@ -85,7 +88,7 @@ export const getColumns = ({
 						{(value.issues ?? []).map((ref) => (
 							<Badge
 								key={ref.rule_id}
-								variant={ref.expected ? 'expected' : 'unexpected'}
+								variant={expectedBadge(ref.expected).variant}
 								overflowWrap
 							>
 								{ref.category}

--- a/libs/bublik/features/run/src/lib/result-table/result-table.columns.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.columns.tsx
@@ -12,6 +12,7 @@ import { createNextState } from '@reduxjs/toolkit';
 import { RESULT_PROPERTIES, RESULT_TYPE, RunDataResults } from '@/shared/types';
 import { config } from '@/bublik/config';
 import { ResultLinksContainer } from '@/bublik/features/result-links';
+import { ClassifyPopover } from '@/bublik/features/result-classification';
 import {
 	Badge,
 	Icon,
@@ -70,9 +71,10 @@ export const getColumns = ({
 			id: 'links',
 			cell: (cell) => {
 				const value = cell.getValue();
+				const isFailed = value.has_error || (value.issues?.length ?? 0) > 0;
 
 				return (
-					<div className="flex items-center h-full">
+					<div className="flex items-center gap-2 h-full">
 						<ResultLinksContainer
 							runId={String(value.run_id)}
 							resultId={value.result_id}
@@ -80,6 +82,19 @@ export const getColumns = ({
 							showLinkToRun={showLinkToRun}
 							path={path}
 						/>
+						{(value.issues ?? []).map((ref) => (
+							<Badge
+								key={ref.rule_id}
+								variant={ref.expected ? 'expected' : 'unexpected'}
+								overflowWrap
+							>
+								{ref.category}
+								{ref.issue_state === 'closed' ? ' (closed)' : ''}
+							</Badge>
+						))}
+						{isFailed ? (
+							<ClassifyPopover resultId={value.result_id} />
+						) : null}
 					</div>
 				);
 			},

--- a/libs/bublik/features/run/src/lib/result-table/result-table.columns.tsx
+++ b/libs/bublik/features/run/src/lib/result-table/result-table.columns.tsx
@@ -93,7 +93,10 @@ export const getColumns = ({
 							</Badge>
 						))}
 						{isFailed ? (
-							<ClassifyPopover resultId={value.result_id} />
+							<ClassifyPopover
+								resultId={value.result_id}
+								projectId={value.project_id}
+							/>
 						) : null}
 					</div>
 				);

--- a/libs/services/bublik-api/src/lib/bublikAPI.ts
+++ b/libs/services/bublik-api/src/lib/bublikAPI.ts
@@ -196,6 +196,7 @@ export const {
 	useActivateRuleMutation,
 	useGetIssueQuery,
 	useGetIssueRuleResultsQuery,
+	useGetIssueResultsQuery,
 	useApplyRulesToRunMutation,
 	useGetRunIssuesQuery,
 	useGetRunIssueResultsQuery

--- a/libs/services/bublik-api/src/lib/bublikAPI.ts
+++ b/libs/services/bublik-api/src/lib/bublikAPI.ts
@@ -193,6 +193,9 @@ export const {
 	useCloseIssueMutation,
 	useReopenIssueMutation,
 	useDeactivateRuleMutation,
+	useActivateRuleMutation,
+	useGetIssueQuery,
+	useGetIssueRuleResultsQuery,
 	useApplyRulesToRunMutation,
 	useGetRunIssuesQuery,
 	useGetRunIssueResultsQuery

--- a/libs/services/bublik-api/src/lib/bublikAPI.ts
+++ b/libs/services/bublik-api/src/lib/bublikAPI.ts
@@ -192,5 +192,6 @@ export const {
 	useCloseIssueMutation,
 	useReopenIssueMutation,
 	useDeactivateRuleMutation,
-	useApplyRulesToRunMutation
+	useApplyRulesToRunMutation,
+	useGetRunIssuesQuery
 } = bublikAPI;

--- a/libs/services/bublik-api/src/lib/bublikAPI.ts
+++ b/libs/services/bublik-api/src/lib/bublikAPI.ts
@@ -31,7 +31,8 @@ import {
 	reportEndpoints,
 	configsEndpoints,
 	projectEndpoints,
-	analyticsEndpoints
+	analyticsEndpoints,
+	classificationEndpoints
 } from './endpoints';
 
 const baseQuery = fetchBaseQuery(getAPIConfig());
@@ -111,7 +112,8 @@ export const bublikAPI = createApi({
 	.injectEndpoints(reportEndpoints)
 	.injectEndpoints(configsEndpoints)
 	.injectEndpoints(projectEndpoints)
-	.injectEndpoints(analyticsEndpoints);
+	.injectEndpoints(analyticsEndpoints)
+	.injectEndpoints(classificationEndpoints);
 
 export const {
 	// Dashboard
@@ -182,5 +184,13 @@ export const {
 	useGetAnalyticsFacetsQuery,
 	useGetAnalyticsChartsQuery,
 	useLazyGetAnalyticsExportQuery,
-	useImportAnalyticsDataMutation
+	useImportAnalyticsDataMutation,
+	// Classification
+	useGetIssuesQuery,
+	useGetIssueRulesQuery,
+	useClassifyResultMutation,
+	useCloseIssueMutation,
+	useReopenIssueMutation,
+	useDeactivateRuleMutation,
+	useApplyRulesToRunMutation
 } = bublikAPI;

--- a/libs/services/bublik-api/src/lib/bublikAPI.ts
+++ b/libs/services/bublik-api/src/lib/bublikAPI.ts
@@ -187,6 +187,7 @@ export const {
 	useImportAnalyticsDataMutation,
 	// Classification
 	useGetIssuesQuery,
+	useGetIssuePickerQuery,
 	useGetIssueRulesQuery,
 	useClassifyResultMutation,
 	useCloseIssueMutation,

--- a/libs/services/bublik-api/src/lib/bublikAPI.ts
+++ b/libs/services/bublik-api/src/lib/bublikAPI.ts
@@ -193,5 +193,6 @@ export const {
 	useReopenIssueMutation,
 	useDeactivateRuleMutation,
 	useApplyRulesToRunMutation,
-	useGetRunIssuesQuery
+	useGetRunIssuesQuery,
+	useGetRunIssueResultsQuery
 } = bublikAPI;

--- a/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
@@ -7,6 +7,7 @@ import {
 	Issue,
 	IssuePickerOption,
 	IssueRule,
+	RuleResultRow,
 	RunIssueResultRow,
 	RunIssueRow
 } from '@/shared/types';
@@ -120,6 +121,36 @@ export const classificationEndpoints = {
 				params: { project: projectId }
 			}),
 			invalidatesTags: [BUBLIK_TAG.IssueRules, BUBLIK_TAG.Run]
+		}),
+		getIssue: build.query<Issue, { issueId: number; projectId?: number }>({
+			query: ({ issueId, projectId }) => ({
+				url: withApiV2(`/issues/${issueId}`),
+				params: { project: projectId },
+				cache: 'no-cache'
+			}),
+			providesTags: [BUBLIK_TAG.Issues]
+		}),
+		activateRule: build.mutation<
+			IssueRule,
+			{ ruleId: number; projectId?: number }
+		>({
+			query: ({ ruleId, projectId }) => ({
+				url: withApiV2(`/issue-rules/${ruleId}/activate`),
+				method: 'POST',
+				params: { project: projectId }
+			}),
+			invalidatesTags: [BUBLIK_TAG.IssueRules, BUBLIK_TAG.Run]
+		}),
+		getIssueRuleResults: build.query<
+			RuleResultRow[],
+			{ ruleId: number; projectId?: number; limit?: number }
+		>({
+			query: ({ ruleId, projectId, limit }) => ({
+				url: withApiV2(`/issue-rules/${ruleId}/results`),
+				params: { project: projectId, limit },
+				cache: 'no-cache'
+			}),
+			providesTags: [BUBLIK_TAG.ResultClassification]
 		}),
 		getRunIssues: build.query<
 			RunIssueRow[],

--- a/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
@@ -1,0 +1,114 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2026 OKTET Labs Ltd. */
+import { EndpointBuilder } from '@reduxjs/toolkit/query';
+
+import { ClassifyRequest, Issue, IssueRule } from '@/shared/types';
+
+import { BUBLIK_TAG } from '../types';
+import { prepareForSend } from '../utils';
+import { API_REDUCER_PATH } from '../constants';
+import { BublikBaseQueryFn, withApiV2 } from '../config';
+
+export const classificationEndpoints = {
+	endpoints: (
+		build: EndpointBuilder<
+			BublikBaseQueryFn,
+			BUBLIK_TAG | string,
+			API_REDUCER_PATH
+		>
+	) => ({
+		getIssues: build.query<
+			Issue[],
+			{ projectId?: number; state?: string; category?: string }
+		>({
+			query: (args) => ({
+				url: withApiV2('/issues', true),
+				params: {
+					project: args.projectId,
+					state: args.state,
+					category: args.category
+				},
+				cache: 'no-cache'
+			}),
+			providesTags: [BUBLIK_TAG.Issues]
+		}),
+		getIssueRules: build.query<
+			IssueRule[],
+			{ projectId?: number; issue?: number }
+		>({
+			query: (args) => ({
+				url: withApiV2('/issue-rules', true),
+				params: { project: args.projectId, issue: args.issue },
+				cache: 'no-cache'
+			}),
+			providesTags: [BUBLIK_TAG.IssueRules]
+		}),
+		classifyResult: build.mutation<
+			{ issue_id: number; rule_id: number },
+			ClassifyRequest
+		>({
+			query: ({ resultId, projectId, ...body }) => ({
+				url: withApiV2(`/results/${resultId}/classify`),
+				method: 'POST',
+				params: { project: projectId },
+				body: prepareForSend(body)
+			}),
+			invalidatesTags: [
+				BUBLIK_TAG.Run,
+				BUBLIK_TAG.Issues,
+				BUBLIK_TAG.IssueRules,
+				BUBLIK_TAG.ResultClassification,
+				BUBLIK_TAG.HistoryData,
+				BUBLIK_TAG.DashboardData
+			]
+		}),
+		closeIssue: build.mutation<
+			Issue,
+			{ issueId: number; projectId?: number }
+		>({
+			query: ({ issueId, projectId }) => ({
+				url: withApiV2(`/issues/${issueId}/close`),
+				method: 'POST',
+				params: { project: projectId }
+			}),
+			invalidatesTags: [
+				BUBLIK_TAG.Issues,
+				BUBLIK_TAG.IssueRules,
+				BUBLIK_TAG.Run
+			]
+		}),
+		reopenIssue: build.mutation<
+			Issue,
+			{ issueId: number; projectId?: number }
+		>({
+			query: ({ issueId, projectId }) => ({
+				url: withApiV2(`/issues/${issueId}/reopen`),
+				method: 'POST',
+				params: { project: projectId }
+			}),
+			invalidatesTags: [BUBLIK_TAG.Issues, BUBLIK_TAG.Run]
+		}),
+		deactivateRule: build.mutation<
+			IssueRule,
+			{ ruleId: number; projectId?: number }
+		>({
+			query: ({ ruleId, projectId }) => ({
+				url: withApiV2(`/issue-rules/${ruleId}/deactivate`),
+				method: 'POST',
+				params: { project: projectId }
+			}),
+			invalidatesTags: [BUBLIK_TAG.IssueRules, BUBLIK_TAG.Run]
+		}),
+		applyRulesToRun: build.mutation<
+			{ stamps_created: number },
+			{ runId: number | string; projectId?: number }
+		>({
+			query: ({ runId, projectId }) => ({
+				url: withApiV2(`/runs/${runId}/apply-rules`),
+				method: 'POST',
+				params: { project: projectId }
+			}),
+			invalidatesTags: [BUBLIK_TAG.Run, BUBLIK_TAG.ResultClassification]
+		})
+	})
+};

--- a/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
@@ -152,6 +152,17 @@ export const classificationEndpoints = {
 			}),
 			providesTags: [BUBLIK_TAG.ResultClassification]
 		}),
+		getIssueResults: build.query<
+			RuleResultRow[],
+			{ issueId: number; projectId?: number; limit?: number }
+		>({
+			query: ({ issueId, projectId, limit }) => ({
+				url: withApiV2(`/issues/${issueId}/results`),
+				params: { project: projectId, limit },
+				cache: 'no-cache'
+			}),
+			providesTags: [BUBLIK_TAG.ResultClassification]
+		}),
 		getRunIssues: build.query<
 			RunIssueRow[],
 			{ runId: number | string; projectId?: number }

--- a/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
@@ -2,7 +2,13 @@
 /* SPDX-FileCopyrightText: 2026 OKTET Labs Ltd. */
 import { EndpointBuilder } from '@reduxjs/toolkit/query';
 
-import { ClassifyRequest, Issue, IssueRule, RunIssueRow } from '@/shared/types';
+import {
+	ClassifyRequest,
+	Issue,
+	IssueRule,
+	RunIssueResultRow,
+	RunIssueRow
+} from '@/shared/types';
 
 import { BUBLIK_TAG } from '../types';
 import { prepareForSend } from '../utils';
@@ -113,6 +119,17 @@ export const classificationEndpoints = {
 				cache: 'no-cache'
 			}),
 			providesTags: [BUBLIK_TAG.Issues, BUBLIK_TAG.ResultClassification]
+		}),
+		getRunIssueResults: build.query<
+			RunIssueResultRow[],
+			{ runId: number | string; issueId: number; projectId?: number }
+		>({
+			query: ({ runId, issueId, projectId }) => ({
+				url: withApiV2(`/runs/${runId}/issues/${issueId}/results`),
+				params: { project: projectId },
+				cache: 'no-cache'
+			}),
+			providesTags: [BUBLIK_TAG.ResultClassification]
 		}),
 		applyRulesToRun: build.mutation<
 			{ stamps_created: number },

--- a/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
@@ -30,6 +30,8 @@ export const classificationEndpoints = {
 				},
 				cache: 'no-cache'
 			}),
+			transformResponse: (response: { results: Issue[] }) =>
+				response?.results ?? [],
 			providesTags: [BUBLIK_TAG.Issues]
 		}),
 		getIssueRules: build.query<
@@ -41,6 +43,8 @@ export const classificationEndpoints = {
 				params: { project: args.projectId, issue: args.issue },
 				cache: 'no-cache'
 			}),
+			transformResponse: (response: { results: IssueRule[] }) =>
+				response?.results ?? [],
 			providesTags: [BUBLIK_TAG.IssueRules]
 		}),
 		classifyResult: build.mutation<

--- a/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
@@ -2,7 +2,7 @@
 /* SPDX-FileCopyrightText: 2026 OKTET Labs Ltd. */
 import { EndpointBuilder } from '@reduxjs/toolkit/query';
 
-import { ClassifyRequest, Issue, IssueRule } from '@/shared/types';
+import { ClassifyRequest, Issue, IssueRule, RunIssueRow } from '@/shared/types';
 
 import { BUBLIK_TAG } from '../types';
 import { prepareForSend } from '../utils';
@@ -102,6 +102,17 @@ export const classificationEndpoints = {
 				params: { project: projectId }
 			}),
 			invalidatesTags: [BUBLIK_TAG.IssueRules, BUBLIK_TAG.Run]
+		}),
+		getRunIssues: build.query<
+			RunIssueRow[],
+			{ runId: number | string; projectId?: number }
+		>({
+			query: ({ runId, projectId }) => ({
+				url: withApiV2(`/runs/${runId}/issues`),
+				params: { project: projectId },
+				cache: 'no-cache'
+			}),
+			providesTags: [BUBLIK_TAG.Issues, BUBLIK_TAG.ResultClassification]
 		}),
 		applyRulesToRun: build.mutation<
 			{ stamps_created: number },

--- a/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
@@ -22,7 +22,7 @@ export const classificationEndpoints = {
 			{ projectId?: number; state?: string; category?: string }
 		>({
 			query: (args) => ({
-				url: withApiV2('/issues', true),
+				url: withApiV2('/issues'),
 				params: {
 					project: args.projectId,
 					state: args.state,
@@ -37,7 +37,7 @@ export const classificationEndpoints = {
 			{ projectId?: number; issue?: number }
 		>({
 			query: (args) => ({
-				url: withApiV2('/issue-rules', true),
+				url: withApiV2('/issue-rules'),
 				params: { project: args.projectId, issue: args.issue },
 				cache: 'no-cache'
 			}),

--- a/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
@@ -85,10 +85,7 @@ export const classificationEndpoints = {
 				BUBLIK_TAG.DashboardData
 			]
 		}),
-		closeIssue: build.mutation<
-			Issue,
-			{ issueId: number; projectId?: number }
-		>({
+		closeIssue: build.mutation<Issue, { issueId: number; projectId?: number }>({
 			query: ({ issueId, projectId }) => ({
 				url: withApiV2(`/issues/${issueId}/close`),
 				method: 'POST',
@@ -100,17 +97,16 @@ export const classificationEndpoints = {
 				BUBLIK_TAG.Run
 			]
 		}),
-		reopenIssue: build.mutation<
-			Issue,
-			{ issueId: number; projectId?: number }
-		>({
-			query: ({ issueId, projectId }) => ({
-				url: withApiV2(`/issues/${issueId}/reopen`),
-				method: 'POST',
-				params: { project: projectId }
-			}),
-			invalidatesTags: [BUBLIK_TAG.Issues, BUBLIK_TAG.Run]
-		}),
+		reopenIssue: build.mutation<Issue, { issueId: number; projectId?: number }>(
+			{
+				query: ({ issueId, projectId }) => ({
+					url: withApiV2(`/issues/${issueId}/reopen`),
+					method: 'POST',
+					params: { project: projectId }
+				}),
+				invalidatesTags: [BUBLIK_TAG.Issues, BUBLIK_TAG.Run]
+			}
+		),
 		deactivateRule: build.mutation<
 			IssueRule,
 			{ ruleId: number; projectId?: number }

--- a/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/classification-endpoints.ts
@@ -5,6 +5,7 @@ import { EndpointBuilder } from '@reduxjs/toolkit/query';
 import {
 	ClassifyRequest,
 	Issue,
+	IssuePickerOption,
 	IssueRule,
 	RunIssueResultRow,
 	RunIssueRow
@@ -38,6 +39,17 @@ export const classificationEndpoints = {
 			}),
 			transformResponse: (response: { results: Issue[] }) =>
 				response?.results ?? [],
+			providesTags: [BUBLIK_TAG.Issues]
+		}),
+		getIssuePicker: build.query<
+			IssuePickerOption[],
+			{ projectId?: number; search?: string }
+		>({
+			query: ({ projectId, search }) => ({
+				url: withApiV2('/issues/picker'),
+				params: { project: projectId, search: search || undefined },
+				cache: 'no-cache'
+			}),
 			providesTags: [BUBLIK_TAG.Issues]
 		}),
 		getIssueRules: build.query<

--- a/libs/services/bublik-api/src/lib/endpoints/index.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/index.ts
@@ -14,3 +14,4 @@ export * from './report-endpoints';
 export * from './configs-endpoints';
 export * from './project-endpoints';
 export * from './analytics-endpoints';
+export * from './classification-endpoints';

--- a/libs/services/bublik-api/src/lib/endpoints/run-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/run-endpoints.ts
@@ -258,7 +258,8 @@ export const runEndpoints = {
 						}
 					};
 				}
-			}
+			},
+			providesTags: [{ type: BUBLIK_TAG.Run }]
 		}),
 		getCompromisedTags: build.query<
 			CompromisedTagsResponse,

--- a/libs/services/bublik-api/src/lib/tags.ts
+++ b/libs/services/bublik-api/src/lib/tags.ts
@@ -8,5 +8,8 @@ export const tagTypes: BUBLIK_TAG[] = [
 	BUBLIK_TAG.HistoryData,
 	BUBLIK_TAG.LogData,
 	BUBLIK_TAG.User,
-	BUBLIK_TAG.Analytics
+	BUBLIK_TAG.Analytics,
+	BUBLIK_TAG.Issues,
+	BUBLIK_TAG.IssueRules,
+	BUBLIK_TAG.ResultClassification
 ];

--- a/libs/services/bublik-api/src/lib/types/index.ts
+++ b/libs/services/bublik-api/src/lib/types/index.ts
@@ -16,5 +16,8 @@ export const enum BUBLIK_TAG {
 	importEvents = 'import-events',
 	SessionList = 'session-list',
 	Project = 'project',
-	Analytics = 'analytics'
+	Analytics = 'analytics',
+	Issues = 'issues',
+	IssueRules = 'issue-rules',
+	ResultClassification = 'result-classification'
 }

--- a/libs/shared/tailwind-ui/src/lib/drawer/drawer.component.tsx
+++ b/libs/shared/tailwind-ui/src/lib/drawer/drawer.component.tsx
@@ -5,6 +5,7 @@ import {
 	Dialog,
 	DialogContent,
 	DialogOverlay,
+	DialogPortal,
 	DialogTrigger,
 	dialogOverlayStyles
 } from '../dialog';
@@ -25,22 +26,30 @@ export const DrawerTrigger = forwardRef<HTMLButtonElement, DialogTriggerProps>(
 	}
 );
 
-export const DrawerContent = forwardRef<HTMLDivElement, DialogContentProps>(
-	({ className, children, ...props }, ref) => {
-		return (
-			<>
-				<DialogOverlay className={dialogOverlayStyles()} />
-				<DialogContent
-					{...props}
-					className={cn(
-						'fixed top-0 right-0 z-50 h-screen h-svh bg-white rdx-state-open:animate-drawer-slide-in-right rdx-state-closed:animate-drawer-slide-out-right',
-						className
-					)}
-					ref={ref}
-				>
-					{children}
-				</DialogContent>
-			</>
-		);
-	}
-);
+export const DrawerContent = forwardRef<
+	HTMLDivElement,
+	// portal escapes the trigger's stacking context (e.g. a table row) so rows
+	// can't paint over the drawer. Opt-in to keep the inline behavior other
+	// callers rely on.
+	DialogContentProps & { portal?: boolean }
+>(({ className, children, portal, ...props }, ref) => {
+	const content = (
+		<>
+			<DialogOverlay className={dialogOverlayStyles()} />
+			<DialogContent
+				{...props}
+				className={cn(
+					'fixed top-0 right-0 z-50 h-screen h-svh bg-white rdx-state-open:animate-drawer-slide-in-right rdx-state-closed:animate-drawer-slide-out-right',
+					className
+				)}
+				ref={ref}
+			>
+				{children}
+			</DialogContent>
+		</>
+	);
+
+	// Portal (to document.body) escapes the trigger's stacking context so the
+	// drawer layers above the table instead of behind it.
+	return portal ? <DialogPortal>{content}</DialogPortal> : content;
+});

--- a/libs/shared/tailwind-ui/src/lib/popover/popover.tsx
+++ b/libs/shared/tailwind-ui/src/lib/popover/popover.tsx
@@ -23,9 +23,12 @@ export const popoverContentStyles = cva({
 
 export const StyledContent = forwardRef<
 	HTMLDivElement,
-	PopoverPrimitive.PopoverContentProps
->(({ children, ...props }, ref) => {
-	return (
+	// portal escapes the trigger's stacking context (e.g. a table row), so the
+	// content can't be painted over by later siblings. Opt-in to avoid changing
+	// the inline behavior other callers rely on.
+	PopoverPrimitive.PopoverContentProps & { portal?: boolean }
+>(({ children, portal, ...props }, ref) => {
+	const content = (
 		<PopoverPrimitive.Content
 			{...props}
 			className={cn(popoverContentStyles, props.className)}
@@ -34,6 +37,14 @@ export const StyledContent = forwardRef<
 		>
 			{children}
 		</PopoverPrimitive.Content>
+	);
+
+	// Portal (to document.body) escapes the trigger's stacking context so the
+	// content layers above the table instead of behind it.
+	return portal ? (
+		<PopoverPrimitive.Portal>{content}</PopoverPrimitive.Portal>
+	) : (
+		content
 	);
 });
 

--- a/libs/shared/types/src/index.ts
+++ b/libs/shared/types/src/index.ts
@@ -15,3 +15,4 @@ export * from './lib/performance';
 export * from './lib/report';
 export * from './lib/analytics';
 export * from './lib/sidebar';
+export * from './lib/classification';

--- a/libs/shared/types/src/lib/classification.ts
+++ b/libs/shared/types/src/lib/classification.ts
@@ -114,4 +114,8 @@ export interface RuleResultRow {
 	path: string[];
 	obtained_result: string | null;
 	verdicts: string[];
+	// Present on the per-issue aggregate (results span multiple rules/categories).
+	rule_id?: number;
+	category?: IssueCategory;
+	expected?: boolean | null;
 }

--- a/libs/shared/types/src/lib/classification.ts
+++ b/libs/shared/types/src/lib/classification.ts
@@ -58,6 +58,15 @@ export type ResultIssueRef = {
 	origin: 'import' | 'manual_apply' | 'manual_oneoff';
 };
 
+export interface RunIssueRow {
+	issue_id: number;
+	title: string;
+	state: IssueState;
+	bug_key: string | null;
+	result_count: number;
+	categories: { category: IssueCategory; expected: boolean }[];
+}
+
 export type ClassifyScope = 'future' | 'oneoff';
 
 export type ClassifyRequest = {

--- a/libs/shared/types/src/lib/classification.ts
+++ b/libs/shared/types/src/lib/classification.ts
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2026 OKTET Labs Ltd. */
+
+export type IssueCategory =
+	| 'product-defect'
+	| 'test-bug'
+	| 'env'
+	| 'known-issue'
+	| 'flaky'
+	| 'to-investigate';
+
+export type IssueState = 'open' | 'closed';
+
+export type IssueExt = {
+	id: number;
+	key: string;
+	status: string | null;
+	title: string | null;
+	synced_at: string | null;
+};
+
+export type Issue = {
+	id: number;
+	title: string;
+	description: string | null;
+	state: IssueState;
+	issue_ext: IssueExt | null;
+	created_at: string;
+	updated_at: string;
+	closed_at: string | null;
+};
+
+export type IssueRule = {
+	id: number;
+	project: number;
+	issue: number;
+	category: IssueCategory;
+	expected: boolean;
+	active: boolean;
+	test: number;
+	match_parameters: boolean;
+	match_verdicts: boolean;
+	match_important_tags: boolean;
+	match_all_tags: boolean;
+	parameters: Record<string, string>;
+	verdicts: string[];
+	tags: string[];
+};
+
+/** Per-result classification badge data (embedded in run result rows). */
+export type ResultIssueRef = {
+	issue_id: number;
+	issue_title: string;
+	issue_state: IssueState;
+	category: IssueCategory;
+	expected: boolean;
+	rule_id: number;
+	origin: 'import' | 'manual_apply' | 'manual_oneoff';
+};
+
+export type ClassifyScope = 'future' | 'oneoff';
+
+export type ClassifyRequest = {
+	resultId: number;
+	projectId: number;
+	issue: number | { title: string; description?: string; bug_key?: string };
+	category: IssueCategory;
+	expected?: boolean;
+	scope: ClassifyScope;
+};

--- a/libs/shared/types/src/lib/classification.ts
+++ b/libs/shared/types/src/lib/classification.ts
@@ -38,6 +38,7 @@ export type IssueRule = {
 	expected: boolean;
 	active: boolean;
 	test: number;
+	test_name: string;
 	match_parameters: boolean;
 	match_verdicts: boolean;
 	match_important_tags: boolean;
@@ -102,3 +103,13 @@ export type ClassifyRequest = {
 	// the backend defaults (path + params + verdicts + important tags).
 	matcher?: ClassifyMatcher;
 };
+
+export interface RuleResultRow {
+	result_id: number;
+	run_id: number | null;
+	run_start: string | null;
+	name: string | null;
+	path: string[];
+	obtained_result: string | null;
+	verdicts: string[];
+}

--- a/libs/shared/types/src/lib/classification.ts
+++ b/libs/shared/types/src/lib/classification.ts
@@ -75,6 +75,13 @@ export interface RunIssueResultRow {
 	verdicts: string[];
 }
 
+export interface IssuePickerOption {
+	id: number;
+	title: string;
+	key: string | null;
+	category: IssueCategory | null;
+}
+
 export type ClassifyScope = 'future' | 'oneoff';
 
 export type ClassifyRequest = {

--- a/libs/shared/types/src/lib/classification.ts
+++ b/libs/shared/types/src/lib/classification.ts
@@ -84,6 +84,13 @@ export interface IssuePickerOption {
 
 export type ClassifyScope = 'future' | 'oneoff';
 
+export interface ClassifyMatcher {
+	matchParameters: boolean;
+	matchVerdicts: boolean;
+	matchImportantTags: boolean;
+	matchAllTags: boolean;
+}
+
 export type ClassifyRequest = {
 	resultId: number;
 	projectId: number;
@@ -91,4 +98,7 @@ export type ClassifyRequest = {
 	category: IssueCategory;
 	expected?: boolean;
 	scope: ClassifyScope;
+	// Optional; keys are decamelized to match_* by prepareForSend. Omit to keep
+	// the backend defaults (path + params + verdicts + important tags).
+	matcher?: ClassifyMatcher;
 };

--- a/libs/shared/types/src/lib/classification.ts
+++ b/libs/shared/types/src/lib/classification.ts
@@ -67,6 +67,14 @@ export interface RunIssueRow {
 	categories: { category: IssueCategory; expected: boolean }[];
 }
 
+export interface RunIssueResultRow {
+	result_id: number;
+	name: string | null;
+	path: string[];
+	obtained_result: string | null;
+	verdicts: string[];
+}
+
 export type ClassifyScope = 'future' | 'oneoff';
 
 export type ClassifyRequest = {

--- a/libs/shared/types/src/lib/classification.ts
+++ b/libs/shared/types/src/lib/classification.ts
@@ -35,7 +35,7 @@ export type IssueRule = {
 	project: number;
 	issue: number;
 	category: IssueCategory;
-	expected: boolean;
+	expected: boolean | null;
 	active: boolean;
 	test: number;
 	test_name: string;
@@ -56,7 +56,7 @@ export type ResultIssueRef = {
 	/** External bug key (e.g. ISSUE-240); populated in history rows. */
 	bug_key?: string | null;
 	category: IssueCategory;
-	expected: boolean;
+	expected: boolean | null;
 	rule_id: number;
 	origin: 'import' | 'manual_apply' | 'manual_oneoff';
 };
@@ -67,7 +67,7 @@ export interface RunIssueRow {
 	state: IssueState;
 	bug_key: string | null;
 	result_count: number;
-	categories: { category: IssueCategory; expected: boolean }[];
+	categories: { category: IssueCategory; expected: boolean | null }[];
 }
 
 export interface RunIssueResultRow {
@@ -99,7 +99,7 @@ export type ClassifyRequest = {
 	projectId: number;
 	issue: number | { title: string; description?: string; bug_key?: string };
 	category: IssueCategory;
-	expected?: boolean;
+	expected?: boolean | null;
 	scope: ClassifyScope;
 	// Optional; keys are decamelized to match_* by prepareForSend. Omit to keep
 	// the backend defaults (path + params + verdicts + important tags).

--- a/libs/shared/types/src/lib/classification.ts
+++ b/libs/shared/types/src/lib/classification.ts
@@ -53,6 +53,8 @@ export type ResultIssueRef = {
 	issue_id: number;
 	issue_title: string;
 	issue_state: IssueState;
+	/** External bug key (e.g. ISSUE-240); populated in history rows. */
+	bug_key?: string | null;
 	category: IssueCategory;
 	expected: boolean;
 	rule_id: number;

--- a/libs/shared/types/src/lib/history.ts
+++ b/libs/shared/types/src/lib/history.ts
@@ -41,6 +41,11 @@ export type HistoryAPIBackendQuery = {
 	verdictLookup?: VERDICT_TYPE;
 	verdict?: string;
 
+	/* Result classification (Plan 2) */
+	categories?: string;
+	issue?: string;
+	untriaged?: string;
+
 	page?: string;
 	pageSize?: string;
 	projects?: number[];
@@ -72,6 +77,11 @@ export const HistoryAPIBackendQuerySchema = z.object({
 
 	verdictLookup: z.nativeEnum(VERDICT_TYPE).optional(),
 	verdict: z.string().optional(),
+
+	/* Result classification (Plan 2) */
+	categories: z.string().optional(),
+	issue: z.string().optional(),
+	untriaged: z.string().optional(),
 
 	page: z.string().optional(),
 	pageSize: z.string().optional(),
@@ -107,6 +117,12 @@ export type HistoryAPIQuery = {
 
 	verdictLookup?: VERDICT_TYPE;
 	verdict?: string;
+
+	/* Result classification (Plan 2) */
+	categories?: string;
+	issue?: string;
+	untriaged?: string;
+
 	project?: string;
 };
 

--- a/libs/shared/types/src/lib/history.ts
+++ b/libs/shared/types/src/lib/history.ts
@@ -178,7 +178,7 @@ const HistoryIssueRefSchema = z.object({
 		'flaky',
 		'to-investigate'
 	]),
-	expected: z.boolean(),
+	expected: z.boolean().nullable(),
 	rule_id: z.number(),
 	origin: z.enum(['import', 'manual_apply', 'manual_oneoff'])
 });

--- a/libs/shared/types/src/lib/history.ts
+++ b/libs/shared/types/src/lib/history.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import { RESULT_TYPE, ResultTypeSchema, RunResult, VERDICT_TYPE } from './run';
 import { Pagination } from './utils';
+import { ResultIssueRef } from './classification';
 
 /**
 |--------------------------------------------------
@@ -156,11 +157,30 @@ export type HistoryDataLinear = {
 	important_tags: string[];
 	run_properties?: string[];
 	report_config_id?: number | null;
+	issues?: ResultIssueRef[];
 };
 
 const RunResultSchema = z.object({
 	result_type: ResultTypeSchema,
 	verdicts: z.array(z.string())
+});
+
+const HistoryIssueRefSchema = z.object({
+	issue_id: z.number(),
+	issue_title: z.string(),
+	issue_state: z.enum(['open', 'closed']),
+	bug_key: z.string().nullable().optional(),
+	category: z.enum([
+		'product-defect',
+		'test-bug',
+		'env',
+		'known-issue',
+		'flaky',
+		'to-investigate'
+	]),
+	expected: z.boolean(),
+	rule_id: z.number(),
+	origin: z.enum(['import', 'manual_apply', 'manual_oneoff'])
 });
 
 export const HistoryDataLinearSchema = z.object({
@@ -181,7 +201,8 @@ export const HistoryDataLinearSchema = z.object({
 	result_properties: z.array(z.string()).optional(),
 	important_tags: z.array(z.string()),
 	run_properties: z.array(z.string()).optional(),
-	report_config_id: z.number().nullable().optional()
+	report_config_id: z.number().nullable().optional(),
+	issues: z.array(HistoryIssueRefSchema).optional()
 });
 
 export type HistoryCount = {

--- a/libs/shared/types/src/lib/run.ts
+++ b/libs/shared/types/src/lib/run.ts
@@ -3,6 +3,7 @@
 import { z } from 'zod';
 
 import { NodeEntity } from './tree';
+import { ResultIssueRef } from './classification';
 
 /** Run property state */
 export const enum RUN_PROPERTIES {
@@ -205,7 +206,10 @@ export const RunDataResultsSchema = z.object({
 	parameters: z.array(z.string()),
 	start: z.string(),
 	artifacts: z.array(z.string()).optional(),
-	requirements: z.array(z.string()).optional()
+	requirements: z.array(z.string()).optional(),
+	// classification (Plan 2 read-side); optional for backward-compat
+	effective_expected: z.boolean().optional(),
+	issues: z.array(z.custom<ResultIssueRef>()).optional()
 });
 
 export type RunDataResults = z.infer<typeof RunDataResultsSchema>;

--- a/libs/shared/types/src/lib/run.ts
+++ b/libs/shared/types/src/lib/run.ts
@@ -198,6 +198,8 @@ export const RunDataResultsSchema = z.object({
 	result_id: z.number(),
 	iteration_id: z.number(),
 	run_id: z.number(),
+	// classify uses the result's own project, not the global selector
+	project_id: z.number().optional(),
 	has_measurements: z.boolean(),
 	has_error: z.boolean(),
 	expected_results: z.array(RunResultWithKeysSchema),

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -67,6 +67,9 @@
 			"@/bublik/features/projects": [
 				"libs/bublik/features/projects/src/index.ts"
 			],
+			"@/bublik/features/result-classification": [
+				"libs/bublik/features/result-classification/src/index.ts"
+			],
 			"@/bublik/features/result-links": [
 				"libs/bublik/features/result-links/src/index.ts"
 			],


### PR DESCRIPTION
## Summary

Frontend for **dynamic result classification** — classify failed results from the UI, have classifications inherited by future runs, and suppress known failures from unexpected counts. Pairs with the backend PR (ts-factory/bublik#344).

Highlights:
- **Classify popover + drawer** on failed results: pick/create an Issue, category, tri-state disposition (Expected / Unexpected / Don't change), and a match scope (preset + advanced toggles). Shared react-hook-form across popover and drawer.
- **Searchable issue picker** (recent + title/key typeahead).
- **Admin → Issues** page: list project issues with state + close/reopen; per-issue page (`/admin/issues/:id`) with the issue's rules (enable/disable) and a **consolidated per-issue results list** across all its rules/tests.
- **Run → Issues**: per-run issue summary + drill-down (`/runs/:id/issues`), reachable from an Issues button in the run header.
- **History**: category/issue/untriaged filters and issue key + category badges in the obtained-result column; disposition-colored badges.
- Shared types + RTK endpoints/hooks for issues, rules, and classification; `effective_expected`/`issues` surfaced on run results.

## Rebase note

Rebased onto current `main`. Upstream's `2f278f5 refactor(sidebar)` replaced the monolithic bottom-nav with a per-feature nav model, so the sidebar wiring was **re-implemented against the new API** (Issues entry added to the Admin submenu via `admin-sidebar-nav`); the obsolete bottom-nav/main-nav edits were dropped. Run→Issues stays reachable via the in-page run-header button.

## Test Plan
- [x] `pnpm nx build bublik` — green after rebase (incl. `RunDataResultsSchema` folding `effective_expected`/`issues`).
- [ ] Reviewer: CI green; smoke-test classify flow + Admin → Issues sidebar entry.