### PR TITLE
feat(log): remember all-pages selection

### DIFF
--- a/libs/bublik/features/log/src/lib/containers/log-container/log-container.tsx
+++ b/libs/bublik/features/log/src/lib/containers/log-container/log-container.tsx
@@ -6,7 +6,8 @@ import { analyticsEventNames, trackEvent } from '@/bublik/features/analytics';
 import {
 	useGetLogJsonQuery,
 	useGetLogUrlByResultIdQuery,
-	useGetRunDetailsQuery
+	useGetRunDetailsQuery,
+	useGetTreeByRunIdQuery
 } from '@/services/bublik-api';
 import {
 	LogTableContext,
@@ -19,7 +20,7 @@ import { cn, RunRunning } from '@/shared/tailwind-ui';
 import { BublikEmptyState, BublikErrorState } from '@/bublik/features/ui-state';
 import { RUN_STATUS } from '@/shared/types';
 
-import { useIsLogLegacy, useLogPage } from '../../hooks';
+import { useAllPagesMemory, useIsLogLegacy, useLogPage } from '../../hooks';
 
 const highlightRow = (el: HTMLElement) => {
 	el.classList.add('animate-highlight-row');
@@ -58,6 +59,20 @@ export function LogPickerContainer() {
 		page,
 		setPage
 	} = useLogPage();
+	const { data: details } = useGetRunDetailsQuery(runId ?? skipToken);
+	const { data: treeData } = useGetTreeByRunIdQuery(runId ?? skipToken);
+	const { isRemembered, remember, forget } = useAllPagesMemory();
+	const focusedNode = focusId ? treeData?.tree[focusId] : undefined;
+	const allPagesIdentity =
+		details && focusedNode?.path
+			? {
+					projectId: details.project_id,
+					runId: details.id,
+					path: focusedNode.path
+			  }
+			: null;
+	const effectivePage =
+		page ?? (allPagesIdentity && isRemembered(allPagesIdentity) ? '0' : null);
 
 	if (!runId) {
 		return <BublikEmptyState title="No data" description="Run ID is missing" />;
@@ -67,6 +82,14 @@ export function LogPickerContainer() {
 		trackEvent(analyticsEventNames.logPageChange, {
 			page
 		});
+
+		if (allPagesIdentity) {
+			if (page === 0) {
+				remember(allPagesIdentity);
+			} else {
+				forget(allPagesIdentity);
+			}
+		}
 
 		setPage(page);
 	};
@@ -123,7 +146,7 @@ export function LogPickerContainer() {
 			<JsonLog
 				runId={runId}
 				focusId={focusId}
-				page={page}
+				page={effectivePage}
 				isShowingRunLog={isShowingRunLog}
 			/>
 		</LogTableContextProvider>

--- a/libs/bublik/features/log/src/lib/containers/log-tree/tree-view/tree-view.tsx
+++ b/libs/bublik/features/log/src/lib/containers/log-tree/tree-view/tree-view.tsx
@@ -8,7 +8,6 @@ import {
 	useImperativeHandle,
 	useRef
 } from 'react';
-import { useSearchParams } from 'react-router-dom';
 import {
 	FixedSizeNodeData,
 	FixedSizeTree,
@@ -26,6 +25,7 @@ import {
 } from '@/shared/hooks';
 import { NodeData } from '@/shared/types';
 
+import { useLogPage } from '../../../hooks';
 import { Node } from '../tree-node';
 
 export type TreeNode = Readonly<NodeData>;
@@ -85,7 +85,7 @@ export const TreeView: FC<TreeViewProps> = forwardRef<
 	} = props;
 
 	const treeRef = useRef<FixedSizeTree<TreeData>>(null);
-	const [, setSearchParams] = useSearchParams();
+	const { setFocusId } = useLogPage();
 
 	const treeWalker = useCallback(
 		function* treeWalkerFn(): ReturnType<TreeWalker<TreeData, NodeMeta>> {
@@ -393,18 +393,13 @@ export const TreeView: FC<TreeViewProps> = forwardRef<
 			});
 		}
 
-		if (tree[currentScrollId.current].entity !== 'suite') {
-			setSearchParams((params) => {
-				if (params.get('focusId') !== currentScrollId.current) {
-					params.delete('lineNumber');
-				}
-
-				params.set('focusId', currentScrollId.current);
-
-				return params;
-			});
+		if (
+			tree[currentScrollId.current].entity !== 'suite' &&
+			focusId !== currentScrollId.current
+		) {
+			setFocusId(currentScrollId.current);
 		}
-	}, [main_package, setSearchParams, tree]);
+	}, [focusId, main_package, setFocusId, tree]);
 
 	usePhysicalHotkeys(
 		[

--- a/libs/bublik/features/log/src/lib/hooks/all-pages-memory.spec.ts
+++ b/libs/bublik/features/log/src/lib/hooks/all-pages-memory.spec.ts
@@ -1,0 +1,71 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2026 OKTET LTD */
+import { describe, expect, it } from 'vitest';
+
+import {
+	ALL_PAGES_MEMORY_TTL,
+	getAllPagesMemoryKey,
+	isAllPagesRemembered,
+	updateAllPagesMemory,
+	type AllPagesIdentity
+} from './all-pages-memory';
+
+const NOW = Date.parse('2026-07-29T10:00:00.000Z');
+const IDENTITY: AllPagesIdentity = {
+	projectId: 10,
+	runId: 20,
+	path: 'package/session/test'
+};
+
+describe('all pages memory', () => {
+	it('isolates entries by project, run, and node path', () => {
+		const key = getAllPagesMemoryKey(IDENTITY);
+
+		expect(
+			getAllPagesMemoryKey({ ...IDENTITY, projectId: IDENTITY.projectId + 1 })
+		).not.toBe(key);
+		expect(
+			getAllPagesMemoryKey({ ...IDENTITY, runId: Number(IDENTITY.runId) + 1 })
+		).not.toBe(key);
+		expect(
+			getAllPagesMemoryKey({ ...IDENTITY, path: 'other/session/test' })
+		).not.toBe(key);
+	});
+
+	it('remembers an entry for 24 hours', () => {
+		const memory = updateAllPagesMemory({}, IDENTITY, true, NOW);
+
+		expect(isAllPagesRemembered(memory, IDENTITY, NOW)).toBe(true);
+		expect(
+			isAllPagesRemembered(memory, IDENTITY, NOW + ALL_PAGES_MEMORY_TTL - 1)
+		).toBe(true);
+		expect(
+			isAllPagesRemembered(memory, IDENTITY, NOW + ALL_PAGES_MEMORY_TTL)
+		).toBe(false);
+	});
+
+	it('forgets an entry when a specific page is selected', () => {
+		const remembered = updateAllPagesMemory({}, IDENTITY, true, NOW);
+		const forgotten = updateAllPagesMemory(
+			remembered,
+			IDENTITY,
+			false,
+			NOW + 1
+		);
+
+		expect(isAllPagesRemembered(forgotten, IDENTITY, NOW + 1)).toBe(false);
+	});
+
+	it('removes expired entries while updating memory', () => {
+		const expiredIdentity = { ...IDENTITY, path: 'package/session/expired' };
+		const expiredKey = getAllPagesMemoryKey(expiredIdentity);
+		const memory = updateAllPagesMemory(
+			{ [expiredKey]: NOW - 1 },
+			IDENTITY,
+			true,
+			NOW
+		);
+
+		expect(memory).not.toHaveProperty(expiredKey);
+	});
+});

--- a/libs/bublik/features/log/src/lib/hooks/all-pages-memory.ts
+++ b/libs/bublik/features/log/src/lib/hooks/all-pages-memory.ts
@@ -1,0 +1,102 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2026 OKTET LTD */
+import { z } from 'zod';
+
+import { useUserPreferences } from '@/bublik/features/user-preferences';
+import { useLocalStorage } from '@/shared/hooks';
+
+const ALL_PAGES_MEMORY_KEY = 'log-all-pages-memory';
+const ALL_PAGES_MEMORY_TTL = 24 * 60 * 60 * 1000;
+const EMPTY_ALL_PAGES_MEMORY: AllPagesMemory = {};
+const AllPagesMemorySchema = z.record(z.string(), z.number()).catch({});
+
+interface AllPagesIdentity {
+	projectId: number;
+	runId: string | number;
+	path: string;
+}
+
+type AllPagesMemory = Record<string, number>;
+
+function getAllPagesMemoryKey(identity: AllPagesIdentity): string {
+	return JSON.stringify([
+		identity.projectId,
+		identity.runId.toString(),
+		identity.path
+	]);
+}
+
+function isAllPagesRemembered(
+	memory: AllPagesMemory,
+	identity: AllPagesIdentity,
+	now = Date.now()
+): boolean {
+	return (memory[getAllPagesMemoryKey(identity)] ?? 0) > now;
+}
+
+function updateAllPagesMemory(
+	memory: AllPagesMemory,
+	identity: AllPagesIdentity,
+	remember: boolean,
+	now = Date.now()
+): AllPagesMemory {
+	const nextMemory = Object.fromEntries(
+		Object.entries(memory).filter(([, expiresAt]) => expiresAt > now)
+	);
+	const key = getAllPagesMemoryKey(identity);
+
+	if (remember) {
+		nextMemory[key] = now + ALL_PAGES_MEMORY_TTL;
+	} else {
+		delete nextMemory[key];
+	}
+
+	return nextMemory;
+}
+
+function useAllPagesMemory() {
+	const { userPreferences } = useUserPreferences();
+	const [storedMemory, setStoredMemory] = useLocalStorage<AllPagesMemory>(
+		ALL_PAGES_MEMORY_KEY,
+		EMPTY_ALL_PAGES_MEMORY
+	);
+	const memory = AllPagesMemorySchema.parse(storedMemory);
+	const isEnabled = userPreferences.log.rememberAllPages;
+
+	const isRemembered = (identity: AllPagesIdentity): boolean => {
+		return isEnabled && isAllPagesRemembered(memory, identity);
+	};
+
+	const remember = (identity: AllPagesIdentity): void => {
+		if (!isEnabled) return;
+
+		setStoredMemory((currentMemory) =>
+			updateAllPagesMemory(
+				AllPagesMemorySchema.parse(currentMemory),
+				identity,
+				true
+			)
+		);
+	};
+
+	const forget = (identity: AllPagesIdentity): void => {
+		setStoredMemory((currentMemory) =>
+			updateAllPagesMemory(
+				AllPagesMemorySchema.parse(currentMemory),
+				identity,
+				false
+			)
+		);
+	};
+
+	return { isRemembered, remember, forget } as const;
+}
+
+export {
+	ALL_PAGES_MEMORY_TTL,
+	getAllPagesMemoryKey,
+	isAllPagesRemembered,
+	updateAllPagesMemory,
+	useAllPagesMemory
+};
+export type { AllPagesIdentity, AllPagesMemory };

--- a/libs/bublik/features/log/src/lib/hooks/index.ts
+++ b/libs/bublik/features/log/src/lib/hooks/index.ts
@@ -6,6 +6,8 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import { toast } from '@/shared/tailwind-ui';
 import { LogPageParams } from '@/shared/types';
 
+export { useAllPagesMemory } from './all-pages-memory';
+
 const EXPERIMENTAL_KEY = 'experimental';
 const LEGACY_KEY = 'legacy';
 const FOCUS_ID_KEY = 'focusId';

--- a/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/log-table.component.spec.tsx
+++ b/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/log-table.component.spec.tsx
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2026 OKTET LTD */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { LogPagination } from './log-table.component';
+
+describe('LogPagination', () => {
+	test('provides a page-one fallback when all-pages count is unavailable', () => {
+		const onPageClick = vi.fn();
+
+		render(
+			<LogPagination
+				id="log-block"
+				pageIndex={-1}
+				totalCount={0}
+				onPageClick={onPageClick}
+			/>
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Page 1' }));
+
+		expect(onPageClick).toHaveBeenCalledWith('log-block', 1);
+		expect(screen.getByRole('button', { name: 'All pages' })).toBeTruthy();
+	});
+
+	test('does not highlight a numbered page in all-pages mode', () => {
+		render(
+			<LogPagination
+				id="log-block"
+				pageIndex={-1}
+				totalCount={3}
+				pageSize={1}
+				currentPage={1}
+				disablePageSizeSelect
+			/>
+		);
+
+		expect(
+			screen.getByRole('button', { name: '1' }).getAttribute('aria-current')
+		).toBeNull();
+		expect(
+			screen
+				.getByRole('button', { name: 'All pages' })
+				.getAttribute('aria-pressed')
+		).toBe('true');
+	});
+});

--- a/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/log-table.component.tsx
+++ b/libs/bublik/features/session-log/src/lib/v1/log-blocks/log-table/log-table.component.tsx
@@ -72,6 +72,7 @@ export const BlockLogTable = (props: LogTableBlock & { id: string }) => {
 	const { pagination, totalCount } = useLogTablePagination({
 		context: paginationContext
 	});
+	const hasPagination = Boolean(paginationContext?.pagination);
 
 	const table = useReactTable<LogTableData>({
 		pageCount: totalCount,
@@ -137,7 +138,7 @@ export const BlockLogTable = (props: LogTableBlock & { id: string }) => {
 						Logs
 					</h2>
 					<LogTableToolbar {...toolbarProps} />
-					{pagination && totalCount ? (
+					{hasPagination ? (
 						<LogPagination
 							id={id}
 							pageIndex={paginationContext?.pagination?.state.pageIndex}
@@ -199,7 +200,7 @@ export const BlockLogTable = (props: LogTableBlock & { id: string }) => {
 							</tbody>
 						</table>
 					</div>
-					{pagination && totalCount ? (
+					{hasPagination ? (
 						<LogPagination
 							id={id}
 							pageIndex={paginationContext?.pagination?.state.pageIndex}
@@ -266,16 +267,32 @@ interface LogPaginationProps extends ComponentProps<typeof Pagination> {
 	onPageClick?: (id: string, page: number) => void;
 }
 
-function LogPagination(props: LogPaginationProps) {
-	const { pageIndex, id, onPageClick, ...restProps } = props;
+export function LogPagination(props: LogPaginationProps) {
+	const { pageIndex, id, onPageClick, totalCount, ...restProps } = props;
+	const isAllPages = pageIndex === -1;
 
 	return (
 		<div className="flex justify-center gap-4 my-4">
-			<Pagination {...restProps} />
+			{totalCount > 0 ? (
+				<Pagination
+					{...restProps}
+					totalCount={totalCount}
+					showCurrentPage={!isAllPages}
+				/>
+			) : isAllPages ? (
+				<ButtonTw
+					size="md"
+					variant="outline"
+					onClick={() => onPageClick?.(id, 1)}
+				>
+					Page 1
+				</ButtonTw>
+			) : null}
 			<ButtonTw
 				size="md"
 				variant="outline"
-				state={pageIndex === -1 ? 'active' : 'default'}
+				state={isAllPages ? 'active' : 'default'}
+				aria-pressed={isAllPages}
 				onClick={() => onPageClick?.(id, 0)}
 			>
 				All pages

--- a/libs/bublik/features/user-preferences/src/lib/user-preferences-form/log-preferences-form.component.tsx
+++ b/libs/bublik/features/user-preferences/src/lib/user-preferences-form/log-preferences-form.component.tsx
@@ -16,7 +16,7 @@ function LogPreferencesForm() {
 	});
 
 	return (
-		<div className="max-w-md">
+		<div className="max-w-md space-y-4">
 			<Controller
 				name="log.preferLegacyLog"
 				control={control}
@@ -43,6 +43,40 @@ function LogPreferencesForm() {
 						</div>
 						<p className="text-xs text-text-menu ml-8">
 							Make legacy logs your default choice
+						</p>
+					</div>
+				)}
+			></Controller>
+			<Controller
+				name="log.rememberAllPages"
+				control={control}
+				render={({ field }) => (
+					<div>
+						<div className="flex items-center">
+							<Checkbox
+								id="remember-all-log-pages"
+								checked={field.value}
+								onCheckedChange={(checked) => {
+									field.onChange(checked);
+									setUserPreferences({
+										...userPreferences,
+										log: {
+											...userPreferences.log,
+											rememberAllPages: checked === true
+										}
+									});
+								}}
+							/>
+							<label
+								htmlFor="remember-all-log-pages"
+								className="pl-2 text-sm font-normal"
+							>
+								Remember "All pages" for 24 hours
+							</label>
+						</div>
+						<p className="text-xs text-text-menu ml-8">
+							Reopen each test or package in "All pages" mode within the same
+							run
 						</p>
 					</div>
 				)}

--- a/libs/bublik/features/user-preferences/src/lib/user-preferences-form/user-preference.types.spec.ts
+++ b/libs/bublik/features/user-preferences/src/lib/user-preferences-form/user-preference.types.spec.ts
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2026 OKTET LTD */
+import { describe, expect, it } from 'vitest';
+
+import {
+	USER_PREFERENCES_DEFAULTS,
+	UserPreferencesSchema
+} from './user-preference.types';
+
+describe('UserPreferencesSchema', () => {
+	it('remembers all log pages by default', () => {
+		expect(USER_PREFERENCES_DEFAULTS.log.rememberAllPages).toBe(true);
+	});
+
+	it('adds the default to existing log preferences', () => {
+		const preferences = UserPreferencesSchema.parse({
+			log: { preferLegacyLog: true }
+		});
+
+		expect(preferences.log).toEqual({
+			preferLegacyLog: true,
+			rememberAllPages: true
+		});
+	});
+});

--- a/libs/bublik/features/user-preferences/src/lib/user-preferences-form/user-preference.types.ts
+++ b/libs/bublik/features/user-preferences/src/lib/user-preferences-form/user-preference.types.ts
@@ -12,20 +12,23 @@ export const UserPreferencesSchema = z
 			})
 			.default({ defaultMode: 'linear' }),
 		log: z
-			.object({ preferLegacyLog: z.boolean().default(false) })
-			.default({ preferLegacyLog: false }),
+			.object({
+				preferLegacyLog: z.boolean().default(false),
+				rememberAllPages: z.boolean().default(true)
+			})
+			.default({ preferLegacyLog: false, rememberAllPages: true }),
 		runs: z
 			.object({ autoApplyBadgeFilters: z.boolean().default(true) })
 			.default({ autoApplyBadgeFilters: true })
 	})
 	.default({
 		history: { defaultMode: 'linear' },
-		log: { preferLegacyLog: false },
+		log: { preferLegacyLog: false, rememberAllPages: true },
 		runs: { autoApplyBadgeFilters: true }
 	})
 	.catch({
 		history: { defaultMode: 'linear' },
-		log: { preferLegacyLog: false },
+		log: { preferLegacyLog: false, rememberAllPages: true },
 		runs: { autoApplyBadgeFilters: true }
 	});
 

--- a/libs/services/bublik-api/src/lib/endpoints/log-endpoint.spec.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/log-endpoint.spec.ts
@@ -1,7 +1,33 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
+import type { BaseQueryApi } from '@reduxjs/toolkit/query';
 import { describe, expect } from 'vitest';
-import { constructJsonUrl, normalizeLogJsonInput } from './log-endpoints';
+
+import type { GetLogJsonInputs, RootBlock } from '@/shared/types';
+
+import {
+	constructJsonUrl,
+	fixPagesCountForAllView,
+	normalizeLogJsonInput
+} from './log-endpoints';
+
+const createLogBlocks = (curPage: number, pagesCount: number): RootBlock => ({
+	version: 'v1',
+	root: [
+		{
+			type: 'te-log',
+			pagination: { cur_page: curPage, pages_count: pagesCount },
+			content: []
+		}
+	]
+});
+
+const createApi = (
+	queries: Record<string, { originalArgs?: GetLogJsonInputs; data?: RootBlock }>
+): BaseQueryApi =>
+	({
+		getState: () => ({ bublikApi: { queries } })
+	} as unknown as BaseQueryApi);
 
 describe('constructJsonUrl', () => {
 	test('it constructs the correct URL without page', () => {
@@ -23,6 +49,12 @@ describe('constructJsonUrl', () => {
 
 		expect(resultWithNullPage).toBe(resultWithoutPage);
 	});
+
+	test('it constructs the all-pages URL for numeric page zero', () => {
+		expect(constructJsonUrl({ id: '1', page: 0 })).toBe(
+			'/api/v2/logs/1/json/?page=0'
+		);
+	});
 });
 
 describe('normalizeLogJsonInput', () => {
@@ -35,5 +67,36 @@ describe('normalizeLogJsonInput', () => {
 			id: '1',
 			page: 2
 		});
+	});
+});
+
+describe('fixPagesCountForAllView', () => {
+	test('uses the cached canonical first page count', () => {
+		const allPages = createLogBlocks(0, 0);
+		const api = createApi({
+			'getLogJson({"id":"1"})': {
+				originalArgs: { id: '1' },
+				data: createLogBlocks(1, 12)
+			}
+		});
+
+		const result = fixPagesCountForAllView(allPages, 1, api);
+
+		expect(result.root[0].pagination?.pages_count).toBe(12);
+		expect(allPages.root[0].pagination?.pages_count).toBe(0);
+	});
+
+	test('does not use another all-pages cache entry', () => {
+		const allPages = createLogBlocks(0, 0);
+		const api = createApi({
+			'getLogJson({"id":"1","page":"0"})': {
+				originalArgs: { id: '1', page: '0' },
+				data: createLogBlocks(0, 12)
+			}
+		});
+
+		const result = fixPagesCountForAllView(allPages, 1, api);
+
+		expect(result.root[0].pagination?.pages_count).toBe(0);
 	});
 });

--- a/libs/services/bublik-api/src/lib/endpoints/log-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/log-endpoints.ts
@@ -137,13 +137,9 @@ export const normalizeLogJsonInput = (
 export const constructJsonUrl = (input: GetLogJsonInputs): string => {
 	const PREFIX = '/api/v2';
 
-	if (!input.page) return `${PREFIX}/logs/${input.id}/json/`;
+	if (input.page == null) return `${PREFIX}/logs/${input.id}/json/`;
 
-	let result = `${PREFIX}/logs/${input.id}/json`;
-
-	if (input.page) result += `/?page=${input.page}`;
-
-	return result;
+	return `${PREFIX}/logs/${input.id}/json/?page=${input.page}`;
 };
 
 const fetchJson = async <T = unknown>(
@@ -325,7 +321,7 @@ function addArtifactsVerdicts(
 	});
 }
 
-function fixPagesCountForAllView(
+export function fixPagesCountForAllView(
 	logBlocks: RootBlock,
 	id: string | number | null | undefined,
 	api: BaseQueryApi
@@ -355,10 +351,10 @@ function fixPagesCountForAllView(
 		const cached = queries[key];
 		if (String(cached?.originalArgs?.id) !== String(id)) continue;
 
-		// Skip page=0 entries (they also have pages_count=0)
-		// Skip page=null/undefined (all pages view)
+		// Only page=0 is the all-pages view. An omitted page is the canonical
+		// first page and can provide the page count.
 		const cachedPage = cached.originalArgs?.page;
-		if (cachedPage == null || cachedPage === 0 || cachedPage === '0') continue;
+		if (cachedPage === 0 || cachedPage === '0') continue;
 
 		const cachedTeLog = cached.data?.root.find((b) => b.type === 'te-log');
 		if (

--- a/libs/shared/tailwind-ui/src/lib/pagination/pagination.spec.tsx
+++ b/libs/shared/tailwind-ui/src/lib/pagination/pagination.spec.tsx
@@ -12,4 +12,19 @@ describe('components/Pagination', () => {
 		const badge = getByTestId('tw-pagination');
 		expect(badge).toBeVisible();
 	});
+
+	it('can render navigation without an active numbered page', () => {
+		const { getByRole } = render(
+			<Pagination
+				totalCount={3}
+				pageSize={1}
+				currentPage={1}
+				showCurrentPage={false}
+			/>
+		);
+
+		expect(getByRole('button', { name: '1' })).not.toHaveAttribute(
+			'aria-current'
+		);
+	});
 });

--- a/libs/shared/tailwind-ui/src/lib/pagination/pagination.tsx
+++ b/libs/shared/tailwind-ui/src/lib/pagination/pagination.tsx
@@ -82,6 +82,7 @@ export interface PaginationRangeProps {
 	variant?: VariantProps<typeof buttonStyles>['variant'];
 	range: (string | number)[];
 	currentPage: number;
+	showCurrentPage: boolean;
 	siblingCount: number;
 	handlePageIndexClick: (page: number) => void;
 	handleDotsClick: (page: number) => void;
@@ -91,6 +92,7 @@ const PaginationRange = ({
 	variant,
 	range,
 	currentPage,
+	showCurrentPage,
 	siblingCount,
 	handleDotsClick,
 	handlePageIndexClick
@@ -128,12 +130,15 @@ const PaginationRange = ({
 					);
 				}
 
+				const isActive = showCurrentPage && currentPage === pageNumber;
+
 				return (
 					<PageButton
 						key={pageNumber}
 						variant={variant}
 						onClick={() => handlePageIndexClick(pageNumber as number)}
-						isActive={currentPage === pageNumber}
+						isActive={isActive}
+						aria-current={isActive ? 'page' : undefined}
 					>
 						{pageNumber}
 					</PageButton>
@@ -167,6 +172,7 @@ export interface PaginationProps extends ComponentPropsWithoutRef<'div'> {
 	totalCount: number;
 	pageSize?: number;
 	currentPage?: number;
+	showCurrentPage?: boolean;
 	siblingCount?: number;
 	onPageChange?: (newPageIndex: number) => void;
 	onPageSizeChange?: (newPageSize: number) => void;
@@ -179,6 +185,7 @@ export const Pagination = (props: PaginationProps) => {
 		totalCount,
 		pageSize = 25,
 		currentPage = 1,
+		showCurrentPage = true,
 		siblingCount = 1,
 		onPageChange,
 		onPageSizeChange,
@@ -233,6 +240,7 @@ export const Pagination = (props: PaginationProps) => {
 				variant={variant}
 				range={paginationRange}
 				currentPage={currentPage}
+				showCurrentPage={showCurrentPage}
 				siblingCount={siblingCount}
 				handleDotsClick={handleDotsClick}
 				handlePageIndexClick={handlePageIndexClick}


### PR DESCRIPTION
## Summary

- add a default-enabled setting to remember the "All pages" log mode
- remember the selection for 24 hours using project, run, and node path as identity
- restore "All pages" when returning to the same test or package
- clear remembered mode when a specific page is selected
- align keyboard and mouse test selection behavior

## Implementation

Remembered entries are stored separately from log data in local storage. Each entry uses the following semantic identity:

- project ID
- run ID
- full test or package path

Expired entries are removed when the memory is updated. Explicit page values in the URL take precedence over remembered state.
