### PR TITLE
Default test history to the latest three months

### DIFF
--- a/libs/bublik/config/src/lib/constants.ts
+++ b/libs/bublik/config/src/lib/constants.ts
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { addDays } from 'date-fns';
+import { addMonths } from 'date-fns';
 
 import {
 	RESULT_TYPE,
@@ -63,8 +63,11 @@ export const DEFAULT_RESULT_PROPERTIES: RESULT_PROPERTIES[] = [
 
 export const DEFAULT_VERDICT_LOOKUP: VERDICT_TYPE = VERDICT_TYPE.String;
 
-export const DEFAULT_HISTORY_START_DATE = addDays(new Date(), -31);
-
-export const DEFAULT_HISTORY_END_DATE = new Date();
+export const getDefaultHistoryDateRange = (
+	finishDate: Date = new Date()
+): { startDate: Date; finishDate: Date } => ({
+	startDate: addMonths(finishDate, -3),
+	finishDate
+});
 
 export const HISTORY_MAX_RESULTS_IDS = 6000;

--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.constants.ts
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.constants.ts
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { addDays } from 'date-fns';
+import { getDefaultHistoryDateRange } from '@/bublik/config';
 import {
 	VERDICT_TYPE,
 	RESULT_TYPE,
@@ -36,16 +36,15 @@ const createHistoryConfig = (): HistoryConfig => {
 		RESULT_PROPERTIES.Unexpected
 	];
 
-	const defaultStartDate = addDays(new Date(), -93);
-	const defaultEndDate = new Date();
+	const defaultDates = getDefaultHistoryDateRange();
 
 	return {
 		verdict: defaultVerdict,
 		results: defaultResults,
 		runProperties: defaultRunProperties,
 		resultProperties: defaultResultProperties,
-		startDate: defaultStartDate,
-		endDate: defaultEndDate
+		startDate: defaultDates.startDate,
+		endDate: defaultDates.finishDate
 	};
 };
 

--- a/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.types.ts
+++ b/libs/bublik/features/history/src/lib/history-global-search-form/global-search-form/global-search-form.types.ts
@@ -7,8 +7,11 @@ import { VERDICT_TYPE } from '@/shared/types';
 import {
 	DEFAULT_RESULT_PROPERTIES,
 	DEFAULT_RESULT_TYPES,
-	DEFAULT_RUN_PROPERTIES
+	DEFAULT_RUN_PROPERTIES,
+	getDefaultHistoryDateRange
 } from '@/bublik/config';
+
+const defaultHistoryDateRange = getDefaultHistoryDateRange();
 
 export const ValidationSchema = z
 	.object({
@@ -56,7 +59,10 @@ export const defaultValues: HistoryGlobalSearchFormValues = {
 	runIds: '',
 	labels: [],
 	hash: '',
-	dates: { startDate: new Date(), endDate: new Date() },
+	dates: {
+		startDate: defaultHistoryDateRange.startDate,
+		endDate: defaultHistoryDateRange.finishDate
+	},
 	revisions: [],
 	tagExpr: '',
 	branches: [],

--- a/libs/bublik/features/history/src/lib/slice/history-slice.ts
+++ b/libs/bublik/features/history/src/lib/slice/history-slice.ts
@@ -9,12 +9,11 @@ import { useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 
 import {
-	DEFAULT_HISTORY_END_DATE,
-	DEFAULT_HISTORY_START_DATE,
 	DEFAULT_RESULT_PROPERTIES,
 	DEFAULT_RESULT_TYPES,
 	DEFAULT_RUN_PROPERTIES,
-	DEFAULT_VERDICT_LOOKUP
+	DEFAULT_VERDICT_LOOKUP,
+	getDefaultHistoryDateRange
 } from '@/bublik/config';
 
 import { HistoryGlobalFilter, HistorySliceState } from './history-slice.types';
@@ -32,6 +31,8 @@ export const DEFAULT_GLOBAL_FILTER: HistorySliceState['globalFilter'] = {
 	substringFilter: ''
 };
 
+const defaultHistoryDateRange = getDefaultHistoryDateRange();
+
 export const DEFAULT_SEARCH_FORM_STATE: HistorySliceState['searchForm'] = {
 	/* Test section */
 	testName: '',
@@ -42,8 +43,8 @@ export const DEFAULT_SEARCH_FORM_STATE: HistorySliceState['searchForm'] = {
 	revisions: [],
 	branches: [],
 	/* Run section */
-	startDate: DEFAULT_HISTORY_START_DATE,
-	finishDate: DEFAULT_HISTORY_END_DATE,
+	startDate: defaultHistoryDateRange.startDate,
+	finishDate: defaultHistoryDateRange.finishDate,
 	runData: [],
 	tagExpr: '',
 	runIds: [],

--- a/libs/bublik/features/history/src/lib/slice/history-slice.utils.spec.ts
+++ b/libs/bublik/features/history/src/lib/slice/history-slice.utils.spec.ts
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { searchQueryToBackendQuery } from './history-slice.utils';
+
+describe('searchQueryToBackendQuery', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-07-24T12:00:00'));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('defaults to the latest three calendar months', () => {
+		const query = searchQueryToBackendQuery({ testName: 'suite/test' });
+
+		expect(query.fromDate).toBe('2026-04-24');
+		expect(query.toDate).toBe('2026-07-24');
+	});
+
+	it('preserves an explicitly selected date range', () => {
+		const query = searchQueryToBackendQuery({
+			testName: 'suite/test',
+			startDate: '2025-01-01',
+			finishDate: '2025-01-31'
+		});
+
+		expect(query.fromDate).toBe('2025-01-01');
+		expect(query.toDate).toBe('2025-01-31');
+	});
+
+	it('derives a missing start date from an explicit finish date', () => {
+		const query = searchQueryToBackendQuery({
+			testName: 'suite/test',
+			finishDate: '2025-01-31'
+		});
+
+		expect(query.fromDate).toBe('2024-10-31');
+		expect(query.toDate).toBe('2025-01-31');
+	});
+});

--- a/libs/bublik/features/history/src/lib/slice/history-slice.utils.ts
+++ b/libs/bublik/features/history/src/lib/slice/history-slice.utils.ts
@@ -1,12 +1,11 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { parse } from 'date-fns';
+import { isValid, parse } from 'date-fns';
 
 import {
 	API_DATE_FORMAT,
 	config,
-	DEFAULT_HISTORY_END_DATE,
-	DEFAULT_HISTORY_START_DATE
+	getDefaultHistoryDateRange
 } from '@/bublik/config';
 import {
 	HistoryAPIBackendQuery,
@@ -51,13 +50,14 @@ const withDefault = <T>(
 export const queryToHistorySearchState = (
 	query: HistoryAPIBackendQuery
 ): HistorySearchFormState => {
+	const defaultDates = getDefaultHistoryDateRange();
 	const startDate = query.fromDate
 		? parse(query.fromDate, API_DATE_FORMAT, new Date())
-		: DEFAULT_HISTORY_START_DATE;
+		: defaultDates.startDate;
 
 	const finishDate = query.toDate
 		? parse(query.toDate, API_DATE_FORMAT, new Date())
-		: DEFAULT_HISTORY_END_DATE;
+		: defaultDates.finishDate;
 
 	return {
 		labels: withDefault(parseArray(query.labels), []),
@@ -122,6 +122,13 @@ export const historySearchStateToForm = (
 export function searchQueryToBackendQuery(
 	query: HistoryAPIQuery
 ): HistoryAPIBackendQuery {
+	const parsedFinishDate = query.finishDate
+		? parse(query.finishDate, API_DATE_FORMAT, new Date())
+		: new Date();
+	const defaultDates = getDefaultHistoryDateRange(
+		isValid(parsedFinishDate) ? parsedFinishDate : new Date()
+	);
+
 	return {
 		testName: query.testName,
 		hash: query.hash,
@@ -137,8 +144,8 @@ export function searchQueryToBackendQuery(
 		testArgExpr: query.testArgExpr,
 		revExpr: query.revisionExpr,
 		verdictExpr: query.verdictExpr,
-		fromDate: query.startDate,
-		toDate: query.finishDate,
+		fromDate: query.startDate || formatTimeToAPI(defaultDates.startDate),
+		toDate: query.finishDate || formatTimeToAPI(defaultDates.finishDate),
 		runIds: query.runIds,
 		/* Result section */
 		resultTypes: query.resultProperties,
@@ -188,9 +195,10 @@ export const historySearchStateToQuery = (
 export const formToSearchState = (
 	form: HistoryGlobalSearchFormValues
 ): Omit<HistorySearchFormState, 'page' | 'pageSize'> => {
+	const defaultDates = getDefaultHistoryDateRange();
 	const dates = form.dates ?? {
-		startDate: DEFAULT_HISTORY_START_DATE,
-		endDate: DEFAULT_HISTORY_END_DATE
+		startDate: defaultDates.startDate,
+		endDate: defaultDates.finishDate
 	};
 
 	return {

--- a/libs/shared/utils/src/lib/router.spec.ts
+++ b/libs/shared/utils/src/lib/router.spec.ts
@@ -4,7 +4,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { RunDataResults, RunDetailsAPIResponse } from '@/shared/types';
 
-import { getHistorySearch, HistorySearch } from './router';
+import {
+	getHistorySearch,
+	HistorySearch,
+	HistorySearchBuilder
+} from './router';
 
 const runFixture: RunDetailsAPIResponse = {
 	finish: '2026-02-10T08:15:00.000Z',
@@ -85,6 +89,36 @@ describe('getHistorySearch', () => {
 		expect(getSearchParams(direct.testNameAndParameters).get('mode')).toBe(
 			'aggregation'
 		);
+	});
+
+	it('uses the latest three months for every shortcut regardless of run age', () => {
+		vi.setSystemTime(new Date('2026-07-24T12:00:00'));
+		const oldRun = { ...runFixture, finish: '2024-01-10T08:15:00.000Z' };
+		const { direct, prefilled } = getHistorySearch(
+			oldRun,
+			resultFixture,
+			'linear'
+		);
+
+		for (const shortcuts of [direct, prefilled]) {
+			for (const shortcut of Object.values(shortcuts)) {
+				const query = getSearchParams(shortcut);
+
+				expect(query.get('startDate')).toBe('2026-04-24');
+				expect(query.get('finishDate')).toBe('2026-07-24');
+			}
+		}
+	});
+
+	it('can anchor a run-scoped search to the selected run', () => {
+		const query = new HistorySearchBuilder('suite/test')
+			.withRunIds([42])
+			.withAnchorDate('2024-01-10T08:15:00.000Z')
+			.build();
+
+		expect(query.runIds).toBe('42');
+		expect(query.startDate).toBe('2023-10-10');
+		expect(query.finishDate).toBe('2024-01-10');
 	});
 
 	it('keeps testName + parameters link focused on parameters only', () => {

--- a/libs/shared/utils/src/lib/router.ts
+++ b/libs/shared/utils/src/lib/router.ts
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
-import { addDays, addMonths, isBefore, isValid, parseISO } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 import { createPath, Link, parsePath, To } from 'react-router-dom';
 import { ComponentProps } from 'react';
 
@@ -15,9 +15,9 @@ import {
 } from '@/shared/types';
 import {
 	config,
-	DEFAULT_HISTORY_END_DATE,
 	DEFAULT_RESULT_TYPES,
-	DEFAULT_VERDICT_LOOKUP
+	DEFAULT_VERDICT_LOOKUP,
+	getDefaultHistoryDateRange
 } from '@/bublik/config';
 import { stringifySearch } from '@/router';
 
@@ -42,47 +42,19 @@ export const transformUrlSearch = (
 	});
 };
 
-/**
- * If passed date is older than 3 months we extend to 6 months
- * else we default to 3 months range
- */
-const getFromDate = (maybeDate: string) => {
-	const today = new Date();
-	const parsedDate = isValid(parseISO(maybeDate)) ? parseISO(maybeDate) : today;
-	const isOlderThanThreeMonths = isBefore(parsedDate, addMonths(today, -3));
-	const offsetFromSixMonths = addMonths(parsedDate, -6);
-	const passedOffset = addMonths(parsedDate, -3);
-
-	if (isOlderThanThreeMonths) {
-		return formatTimeToAPI(addDays(offsetFromSixMonths, -3));
-	} else {
-		return formatTimeToAPI(addDays(passedOffset, -3));
-	}
-};
-
-const getToDate = (maybeDate: string) => {
-	const parsedDate = isValid(parseISO(maybeDate))
-		? parseISO(maybeDate)
-		: new Date();
-
-	return formatTimeToAPI(parsedDate);
-};
-
 export const buildQuery = (config: {
 	result: RunDataResults;
 	details: RunDetailsAPIResponse;
 }): HistorySearchParams => {
-	const { result, details } = config;
+	const { result } = config;
 
 	const query = new HistorySearchBuilder(result.name)
-		.withAnchorDate(details.start)
 		.withParameters(result.parameters)
 		.withResultPropertiesBasedOnError(result.has_error)
 		.build();
 
 	return {
 		...query,
-		finishDate: formatTimeToAPI(DEFAULT_HISTORY_END_DATE),
 		results: result.obtained_result.result_type,
 		pageSize: '25'
 	};
@@ -102,22 +74,27 @@ class HistorySearchBuilder {
 	private delimiter = config.queryDelimiter;
 
 	constructor(testName: string) {
-		const today = new Date().toISOString();
+		const { startDate, finishDate } = getDefaultHistoryDateRange();
 
 		this.query = {
 			page: '1',
 			results: DEFAULT_RESULT_TYPES.join(this.delimiter),
 			verdictLookup: DEFAULT_VERDICT_LOOKUP,
-			startDate: getFromDate(today),
-			finishDate: getToDate(today),
+			startDate: formatTimeToAPI(startDate),
+			finishDate: formatTimeToAPI(finishDate),
 			testName,
 			runProperties: RUN_PROPERTIES.NotCompromised
 		};
 	}
 
 	withAnchorDate(anchorDate: string): HistorySearchBuilder {
-		this.query.startDate = getFromDate(anchorDate);
-		this.query.finishDate = getToDate(anchorDate);
+		const parsedDate = parseISO(anchorDate);
+
+		if (!isValid(parsedDate)) return this;
+
+		const { startDate, finishDate } = getDefaultHistoryDateRange(parsedDate);
+		this.query.startDate = formatTimeToAPI(startDate);
+		this.query.finishDate = formatTimeToAPI(finishDate);
 
 		return this;
 	}
@@ -219,24 +196,19 @@ function getHistorySearch(
 	const { relevant_tags, important_tags } = run;
 	const testNameOrPath = path ?? result.name;
 
-	const testName = new HistorySearchBuilder(testNameOrPath)
-		.withAnchorDate(run.finish)
-		.build();
+	const testName = new HistorySearchBuilder(testNameOrPath).build();
 
 	const testNameAndVerdicts = new HistorySearchBuilder(testNameOrPath)
-		.withAnchorDate(run.finish)
 		.withVerdicts(result.obtained_result.verdicts)
 		.build();
 
 	const testNameAndParameters = new HistorySearchBuilder(testNameOrPath)
-		.withAnchorDate(run.finish)
 		.withParameters(result.parameters)
 		.build();
 
 	const testNameAndParametersAndVerdicts = new HistorySearchBuilder(
 		testNameOrPath
 	)
-		.withAnchorDate(run.finish)
 		.withParameters(result.parameters)
 		.withVerdicts(result.obtained_result.verdicts)
 		.build();
@@ -244,7 +216,6 @@ function getHistorySearch(
 	const testNameAndParametersAndImportantTags = new HistorySearchBuilder(
 		testNameOrPath
 	)
-		.withAnchorDate(run.finish)
 		.withParameters(result.parameters)
 		.withTags(important_tags)
 		.build();
@@ -252,7 +223,6 @@ function getHistorySearch(
 	const testNameAndParametersAndAllTags = new HistorySearchBuilder(
 		testNameOrPath
 	)
-		.withAnchorDate(run.finish)
 		.withParameters(result.parameters)
 		.withTags(relevant_tags)
 		.withTags(important_tags)


### PR DESCRIPTION
## Summary

This PR changes the default test history date range to the latest three calendar months ending today.

Previously, history links were anchored to the source run. Recent runs produced a range ending at the run finish date, while older runs could produce a six-month range that still ended in the past. This prevented users from seeing executions that happened after the selected run.

After this change, the source run is used only to build the test filters. Its date no longer controls the history period.

##  Before

If today is July 24:

- A history link opened from a July 20 run ended on July 20 and excluded newer executions.
- A history link opened from an old January run showed data around or before January and excluded current results.
- Different history initialization paths used inconsistent defaults such as 31 days, 93 days, or no backend date range.

## After

If today is July 24, automatically generated history searches use:

startDate=April 24
finishDate=July 24
This applies regardless of whether the source run is recent or several years old.
Explicitly selected dates are preserved and are not replaced by the default range.

Implementation details:
- Added a shared getDefaultHistoryDateRange helper that calculates a three-calendar-month range ending at the current date.
- Updated the history search builder to use this current range.
- Removed source-run date anchoring and the old three-month/six-month branching logic.
- Updated all direct and prefilled result history shortcuts through the shared link builder.
- Updated run-table history links to use the same range.
- Removed the run-details request that was previously needed only to obtain the run finish date for a run-table history link.
- Aligned history form defaults and legacy form initialization with the shared range.
- Added missing default dates when converting frontend history queries to backend queries.
- Preserved explicit startDate and finishDate values.
- Kept existing test-name, parameter, tag, verdict, result, run-ID, and mode filtering behavior unchanged.

Fixes #611