### PR TITLE
fix(report): preserve deep-link anchors

### DIFF
--- a/libs/bublik/features/log/src/lib/containers/log-container/log-container.tsx
+++ b/libs/bublik/features/log/src/lib/containers/log-container/log-container.tsx
@@ -6,7 +6,8 @@ import { analyticsEventNames, trackEvent } from '@/bublik/features/analytics';
 import {
 	useGetLogJsonQuery,
 	useGetLogUrlByResultIdQuery,
-	useGetRunDetailsQuery
+	useGetRunDetailsQuery,
+	useGetTreeByRunIdQuery
 } from '@/services/bublik-api';
 import {
 	LogTableContext,
@@ -19,7 +20,7 @@ import { cn, RunRunning } from '@/shared/tailwind-ui';
 import { BublikEmptyState, BublikErrorState } from '@/bublik/features/ui-state';
 import { RUN_STATUS } from '@/shared/types';
 
-import { useIsLogLegacy, useLogPage } from '../../hooks';
+import { useAllPagesMemory, useIsLogLegacy, useLogPage } from '../../hooks';
 
 const highlightRow = (el: HTMLElement) => {
 	el.classList.add('animate-highlight-row');
@@ -58,6 +59,20 @@ export function LogPickerContainer() {
 		page,
 		setPage
 	} = useLogPage();
+	const { data: details } = useGetRunDetailsQuery(runId ?? skipToken);
+	const { data: treeData } = useGetTreeByRunIdQuery(runId ?? skipToken);
+	const { isRemembered, remember, forget } = useAllPagesMemory();
+	const focusedNode = focusId ? treeData?.tree[focusId] : undefined;
+	const allPagesIdentity =
+		details && focusedNode?.path
+			? {
+					projectId: details.project_id,
+					runId: details.id,
+					path: focusedNode.path
+			  }
+			: null;
+	const effectivePage =
+		page ?? (allPagesIdentity && isRemembered(allPagesIdentity) ? '0' : null);
 
 	if (!runId) {
 		return <BublikEmptyState title="No data" description="Run ID is missing" />;
@@ -67,6 +82,14 @@ export function LogPickerContainer() {
 		trackEvent(analyticsEventNames.logPageChange, {
 			page
 		});
+
+		if (allPagesIdentity) {
+			if (page === 0) {
+				remember(allPagesIdentity);
+			} else {
+				forget(allPagesIdentity);
+			}
+		}
 
 		setPage(page);
 	};
@@ -123,7 +146,7 @@ export function LogPickerContainer() {
 			<JsonLog
 				runId={runId}
 				focusId={focusId}
-				page={page}
+				page={effectivePage}
 				isShowingRunLog={isShowingRunLog}
 			/>
 		</LogTableContextProvider>

--- a/libs/bublik/features/log/src/lib/containers/log-tree/tree-view/tree-view.tsx
+++ b/libs/bublik/features/log/src/lib/containers/log-tree/tree-view/tree-view.tsx
@@ -8,7 +8,6 @@ import {
 	useImperativeHandle,
 	useRef
 } from 'react';
-import { useSearchParams } from 'react-router-dom';
 import {
 	FixedSizeNodeData,
 	FixedSizeTree,
@@ -26,6 +25,7 @@ import {
 } from '@/shared/hooks';
 import { NodeData } from '@/shared/types';
 
+import { useLogPage } from '../../../hooks';
 import { Node } from '../tree-node';
 
 export type TreeNode = Readonly<NodeData>;
@@ -85,7 +85,7 @@ export const TreeView: FC<TreeViewProps> = forwardRef<
 	} = props;
 
 	const treeRef = useRef<FixedSizeTree<TreeData>>(null);
-	const [, setSearchParams] = useSearchParams();
+	const { setFocusId } = useLogPage();
 
 	const treeWalker = useCallback(
 		function* treeWalkerFn(): ReturnType<TreeWalker<TreeData, NodeMeta>> {
@@ -393,18 +393,13 @@ export const TreeView: FC<TreeViewProps> = forwardRef<
 			});
 		}
 
-		if (tree[currentScrollId.current].entity !== 'suite') {
-			setSearchParams((params) => {
-				if (params.get('focusId') !== currentScrollId.current) {
-					params.delete('lineNumber');
-				}
-
-				params.set('focusId', currentScrollId.current);
-
-				return params;
-			});
+		if (
+			tree[currentScrollId.current].entity !== 'suite' &&
+			focusId !== currentScrollId.current
+		) {
+			setFocusId(currentScrollId.current);
 		}
-	}, [main_package, setSearchParams, tree]);
+	}, [focusId, main_package, setFocusId, tree]);
 
 	usePhysicalHotkeys(
 		[

--- a/libs/bublik/features/log/src/lib/hooks/all-pages-memory.spec.ts
+++ b/libs/bublik/features/log/src/lib/hooks/all-pages-memory.spec.ts
@@ -1,0 +1,71 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2026 OKTET LTD */
+import { describe, expect, it } from 'vitest';
+
+import {
+	ALL_PAGES_MEMORY_TTL,
+	getAllPagesMemoryKey,
+	isAllPagesRemembered,
+	updateAllPagesMemory,
+	type AllPagesIdentity
+} from './all-pages-memory';
+
+const NOW = Date.parse('2026-07-29T10:00:00.000Z');
+const IDENTITY: AllPagesIdentity = {
+	projectId: 10,
+	runId: 20,
+	path: 'package/session/test'
+};
+
+describe('all pages memory', () => {
+	it('isolates entries by project, run, and node path', () => {
+		const key = getAllPagesMemoryKey(IDENTITY);
+
+		expect(
+			getAllPagesMemoryKey({ ...IDENTITY, projectId: IDENTITY.projectId + 1 })
+		).not.toBe(key);
+		expect(
+			getAllPagesMemoryKey({ ...IDENTITY, runId: Number(IDENTITY.runId) + 1 })
+		).not.toBe(key);
+		expect(
+			getAllPagesMemoryKey({ ...IDENTITY, path: 'other/session/test' })
+		).not.toBe(key);
+	});
+
+	it('remembers an entry for 24 hours', () => {
+		const memory = updateAllPagesMemory({}, IDENTITY, true, NOW);
+
+		expect(isAllPagesRemembered(memory, IDENTITY, NOW)).toBe(true);
+		expect(
+			isAllPagesRemembered(memory, IDENTITY, NOW + ALL_PAGES_MEMORY_TTL - 1)
+		).toBe(true);
+		expect(
+			isAllPagesRemembered(memory, IDENTITY, NOW + ALL_PAGES_MEMORY_TTL)
+		).toBe(false);
+	});
+
+	it('forgets an entry when a specific page is selected', () => {
+		const remembered = updateAllPagesMemory({}, IDENTITY, true, NOW);
+		const forgotten = updateAllPagesMemory(
+			remembered,
+			IDENTITY,
+			false,
+			NOW + 1
+		);
+
+		expect(isAllPagesRemembered(forgotten, IDENTITY, NOW + 1)).toBe(false);
+	});
+
+	it('removes expired entries while updating memory', () => {
+		const expiredIdentity = { ...IDENTITY, path: 'package/session/expired' };
+		const expiredKey = getAllPagesMemoryKey(expiredIdentity);
+		const memory = updateAllPagesMemory(
+			{ [expiredKey]: NOW - 1 },
+			IDENTITY,
+			true,
+			NOW
+		);
+
+		expect(memory).not.toHaveProperty(expiredKey);
+	});
+});

--- a/libs/bublik/features/log/src/lib/hooks/all-pages-memory.ts
+++ b/libs/bublik/features/log/src/lib/hooks/all-pages-memory.ts
@@ -1,0 +1,102 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2026 OKTET LTD */
+import { z } from 'zod';
+
+import { useUserPreferences } from '@/bublik/features/user-preferences';
+import { useLocalStorage } from '@/shared/hooks';
+
+const ALL_PAGES_MEMORY_KEY = 'log-all-pages-memory';
+const ALL_PAGES_MEMORY_TTL = 24 * 60 * 60 * 1000;
+const EMPTY_ALL_PAGES_MEMORY: AllPagesMemory = {};
+const AllPagesMemorySchema = z.record(z.string(), z.number()).catch({});
+
+interface AllPagesIdentity {
+	projectId: number;
+	runId: string | number;
+	path: string;
+}
+
+type AllPagesMemory = Record<string, number>;
+
+function getAllPagesMemoryKey(identity: AllPagesIdentity): string {
+	return JSON.stringify([
+		identity.projectId,
+		identity.runId.toString(),
+		identity.path
+	]);
+}
+
+function isAllPagesRemembered(
+	memory: AllPagesMemory,
+	identity: AllPagesIdentity,
+	now = Date.now()
+): boolean {
+	return (memory[getAllPagesMemoryKey(identity)] ?? 0) > now;
+}
+
+function updateAllPagesMemory(
+	memory: AllPagesMemory,
+	identity: AllPagesIdentity,
+	remember: boolean,
+	now = Date.now()
+): AllPagesMemory {
+	const nextMemory = Object.fromEntries(
+		Object.entries(memory).filter(([, expiresAt]) => expiresAt > now)
+	);
+	const key = getAllPagesMemoryKey(identity);
+
+	if (remember) {
+		nextMemory[key] = now + ALL_PAGES_MEMORY_TTL;
+	} else {
+		delete nextMemory[key];
+	}
+
+	return nextMemory;
+}
+
+function useAllPagesMemory() {
+	const { userPreferences } = useUserPreferences();
+	const [storedMemory, setStoredMemory] = useLocalStorage<AllPagesMemory>(
+		ALL_PAGES_MEMORY_KEY,
+		EMPTY_ALL_PAGES_MEMORY
+	);
+	const memory = AllPagesMemorySchema.parse(storedMemory);
+	const isEnabled = userPreferences.log.rememberAllPages;
+
+	const isRemembered = (identity: AllPagesIdentity): boolean => {
+		return isEnabled && isAllPagesRemembered(memory, identity);
+	};
+
+	const remember = (identity: AllPagesIdentity): void => {
+		if (!isEnabled) return;
+
+		setStoredMemory((currentMemory) =>
+			updateAllPagesMemory(
+				AllPagesMemorySchema.parse(currentMemory),
+				identity,
+				true
+			)
+		);
+	};
+
+	const forget = (identity: AllPagesIdentity): void => {
+		setStoredMemory((currentMemory) =>
+			updateAllPagesMemory(
+				AllPagesMemorySchema.parse(currentMemory),
+				identity,
+				false
+			)
+		);
+	};
+
+	return { isRemembered, remember, forget } as const;
+}
+
+export {
+	ALL_PAGES_MEMORY_TTL,
+	getAllPagesMemoryKey,
+	isAllPagesRemembered,
+	updateAllPagesMemory,
+	useAllPagesMemory
+};
+export type { AllPagesIdentity, AllPagesMemory };

--- a/libs/bublik/features/log/src/lib/hooks/index.ts
+++ b/libs/bublik/features/log/src/lib/hooks/index.ts
@@ -6,6 +6,8 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import { toast } from '@/shared/tailwind-ui';
 import { LogPageParams } from '@/shared/types';
 
+export { useAllPagesMemory } from './all-pages-memory';
+
 const EXPERIMENTAL_KEY = 'experimental';
 const LEGACY_KEY = 'legacy';
 const FOCUS_ID_KEY = 'focusId';

--- a/libs/bublik/features/run-report/src/lib/run-report-navigation.utils.spec.ts
+++ b/libs/bublik/features/run-report/src/lib/run-report-navigation.utils.spec.ts
@@ -5,7 +5,9 @@ import { TestBlock } from '@/shared/types';
 import {
 	getArgsValNavigationTarget,
 	getCurrentArgsValNavigationItem,
-	getVisibleArgsValNavigationItems
+	getReportRecordRenderCount,
+	getVisibleArgsValNavigationItems,
+	scrollToReportItem
 } from './run-report-navigation.utils';
 
 function createTestBlock(
@@ -30,6 +32,43 @@ function createTestBlock(
 }
 
 describe('run report arg-val navigation', () => {
+	it('scrolls to a report anchor containing an encoded colon', () => {
+		const scroller = document.createElement('div');
+		const offsetContainer = document.createElement('div');
+		const target = document.createElement('div');
+		const scrollTo = vi.fn();
+
+		scroller.id = 'page-container';
+		scroller.scrollTop = 100;
+		scroller.scrollTo = scrollTo;
+		scroller.getBoundingClientRect = vi.fn(() => ({ top: 50 } as DOMRect));
+		offsetContainer.dataset.offset = '20';
+		target.id = encodeURIComponent('memcached_requests_per_connection:1');
+		target.getBoundingClientRect = vi.fn(() => ({ top: 250 } as DOMRect));
+		offsetContainer.append(target);
+		document.body.append(scroller, offsetContainer);
+
+		expect(scrollToReportItem('memcached_requests_per_connection:1')).toBe(
+			true
+		);
+		expect(scrollToReportItem('memcached_requests_per_connection:1')).toBe(
+			true
+		);
+		expect(scrollTo).toHaveBeenCalledTimes(2);
+		expect(scrollTo).toHaveBeenLastCalledWith({
+			top: 280,
+			behavior: 'smooth'
+		});
+
+		scroller.remove();
+		offsetContainer.remove();
+	});
+
+	it('renders every record shell while navigating to an anchor', () => {
+		expect(getReportRecordRenderCount(10, 24, true)).toBe(24);
+		expect(getReportRecordRenderCount(10, 24, false)).toBe(10);
+	});
+
 	it('returns visible arg-val blocks in report order', () => {
 		const items = getVisibleArgsValNavigationItems([
 			createTestBlock('test-1', [

--- a/libs/bublik/features/run-report/src/lib/run-report-navigation.utils.ts
+++ b/libs/bublik/features/run-report/src/lib/run-report-navigation.utils.ts
@@ -11,6 +11,32 @@ interface ArgValNavigationItem {
 	label: string;
 }
 
+function scrollToReportItem(id: string): boolean {
+	const element = document.getElementById(encodeURIComponent(id));
+	const scroller = document.getElementById('page-container');
+
+	if (!scroller || !element) return false;
+
+	const offsetElement = element.closest<HTMLElement>('[data-offset]');
+	const offset = Number(offsetElement?.dataset.offset || 0);
+	const elementRect = element.getBoundingClientRect();
+	const scrollerRect = scroller.getBoundingClientRect();
+	const relativeTop = elementRect.top - scrollerRect.top;
+	const targetScroll = scroller.scrollTop + relativeTop - offset;
+
+	scroller.scrollTo({ top: targetScroll, behavior: 'smooth' });
+
+	return true;
+}
+
+function getReportRecordRenderCount(
+	progressiveCount: number,
+	totalCount: number,
+	hasAnchor: boolean
+): number {
+	return hasAnchor ? totalCount : progressiveCount;
+}
+
 function getVisibleArgsValNavigationItems(
 	blocks: TestBlock[]
 ): ArgValNavigationItem[] {
@@ -72,8 +98,10 @@ function getCurrentArgsValNavigationItem(
 
 export {
 	RUN_REPORT_TABLE_OF_CONTENTS_ID,
+	getReportRecordRenderCount,
 	getArgsValNavigationTarget,
 	getCurrentArgsValNavigationItem,
-	getVisibleArgsValNavigationItems
+	getVisibleArgsValNavigationItems,
+	scrollToReportItem
 };
 export type { ArgValNavigationDirection, ArgValNavigationItem };

--- a/libs/bublik/features/run-report/src/lib/run-report-test/run-report-test.component.tsx
+++ b/libs/bublik/features/run-report/src/lib/run-report-test/run-report-test.component.tsx
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2024 OKTET LTD */
 import { useState, useCallback, useRef, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 
 import { ArgsValBlock, RecordBlock } from '@/shared/types';
 import {
@@ -27,7 +27,10 @@ import { RunReportTable } from '../run-report-table';
 import { RunReportArgs } from '../run-report-args';
 import { WarningsHoverCard } from '../run-report-warnings';
 import { useDelegatedTableWheelScroll } from './run-report-test.hooks';
-import { getArgsValNavigationTarget } from '../run-report-navigation.utils';
+import {
+	getArgsValNavigationTarget,
+	getReportRecordRenderCount
+} from '../run-report-navigation.utils';
 import type { ArgValNavigationItem } from '../run-report-navigation.utils';
 
 const INITIAL_RECORDS_RENDER_COUNT = 10;
@@ -256,12 +259,18 @@ function MeasurementRecordList(props: MeasurementRecordListProps) {
 	const { records, enableChartView, enableTableView, offset, pageContainer } =
 		props;
 	const { enablePairGainColumns } = props;
-	const visibleCount = useProgressiveVisibleCount({
+	const { hash } = useLocation();
+	const progressiveVisibleCount = useProgressiveVisibleCount({
 		totalCount: records.length,
 		initialCount: INITIAL_RECORDS_RENDER_COUNT,
 		chunkSize: RECORDS_RENDER_CHUNK_SIZE,
 		idleTimeoutMs: 180
 	});
+	const visibleCount = getReportRecordRenderCount(
+		progressiveVisibleCount,
+		records.length,
+		Boolean(hash)
+	);
 
 	const visibleRecords = useMemo(
 		() => records.slice(0, visibleCount),

--- a/libs/bublik/features/run-report/src/lib/run-report.component.tsx
+++ b/libs/bublik/features/run-report/src/lib/run-report.component.tsx
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2024 OKTET LTD */
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { BooleanParam, useQueryParam, withDefault } from 'use-query-params';
 import {
@@ -32,7 +32,7 @@ import {
 } from '@/shared/types';
 import { LinkWithProject } from '@/bublik/features/projects';
 import { BublikEmptyState, BublikErrorState } from '@/bublik/features/ui-state';
-import { useMount, usePhysicalHotkeys } from '@/shared/hooks';
+import { usePhysicalHotkeys } from '@/shared/hooks';
 
 import { RunReportHeader } from './run-report-header';
 import { RunReportTestBlock } from './run-report-test';
@@ -42,28 +42,10 @@ import {
 	RUN_REPORT_TABLE_OF_CONTENTS_ID,
 	getArgsValNavigationTarget,
 	getCurrentArgsValNavigationItem,
-	getVisibleArgsValNavigationItems
+	getVisibleArgsValNavigationItems,
+	scrollToReportItem
 } from './run-report-navigation.utils';
 import type { ArgValNavigationItem } from './run-report-navigation.utils';
-
-function scrollToItem(id: string) {
-	const elem = document.getElementById(encodeURIComponent(id));
-	const scroller = document.getElementById('page-container');
-	const offset = Number(elem?.dataset.offset || 0);
-
-	if (!scroller || !elem) {
-		console.warn('Element or scroller not found', scroller, elem);
-		return;
-	}
-
-	const elemRect = elem.getBoundingClientRect();
-	const scrollerRect = scroller.getBoundingClientRect();
-
-	const relativeTop = elemRect.top - scrollerRect.top;
-	const targetScroll = scroller.scrollTop + relativeTop - offset;
-
-	scroller.scrollTo({ top: targetScroll, behavior: 'smooth' });
-}
 
 interface UseArgValBlockKeyboardNavigationConfig {
 	items: ArgValNavigationItem[];
@@ -250,7 +232,7 @@ function TableOfContentsItem({ item, depth = 0 }: TableOfContentsItemProps) {
 								? 'font-semibold'
 								: 'font-medium'
 						)}
-						onClick={() => scrollToItem(item.id)}
+						onClick={() => scrollToReportItem(item.id)}
 					>
 						{item.label}
 					</LinkWithProject>
@@ -308,7 +290,7 @@ function RunReport(props: RunReportProps) {
 	);
 	const navigateToArgValBlock = useCallback(
 		(id: string) => {
-			scrollToItem(id);
+			scrollToReportItem(id);
 			navigate({
 				search: searchParams.toString(),
 				hash: encodeURIComponent(id)
@@ -317,7 +299,7 @@ function RunReport(props: RunReportProps) {
 		[navigate, searchParams]
 	);
 	const navigateToTableOfContents = useCallback(() => {
-		scrollToItem(RUN_REPORT_TABLE_OF_CONTENTS_ID);
+		scrollToReportItem(RUN_REPORT_TABLE_OF_CONTENTS_ID);
 		navigate({
 			search: searchParams.toString(),
 			hash: RUN_REPORT_TABLE_OF_CONTENTS_ID
@@ -338,12 +320,16 @@ function RunReport(props: RunReportProps) {
 		onPairGainColumnsToggle: togglePairGainColumns
 	});
 
-	useMount(() => {
-		setTimeout(() => {
+	useEffect(() => {
+		if (!location.hash) return;
+
+		const animationFrame = requestAnimationFrame(() => {
 			const id = decodeURIComponent(location.hash.slice(1));
-			scrollToItem(id);
-		}, 0);
-	});
+			scrollToReportItem(id);
+		});
+
+		return () => cancelAnimationFrame(animationFrame);
+	}, [location.hash]);
 
 	return (
 		<div className="flex flex-col gap-1 relative">

--- a/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/log-table.component.spec.tsx
+++ b/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/log-table.component.spec.tsx
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2026 OKTET LTD */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { LogPagination } from './log-table.component';
+
+describe('LogPagination', () => {
+	test('provides a page-one fallback when all-pages count is unavailable', () => {
+		const onPageClick = vi.fn();
+
+		render(
+			<LogPagination
+				id="log-block"
+				pageIndex={-1}
+				totalCount={0}
+				onPageClick={onPageClick}
+			/>
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Page 1' }));
+
+		expect(onPageClick).toHaveBeenCalledWith('log-block', 1);
+		expect(screen.getByRole('button', { name: 'All pages' })).toBeTruthy();
+	});
+
+	test('does not highlight a numbered page in all-pages mode', () => {
+		render(
+			<LogPagination
+				id="log-block"
+				pageIndex={-1}
+				totalCount={3}
+				pageSize={1}
+				currentPage={1}
+				disablePageSizeSelect
+			/>
+		);
+
+		expect(
+			screen.getByRole('button', { name: '1' }).getAttribute('aria-current')
+		).toBeNull();
+		expect(
+			screen
+				.getByRole('button', { name: 'All pages' })
+				.getAttribute('aria-pressed')
+		).toBe('true');
+	});
+});

--- a/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/log-table.component.tsx
+++ b/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/log-table.component.tsx
@@ -72,6 +72,7 @@ export const BlockLogTable = (props: LogTableBlock & { id: string }) => {
 	const { pagination, totalCount } = useLogTablePagination({
 		context: paginationContext
 	});
+	const hasPagination = Boolean(paginationContext?.pagination);
 
 	const table = useReactTable<LogTableData>({
 		pageCount: totalCount,
@@ -137,7 +138,7 @@ export const BlockLogTable = (props: LogTableBlock & { id: string }) => {
 						Logs
 					</h2>
 					<LogTableToolbar {...toolbarProps} />
-					{pagination && totalCount ? (
+					{hasPagination ? (
 						<LogPagination
 							id={id}
 							pageIndex={paginationContext?.pagination?.state.pageIndex}
@@ -199,7 +200,7 @@ export const BlockLogTable = (props: LogTableBlock & { id: string }) => {
 							</tbody>
 						</table>
 					</div>
-					{pagination && totalCount ? (
+					{hasPagination ? (
 						<LogPagination
 							id={id}
 							pageIndex={paginationContext?.pagination?.state.pageIndex}
@@ -266,16 +267,32 @@ interface LogPaginationProps extends ComponentProps<typeof Pagination> {
 	onPageClick?: (id: string, page: number) => void;
 }
 
-function LogPagination(props: LogPaginationProps) {
-	const { pageIndex, id, onPageClick, ...restProps } = props;
+export function LogPagination(props: LogPaginationProps) {
+	const { pageIndex, id, onPageClick, totalCount, ...restProps } = props;
+	const isAllPages = pageIndex === -1;
 
 	return (
 		<div className="flex justify-center gap-4 my-4">
-			<Pagination {...restProps} />
+			{totalCount > 0 ? (
+				<Pagination
+					{...restProps}
+					totalCount={totalCount}
+					showCurrentPage={!isAllPages}
+				/>
+			) : isAllPages ? (
+				<ButtonTw
+					size="md"
+					variant="outline"
+					onClick={() => onPageClick?.(id, 1)}
+				>
+					Page 1
+				</ButtonTw>
+			) : null}
 			<ButtonTw
 				size="md"
 				variant="outline"
-				state={pageIndex === -1 ? 'active' : 'default'}
+				state={isAllPages ? 'active' : 'default'}
+				aria-pressed={isAllPages}
 				onClick={() => onPageClick?.(id, 0)}
 			>
 				All pages

--- a/libs/bublik/features/sidebar/src/lib/use-sidebar-state-writer.spec.tsx
+++ b/libs/bublik/features/sidebar/src/lib/use-sidebar-state-writer.spec.tsx
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+import { useEffect } from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SHARED_SIDEBAR_KEYS } from './sidebar-state.constants';
+import { useSidebarStateWriter } from './use-sidebar-state-writer';
+
+const { navigateMock, locationState } = vi.hoisted(() => ({
+	navigateMock: vi.fn(),
+	locationState: { openUnexpected: true }
+}));
+
+vi.mock('react-router-dom', () => ({
+	useLocation: () => ({ state: locationState }),
+	useNavigate: () => navigateMock
+}));
+
+function HookRunner() {
+	const writeSidebarState = useSidebarStateWriter();
+
+	useEffect(() => {
+		writeSidebarState((sidebarState) => {
+			sidebarState[SHARED_SIDEBAR_KEYS.CURRENT_RUN_ID] = '42';
+		});
+	}, [writeSidebarState]);
+
+	return null;
+}
+
+describe('useSidebarStateWriter', () => {
+	beforeEach(() => {
+		navigateMock.mockClear();
+		window.history.replaceState(
+			null,
+			'',
+			'/v2/runs/42/report?config=7#memcached_requests_per_connection%3A1'
+		);
+	});
+
+	it('preserves the report hash without resubmitting the router basename', async () => {
+		render(<HookRunner />);
+
+		await waitFor(() => {
+			expect(navigateMock).toHaveBeenCalledWith(
+				{
+					search: expect.stringMatching(/(^|&)config=7(&|$)/),
+					hash: '#memcached_requests_per_connection%3A1'
+				},
+				{
+					replace: true,
+					state: locationState
+				}
+			);
+		});
+
+		const [{ search }] = navigateMock.mock.calls[0];
+		expect(new URLSearchParams(search).has('_s')).toBe(true);
+	});
+});

--- a/libs/bublik/features/sidebar/src/lib/use-sidebar-state-writer.ts
+++ b/libs/bublik/features/sidebar/src/lib/use-sidebar-state-writer.ts
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
 import { useCallback } from 'react';
-import { useLocation, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { updateSidebarStateSearchParams } from './sidebar-url.utils';
 
@@ -22,7 +22,7 @@ type SidebarStateUpdater = Parameters<typeof updateSidebarStateSearchParams>[1];
 export function useSidebarStateWriter(): (
 	updater: SidebarStateUpdater
 ) => void {
-	const [, setSearchParams] = useSearchParams();
+	const navigate = useNavigate();
 	const location = useLocation();
 
 	return useCallback(
@@ -37,11 +37,17 @@ export function useSidebarStateWriter(): (
 				return;
 			}
 
-			setSearchParams(newParams, {
-				replace: true,
-				state: location.state
-			});
+			navigate(
+				{
+					search: newParams.toString(),
+					hash: window.location.hash
+				},
+				{
+					replace: true,
+					state: location.state
+				}
+			);
 		},
-		[location.state, setSearchParams]
+		[location.state, navigate]
 	);
 }

--- a/libs/bublik/features/user-preferences/src/lib/user-preferences-form/log-preferences-form.component.tsx
+++ b/libs/bublik/features/user-preferences/src/lib/user-preferences-form/log-preferences-form.component.tsx
@@ -16,7 +16,7 @@ function LogPreferencesForm() {
 	});
 
 	return (
-		<div className="max-w-md">
+		<div className="max-w-md space-y-4">
 			<Controller
 				name="log.preferLegacyLog"
 				control={control}
@@ -43,6 +43,40 @@ function LogPreferencesForm() {
 						</div>
 						<p className="text-xs text-text-menu ml-8">
 							Make legacy logs your default choice
+						</p>
+					</div>
+				)}
+			></Controller>
+			<Controller
+				name="log.rememberAllPages"
+				control={control}
+				render={({ field }) => (
+					<div>
+						<div className="flex items-center">
+							<Checkbox
+								id="remember-all-log-pages"
+								checked={field.value}
+								onCheckedChange={(checked) => {
+									field.onChange(checked);
+									setUserPreferences({
+										...userPreferences,
+										log: {
+											...userPreferences.log,
+											rememberAllPages: checked === true
+										}
+									});
+								}}
+							/>
+							<label
+								htmlFor="remember-all-log-pages"
+								className="pl-2 text-sm font-normal"
+							>
+								Remember "All pages" for 24 hours
+							</label>
+						</div>
+						<p className="text-xs text-text-menu ml-8">
+							Reopen each test or package in "All pages" mode within the same
+							run
 						</p>
 					</div>
 				)}

--- a/libs/bublik/features/user-preferences/src/lib/user-preferences-form/user-preference.types.spec.ts
+++ b/libs/bublik/features/user-preferences/src/lib/user-preferences-form/user-preference.types.spec.ts
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2026 OKTET LTD */
+import { describe, expect, it } from 'vitest';
+
+import {
+	USER_PREFERENCES_DEFAULTS,
+	UserPreferencesSchema
+} from './user-preference.types';
+
+describe('UserPreferencesSchema', () => {
+	it('remembers all log pages by default', () => {
+		expect(USER_PREFERENCES_DEFAULTS.log.rememberAllPages).toBe(true);
+	});
+
+	it('adds the default to existing log preferences', () => {
+		const preferences = UserPreferencesSchema.parse({
+			log: { preferLegacyLog: true }
+		});
+
+		expect(preferences.log).toEqual({
+			preferLegacyLog: true,
+			rememberAllPages: true
+		});
+	});
+});

--- a/libs/bublik/features/user-preferences/src/lib/user-preferences-form/user-preference.types.ts
+++ b/libs/bublik/features/user-preferences/src/lib/user-preferences-form/user-preference.types.ts
@@ -12,20 +12,23 @@ export const UserPreferencesSchema = z
 			})
 			.default({ defaultMode: 'linear' }),
 		log: z
-			.object({ preferLegacyLog: z.boolean().default(false) })
-			.default({ preferLegacyLog: false }),
+			.object({
+				preferLegacyLog: z.boolean().default(false),
+				rememberAllPages: z.boolean().default(true)
+			})
+			.default({ preferLegacyLog: false, rememberAllPages: true }),
 		runs: z
 			.object({ autoApplyBadgeFilters: z.boolean().default(true) })
 			.default({ autoApplyBadgeFilters: true })
 	})
 	.default({
 		history: { defaultMode: 'linear' },
-		log: { preferLegacyLog: false },
+		log: { preferLegacyLog: false, rememberAllPages: true },
 		runs: { autoApplyBadgeFilters: true }
 	})
 	.catch({
 		history: { defaultMode: 'linear' },
-		log: { preferLegacyLog: false },
+		log: { preferLegacyLog: false, rememberAllPages: true },
 		runs: { autoApplyBadgeFilters: true }
 	});
 

--- a/libs/services/bublik-api/src/lib/endpoints/log-endpoint.spec.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/log-endpoint.spec.ts
@@ -1,7 +1,33 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import type { BaseQueryApi } from '@reduxjs/toolkit/query';
 import { describe, expect } from 'vitest';
-import { constructJsonUrl, normalizeLogJsonInput } from './log-endpoints';
+
+import type { GetLogJsonInputs, RootBlock } from '@/shared/types';
+
+import {
+	constructJsonUrl,
+	fixPagesCountForAllView,
+	normalizeLogJsonInput
+} from './log-endpoints';
+
+const createLogBlocks = (curPage: number, pagesCount: number): RootBlock => ({
+	version: 'v1',
+	root: [
+		{
+			type: 'te-log',
+			pagination: { cur_page: curPage, pages_count: pagesCount },
+			content: []
+		}
+	]
+});
+
+const createApi = (
+	queries: Record<string, { originalArgs?: GetLogJsonInputs; data?: RootBlock }>
+): BaseQueryApi =>
+	({
+		getState: () => ({ bublikApi: { queries } })
+	} as unknown as BaseQueryApi);
 
 describe('constructJsonUrl', () => {
 	test('it constructs the correct URL without page', () => {
@@ -23,6 +49,12 @@ describe('constructJsonUrl', () => {
 
 		expect(resultWithNullPage).toBe(resultWithoutPage);
 	});
+
+	test('it constructs the all-pages URL for numeric page zero', () => {
+		expect(constructJsonUrl({ id: '1', page: 0 })).toBe(
+			'/api/v2/logs/1/json/?page=0'
+		);
+	});
 });
 
 describe('normalizeLogJsonInput', () => {
@@ -35,5 +67,36 @@ describe('normalizeLogJsonInput', () => {
 			id: '1',
 			page: 2
 		});
+	});
+});
+
+describe('fixPagesCountForAllView', () => {
+	test('uses the cached canonical first page count', () => {
+		const allPages = createLogBlocks(0, 0);
+		const api = createApi({
+			'getLogJson({"id":"1"})': {
+				originalArgs: { id: '1' },
+				data: createLogBlocks(1, 12)
+			}
+		});
+
+		const result = fixPagesCountForAllView(allPages, 1, api);
+
+		expect(result.root[0].pagination?.pages_count).toBe(12);
+		expect(allPages.root[0].pagination?.pages_count).toBe(0);
+	});
+
+	test('does not use another all-pages cache entry', () => {
+		const allPages = createLogBlocks(0, 0);
+		const api = createApi({
+			'getLogJson({"id":"1","page":"0"})': {
+				originalArgs: { id: '1', page: '0' },
+				data: createLogBlocks(0, 12)
+			}
+		});
+
+		const result = fixPagesCountForAllView(allPages, 1, api);
+
+		expect(result.root[0].pagination?.pages_count).toBe(0);
 	});
 });

--- a/libs/services/bublik-api/src/lib/endpoints/log-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/log-endpoints.ts
@@ -137,13 +137,9 @@ export const normalizeLogJsonInput = (
 export const constructJsonUrl = (input: GetLogJsonInputs): string => {
 	const PREFIX = '/api/v2';
 
-	if (!input.page) return `${PREFIX}/logs/${input.id}/json/`;
+	if (input.page == null) return `${PREFIX}/logs/${input.id}/json/`;
 
-	let result = `${PREFIX}/logs/${input.id}/json`;
-
-	if (input.page) result += `/?page=${input.page}`;
-
-	return result;
+	return `${PREFIX}/logs/${input.id}/json/?page=${input.page}`;
 };
 
 const fetchJson = async <T = unknown>(
@@ -325,7 +321,7 @@ function addArtifactsVerdicts(
 	});
 }
 
-function fixPagesCountForAllView(
+export function fixPagesCountForAllView(
 	logBlocks: RootBlock,
 	id: string | number | null | undefined,
 	api: BaseQueryApi
@@ -355,10 +351,10 @@ function fixPagesCountForAllView(
 		const cached = queries[key];
 		if (String(cached?.originalArgs?.id) !== String(id)) continue;
 
-		// Skip page=0 entries (they also have pages_count=0)
-		// Skip page=null/undefined (all pages view)
+		// Only page=0 is the all-pages view. An omitted page is the canonical
+		// first page and can provide the page count.
 		const cachedPage = cached.originalArgs?.page;
-		if (cachedPage == null || cachedPage === 0 || cachedPage === '0') continue;
+		if (cachedPage === 0 || cachedPage === '0') continue;
 
 		const cachedTeLog = cached.data?.root.find((b) => b.type === 'te-log');
 		if (

--- a/libs/shared/tailwind-ui/src/lib/pagination/pagination.spec.tsx
+++ b/libs/shared/tailwind-ui/src/lib/pagination/pagination.spec.tsx
@@ -12,4 +12,19 @@ describe('components/Pagination', () => {
 		const badge = getByTestId('tw-pagination');
 		expect(badge).toBeVisible();
 	});
+
+	it('can render navigation without an active numbered page', () => {
+		const { getByRole } = render(
+			<Pagination
+				totalCount={3}
+				pageSize={1}
+				currentPage={1}
+				showCurrentPage={false}
+			/>
+		);
+
+		expect(getByRole('button', { name: '1' })).not.toHaveAttribute(
+			'aria-current'
+		);
+	});
 });

--- a/libs/shared/tailwind-ui/src/lib/pagination/pagination.tsx
+++ b/libs/shared/tailwind-ui/src/lib/pagination/pagination.tsx
@@ -82,6 +82,7 @@ export interface PaginationRangeProps {
 	variant?: VariantProps<typeof buttonStyles>['variant'];
 	range: (string | number)[];
 	currentPage: number;
+	showCurrentPage: boolean;
 	siblingCount: number;
 	handlePageIndexClick: (page: number) => void;
 	handleDotsClick: (page: number) => void;
@@ -91,6 +92,7 @@ const PaginationRange = ({
 	variant,
 	range,
 	currentPage,
+	showCurrentPage,
 	siblingCount,
 	handleDotsClick,
 	handlePageIndexClick
@@ -128,12 +130,15 @@ const PaginationRange = ({
 					);
 				}
 
+				const isActive = showCurrentPage && currentPage === pageNumber;
+
 				return (
 					<PageButton
 						key={pageNumber}
 						variant={variant}
 						onClick={() => handlePageIndexClick(pageNumber as number)}
-						isActive={currentPage === pageNumber}
+						isActive={isActive}
+						aria-current={isActive ? 'page' : undefined}
 					>
 						{pageNumber}
 					</PageButton>
@@ -167,6 +172,7 @@ export interface PaginationProps extends ComponentPropsWithoutRef<'div'> {
 	totalCount: number;
 	pageSize?: number;
 	currentPage?: number;
+	showCurrentPage?: boolean;
 	siblingCount?: number;
 	onPageChange?: (newPageIndex: number) => void;
 	onPageSizeChange?: (newPageSize: number) => void;
@@ -179,6 +185,7 @@ export const Pagination = (props: PaginationProps) => {
 		totalCount,
 		pageSize = 25,
 		currentPage = 1,
+		showCurrentPage = true,
 		siblingCount = 1,
 		onPageChange,
 		onPageSizeChange,
@@ -233,6 +240,7 @@ export const Pagination = (props: PaginationProps) => {
 				variant={variant}
 				range={paginationRange}
 				currentPage={currentPage}
+				showCurrentPage={showCurrentPage}
 				siblingCount={siblingCount}
 				handleDotsClick={handleDotsClick}
 				handlePageIndexClick={handlePageIndexClick}


### PR DESCRIPTION
## Summary

Fix report deep links that opened at the top of the page instead of scrolling to the selected graph group.

## Root Cause

- Updating the compressed sidebar state parameter (`_s`) replaced the query string and discarded the current URL hash.
- Report hash navigation ran only once during mounting.
- Progressive rendering initially excluded graph groups beyond the first 10 records, so deep-link targets could be missing from the DOM.

## Changes

- Preserve the current pathname and hash when updating `_s`.
- React to hash changes and scroll to the corresponding report section.
- Render all record shells when navigating to an anchor while keeping heavy chart content lazy-loaded.
- Add regression coverage for encoded anchor IDs, deep records, and hash preservation.

