### PR TITLE
fix(report): preserve deep-link anchors

### DIFF
--- a/libs/bublik/features/run-report/src/lib/run-report-navigation.utils.spec.ts
+++ b/libs/bublik/features/run-report/src/lib/run-report-navigation.utils.spec.ts
@@ -5,7 +5,9 @@ import { TestBlock } from '@/shared/types';
 import {
 	getArgsValNavigationTarget,
 	getCurrentArgsValNavigationItem,
-	getVisibleArgsValNavigationItems
+	getReportRecordRenderCount,
+	getVisibleArgsValNavigationItems,
+	scrollToReportItem
 } from './run-report-navigation.utils';
 
 function createTestBlock(
@@ -30,6 +32,43 @@ function createTestBlock(
 }
 
 describe('run report arg-val navigation', () => {
+	it('scrolls to a report anchor containing an encoded colon', () => {
+		const scroller = document.createElement('div');
+		const offsetContainer = document.createElement('div');
+		const target = document.createElement('div');
+		const scrollTo = vi.fn();
+
+		scroller.id = 'page-container';
+		scroller.scrollTop = 100;
+		scroller.scrollTo = scrollTo;
+		scroller.getBoundingClientRect = vi.fn(() => ({ top: 50 } as DOMRect));
+		offsetContainer.dataset.offset = '20';
+		target.id = encodeURIComponent('memcached_requests_per_connection:1');
+		target.getBoundingClientRect = vi.fn(() => ({ top: 250 } as DOMRect));
+		offsetContainer.append(target);
+		document.body.append(scroller, offsetContainer);
+
+		expect(scrollToReportItem('memcached_requests_per_connection:1')).toBe(
+			true
+		);
+		expect(scrollToReportItem('memcached_requests_per_connection:1')).toBe(
+			true
+		);
+		expect(scrollTo).toHaveBeenCalledTimes(2);
+		expect(scrollTo).toHaveBeenLastCalledWith({
+			top: 280,
+			behavior: 'smooth'
+		});
+
+		scroller.remove();
+		offsetContainer.remove();
+	});
+
+	it('renders every record shell while navigating to an anchor', () => {
+		expect(getReportRecordRenderCount(10, 24, true)).toBe(24);
+		expect(getReportRecordRenderCount(10, 24, false)).toBe(10);
+	});
+
 	it('returns visible arg-val blocks in report order', () => {
 		const items = getVisibleArgsValNavigationItems([
 			createTestBlock('test-1', [

--- a/libs/bublik/features/run-report/src/lib/run-report-navigation.utils.ts
+++ b/libs/bublik/features/run-report/src/lib/run-report-navigation.utils.ts
@@ -11,6 +11,32 @@ interface ArgValNavigationItem {
 	label: string;
 }
 
+function scrollToReportItem(id: string): boolean {
+	const element = document.getElementById(encodeURIComponent(id));
+	const scroller = document.getElementById('page-container');
+
+	if (!scroller || !element) return false;
+
+	const offsetElement = element.closest<HTMLElement>('[data-offset]');
+	const offset = Number(offsetElement?.dataset.offset || 0);
+	const elementRect = element.getBoundingClientRect();
+	const scrollerRect = scroller.getBoundingClientRect();
+	const relativeTop = elementRect.top - scrollerRect.top;
+	const targetScroll = scroller.scrollTop + relativeTop - offset;
+
+	scroller.scrollTo({ top: targetScroll, behavior: 'smooth' });
+
+	return true;
+}
+
+function getReportRecordRenderCount(
+	progressiveCount: number,
+	totalCount: number,
+	hasAnchor: boolean
+): number {
+	return hasAnchor ? totalCount : progressiveCount;
+}
+
 function getVisibleArgsValNavigationItems(
 	blocks: TestBlock[]
 ): ArgValNavigationItem[] {
@@ -72,8 +98,10 @@ function getCurrentArgsValNavigationItem(
 
 export {
 	RUN_REPORT_TABLE_OF_CONTENTS_ID,
+	getReportRecordRenderCount,
 	getArgsValNavigationTarget,
 	getCurrentArgsValNavigationItem,
-	getVisibleArgsValNavigationItems
+	getVisibleArgsValNavigationItems,
+	scrollToReportItem
 };
 export type { ArgValNavigationDirection, ArgValNavigationItem };

--- a/libs/bublik/features/run-report/src/lib/run-report-test/run-report-test.component.tsx
+++ b/libs/bublik/features/run-report/src/lib/run-report-test/run-report-test.component.tsx
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2024 OKTET LTD */
 import { useState, useCallback, useRef, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 
 import { ArgsValBlock, RecordBlock } from '@/shared/types';
 import {
@@ -27,7 +27,10 @@ import { RunReportTable } from '../run-report-table';
 import { RunReportArgs } from '../run-report-args';
 import { WarningsHoverCard } from '../run-report-warnings';
 import { useDelegatedTableWheelScroll } from './run-report-test.hooks';
-import { getArgsValNavigationTarget } from '../run-report-navigation.utils';
+import {
+	getArgsValNavigationTarget,
+	getReportRecordRenderCount
+} from '../run-report-navigation.utils';
 import type { ArgValNavigationItem } from '../run-report-navigation.utils';
 
 const INITIAL_RECORDS_RENDER_COUNT = 10;
@@ -256,12 +259,18 @@ function MeasurementRecordList(props: MeasurementRecordListProps) {
 	const { records, enableChartView, enableTableView, offset, pageContainer } =
 		props;
 	const { enablePairGainColumns } = props;
-	const visibleCount = useProgressiveVisibleCount({
+	const { hash } = useLocation();
+	const progressiveVisibleCount = useProgressiveVisibleCount({
 		totalCount: records.length,
 		initialCount: INITIAL_RECORDS_RENDER_COUNT,
 		chunkSize: RECORDS_RENDER_CHUNK_SIZE,
 		idleTimeoutMs: 180
 	});
+	const visibleCount = getReportRecordRenderCount(
+		progressiveVisibleCount,
+		records.length,
+		Boolean(hash)
+	);
 
 	const visibleRecords = useMemo(
 		() => records.slice(0, visibleCount),

--- a/libs/bublik/features/run-report/src/lib/run-report.component.tsx
+++ b/libs/bublik/features/run-report/src/lib/run-report.component.tsx
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2024 OKTET LTD */
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { BooleanParam, useQueryParam, withDefault } from 'use-query-params';
 import {
@@ -32,7 +32,7 @@ import {
 } from '@/shared/types';
 import { LinkWithProject } from '@/bublik/features/projects';
 import { BublikEmptyState, BublikErrorState } from '@/bublik/features/ui-state';
-import { useMount, usePhysicalHotkeys } from '@/shared/hooks';
+import { usePhysicalHotkeys } from '@/shared/hooks';
 
 import { RunReportHeader } from './run-report-header';
 import { RunReportTestBlock } from './run-report-test';
@@ -42,28 +42,10 @@ import {
 	RUN_REPORT_TABLE_OF_CONTENTS_ID,
 	getArgsValNavigationTarget,
 	getCurrentArgsValNavigationItem,
-	getVisibleArgsValNavigationItems
+	getVisibleArgsValNavigationItems,
+	scrollToReportItem
 } from './run-report-navigation.utils';
 import type { ArgValNavigationItem } from './run-report-navigation.utils';
-
-function scrollToItem(id: string) {
-	const elem = document.getElementById(encodeURIComponent(id));
-	const scroller = document.getElementById('page-container');
-	const offset = Number(elem?.dataset.offset || 0);
-
-	if (!scroller || !elem) {
-		console.warn('Element or scroller not found', scroller, elem);
-		return;
-	}
-
-	const elemRect = elem.getBoundingClientRect();
-	const scrollerRect = scroller.getBoundingClientRect();
-
-	const relativeTop = elemRect.top - scrollerRect.top;
-	const targetScroll = scroller.scrollTop + relativeTop - offset;
-
-	scroller.scrollTo({ top: targetScroll, behavior: 'smooth' });
-}
 
 interface UseArgValBlockKeyboardNavigationConfig {
 	items: ArgValNavigationItem[];
@@ -250,7 +232,7 @@ function TableOfContentsItem({ item, depth = 0 }: TableOfContentsItemProps) {
 								? 'font-semibold'
 								: 'font-medium'
 						)}
-						onClick={() => scrollToItem(item.id)}
+						onClick={() => scrollToReportItem(item.id)}
 					>
 						{item.label}
 					</LinkWithProject>
@@ -308,7 +290,7 @@ function RunReport(props: RunReportProps) {
 	);
 	const navigateToArgValBlock = useCallback(
 		(id: string) => {
-			scrollToItem(id);
+			scrollToReportItem(id);
 			navigate({
 				search: searchParams.toString(),
 				hash: encodeURIComponent(id)
@@ -317,7 +299,7 @@ function RunReport(props: RunReportProps) {
 		[navigate, searchParams]
 	);
 	const navigateToTableOfContents = useCallback(() => {
-		scrollToItem(RUN_REPORT_TABLE_OF_CONTENTS_ID);
+		scrollToReportItem(RUN_REPORT_TABLE_OF_CONTENTS_ID);
 		navigate({
 			search: searchParams.toString(),
 			hash: RUN_REPORT_TABLE_OF_CONTENTS_ID
@@ -338,12 +320,16 @@ function RunReport(props: RunReportProps) {
 		onPairGainColumnsToggle: togglePairGainColumns
 	});
 
-	useMount(() => {
-		setTimeout(() => {
+	useEffect(() => {
+		if (!location.hash) return;
+
+		const animationFrame = requestAnimationFrame(() => {
 			const id = decodeURIComponent(location.hash.slice(1));
-			scrollToItem(id);
-		}, 0);
-	});
+			scrollToReportItem(id);
+		});
+
+		return () => cancelAnimationFrame(animationFrame);
+	}, [location.hash]);
 
 	return (
 		<div className="flex flex-col gap-1 relative">

--- a/libs/bublik/features/sidebar/src/lib/use-sidebar-state-writer.spec.tsx
+++ b/libs/bublik/features/sidebar/src/lib/use-sidebar-state-writer.spec.tsx
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
+import { useEffect } from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SHARED_SIDEBAR_KEYS } from './sidebar-state.constants';
+import { useSidebarStateWriter } from './use-sidebar-state-writer';
+
+const { navigateMock, locationState } = vi.hoisted(() => ({
+	navigateMock: vi.fn(),
+	locationState: { openUnexpected: true }
+}));
+
+vi.mock('react-router-dom', () => ({
+	useLocation: () => ({ state: locationState }),
+	useNavigate: () => navigateMock
+}));
+
+function HookRunner() {
+	const writeSidebarState = useSidebarStateWriter();
+
+	useEffect(() => {
+		writeSidebarState((sidebarState) => {
+			sidebarState[SHARED_SIDEBAR_KEYS.CURRENT_RUN_ID] = '42';
+		});
+	}, [writeSidebarState]);
+
+	return null;
+}
+
+describe('useSidebarStateWriter', () => {
+	beforeEach(() => {
+		navigateMock.mockClear();
+		window.history.replaceState(
+			null,
+			'',
+			'/v2/runs/42/report?config=7#memcached_requests_per_connection%3A1'
+		);
+	});
+
+	it('preserves the report hash without resubmitting the router basename', async () => {
+		render(<HookRunner />);
+
+		await waitFor(() => {
+			expect(navigateMock).toHaveBeenCalledWith(
+				{
+					search: expect.stringMatching(/(^|&)config=7(&|$)/),
+					hash: '#memcached_requests_per_connection%3A1'
+				},
+				{
+					replace: true,
+					state: locationState
+				}
+			);
+		});
+
+		const [{ search }] = navigateMock.mock.calls[0];
+		expect(new URLSearchParams(search).has('_s')).toBe(true);
+	});
+});

--- a/libs/bublik/features/sidebar/src/lib/use-sidebar-state-writer.ts
+++ b/libs/bublik/features/sidebar/src/lib/use-sidebar-state-writer.ts
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2024-2026 OKTET LTD */
 import { useCallback } from 'react';
-import { useLocation, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { updateSidebarStateSearchParams } from './sidebar-url.utils';
 
@@ -22,7 +22,7 @@ type SidebarStateUpdater = Parameters<typeof updateSidebarStateSearchParams>[1];
 export function useSidebarStateWriter(): (
 	updater: SidebarStateUpdater
 ) => void {
-	const [, setSearchParams] = useSearchParams();
+	const navigate = useNavigate();
 	const location = useLocation();
 
 	return useCallback(
@@ -37,11 +37,17 @@ export function useSidebarStateWriter(): (
 				return;
 			}
 
-			setSearchParams(newParams, {
-				replace: true,
-				state: location.state
-			});
+			navigate(
+				{
+					search: newParams.toString(),
+					hash: window.location.hash
+				},
+				{
+					replace: true,
+					state: location.state
+				}
+			);
 		},
-		[location.state, setSearchParams]
+		[location.state, navigate]
 	);
 }


### PR DESCRIPTION
## Summary

Fix report deep links that opened at the top of the page instead of scrolling to the selected graph group.

## Root Cause

- Updating the compressed sidebar state parameter (`_s`) replaced the query string and discarded the current URL hash.
- Report hash navigation ran only once during mounting.
- Progressive rendering initially excluded graph groups beyond the first 10 records, so deep-link targets could be missing from the DOM.

## Changes

- Preserve the current pathname and hash when updating `_s`.
- React to hash changes and scroll to the corresponding report section.
- Render all record shells when navigating to an anchor while keeping heavy chart content lazy-loaded.
- Add regression coverage for encoded anchor IDs, deep records, and hash preservation.
