### PR TITLE
fix(log): retry transient JSON generation failures

### DIFF
--- a/libs/services/bublik-api/src/lib/endpoints/log-endpoint.spec.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/log-endpoint.spec.ts
@@ -1,15 +1,158 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-FileCopyrightText: 2021-2023 OKTET Labs Ltd. */
 import type { BaseQueryApi } from '@reduxjs/toolkit/query';
-import { describe, expect } from 'vitest';
+import { afterEach, describe, expect, vi } from 'vitest';
 
 import type { GetLogJsonInputs, RootBlock } from '@/shared/types';
 
 import {
 	constructJsonUrl,
+	fetchJson,
 	fixPagesCountForAllView,
 	normalizeLogJsonInput
 } from './log-endpoints';
+
+const createResponse = (body: string, status = 200): Response =>
+	new Response(body, {
+		status,
+		statusText: status === 200 ? 'OK' : 'Request failed',
+		headers: { 'Content-Type': 'application/json' }
+	});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+});
+
+describe('fetchJson', () => {
+	test('retries truncated JSON and returns the completed response', async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(createResponse('{"root":'))
+			.mockResolvedValueOnce(createResponse('{"root":[]}'));
+		vi.stubGlobal('fetch', fetchMock);
+
+		const result = fetchJson<{ root: unknown[] }>('/logs/node.json');
+		const expectation = expect(result).resolves.toEqual({ root: [] });
+
+		await vi.runAllTimersAsync();
+		await expectation;
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	test('retries a transient 404 response', async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(createResponse('Not Found', 404))
+			.mockResolvedValueOnce(createResponse('{"root":[]}'));
+		vi.stubGlobal('fetch', fetchMock);
+
+		const result = fetchJson<{ root: unknown[] }>('/logs/node.json');
+		const expectation = expect(result).resolves.toEqual({ root: [] });
+
+		await vi.runAllTimersAsync();
+		await expectation;
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	test('retries a transient fetch failure', async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi
+			.fn()
+			.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+			.mockResolvedValueOnce(createResponse('{"root":[]}'));
+		vi.stubGlobal('fetch', fetchMock);
+
+		const result = fetchJson<{ root: unknown[] }>('/logs/node.json');
+		const expectation = expect(result).resolves.toEqual({ root: [] });
+
+		await vi.runAllTimersAsync();
+		await expectation;
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	test('retries a transient response stream failure', async () => {
+		vi.useFakeTimers();
+		const failedResponse = createResponse('{"root":[]}');
+		vi.spyOn(failedResponse, 'json').mockRejectedValueOnce(
+			new TypeError('NetworkError when attempting to fetch resource')
+		);
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(failedResponse)
+			.mockResolvedValueOnce(createResponse('{"root":[]}'));
+		vi.stubGlobal('fetch', fetchMock);
+
+		const result = fetchJson<{ root: unknown[] }>('/logs/node.json');
+		const expectation = expect(result).resolves.toEqual({ root: [] });
+
+		await vi.runAllTimersAsync();
+		await expectation;
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	test('returns a useful error after parse retries are exhausted', async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi
+			.fn()
+			.mockImplementation(() => Promise.resolve(createResponse('{"root":')));
+		vi.stubGlobal('fetch', fetchMock);
+
+		const result = fetchJson('/logs/node.json').catch((error) => error);
+
+		await vi.runAllTimersAsync();
+		expect(await result).toEqual({
+			status: 503,
+			title: 'Log is not ready',
+			description: 'Log generation did not complete. Please retry in a moment.'
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+
+	test('does not retry a non-transient client error', async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(createResponse('Bad Request', 400));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(fetchJson('/logs/node.json')).rejects.toEqual({
+			status: 400,
+			data: 'Request failed'
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	test('stops retrying when the request is aborted', async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(createResponse('Not Found', 404));
+		vi.stubGlobal('fetch', fetchMock);
+		const controller = new AbortController();
+
+		const result = fetchJson('/logs/node.json', controller.signal);
+		await Promise.resolve();
+		controller.abort();
+
+		await expect(result).rejects.toMatchObject({ name: 'AbortError' });
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	test('does not retry a transport failure after the request is aborted', async () => {
+		const controller = new AbortController();
+		const fetchMock = vi.fn().mockImplementation(() => {
+			controller.abort();
+			return Promise.reject(new TypeError('Failed to fetch'));
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(
+			fetchJson('/logs/node.json', controller.signal)
+		).rejects.toMatchObject({ name: 'AbortError' });
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});
 
 const createLogBlocks = (curPage: number, pagesCount: number): RootBlock => ({
 	version: 'v1',

--- a/libs/services/bublik-api/src/lib/endpoints/log-endpoints.ts
+++ b/libs/services/bublik-api/src/lib/endpoints/log-endpoints.ts
@@ -142,7 +142,44 @@ export const constructJsonUrl = (input: GetLogJsonInputs): string => {
 	return `${PREFIX}/logs/${input.id}/json/?page=${input.page}`;
 };
 
-const fetchJson = async <T = unknown>(
+const LOG_JSON_RETRY_DELAYS_MS = [250, 1000] as const;
+
+const isRetryableLogStatus = (status: number): boolean =>
+	status === 404 ||
+	status === 408 ||
+	status === 425 ||
+	status === 429 ||
+	status >= 500;
+
+const waitForLogRetry = (
+	delay: number,
+	signal?: AbortSignal
+): Promise<void> => {
+	if (signal?.aborted) {
+		return Promise.reject(
+			signal.reason ??
+				new DOMException('The operation was aborted', 'AbortError')
+		);
+	}
+
+	return new Promise((resolve, reject) => {
+		const onAbort = () => {
+			clearTimeout(timeoutId);
+			reject(
+				signal?.reason ??
+					new DOMException('The operation was aborted', 'AbortError')
+			);
+		};
+		const timeoutId = setTimeout(() => {
+			signal?.removeEventListener('abort', onAbort);
+			resolve();
+		}, delay);
+
+		signal?.addEventListener('abort', onAbort, { once: true });
+	});
+};
+
+export const fetchJson = async <T = unknown>(
 	externalUrl: string,
 	signal?: AbortSignal
 ): Promise<T> => {
@@ -157,11 +194,51 @@ const fetchJson = async <T = unknown>(
 		signal
 	};
 
-	const response = await fetch(externalUrl, options);
+	for (let attempt = 0; attempt <= LOG_JSON_RETRY_DELAYS_MS.length; attempt++) {
+		try {
+			const response = await fetch(externalUrl, options);
 
-	if (!response.ok) throw getBublikFromStatusCode(response);
+			if (!response.ok) {
+				const error = getBublikFromStatusCode(response);
+				const retryDelay = LOG_JSON_RETRY_DELAYS_MS[attempt];
 
-	return response.json();
+				if (
+					!isRetryableLogStatus(response.status) ||
+					retryDelay === undefined
+				) {
+					throw error;
+				}
+
+				await waitForLogRetry(retryDelay, signal);
+				continue;
+			}
+
+			return await response.json();
+		} catch (error) {
+			if (signal?.aborted) throw signal.reason ?? error;
+			if (!(error instanceof SyntaxError) && !(error instanceof TypeError)) {
+				throw error;
+			}
+
+			const retryDelay = LOG_JSON_RETRY_DELAYS_MS[attempt];
+			if (retryDelay === undefined) {
+				if (error instanceof TypeError) throw error;
+
+				const generationError: BublikError = {
+					status: 503,
+					title: 'Log is not ready',
+					description:
+						'Log generation did not complete. Please retry in a moment.'
+				};
+
+				throw generationError;
+			}
+
+			await waitForLogRetry(retryDelay, signal);
+		}
+	}
+
+	throw new Error('Log JSON retry loop finished unexpectedly');
 };
 
 export const logEndpoints = {


### PR DESCRIPTION
## Summary

This PR makes the React log viewer tolerate the short interval in which an
on-demand log JSON resource is not yet complete or temporarily unavailable.

The log JSON fetch now performs a bounded retry with abort-aware backoff for:

- JSON parsing failures caused by empty or truncated responses;
- transient connection and response-stream failures;
- HTTP 404, 408, 425, and 429 responses;
- HTTP 5xx responses.

Non-transient client errors are still returned immediately, and changing the
selected test aborts the current request and any pending retry delay.

## Problem

Loading a test log is a two-stage operation:

1. Django returns metadata containing the log-server JSON URL.
2. The React application fetches and parses that URL separately.

The log server generates missing JSON files on demand. Before the accompanying
server fix, the public filename could become visible while the converter was
still writing it. A request could therefore return HTTP 200 with an empty,
truncated, or concurrently corrupted body.

The UI previously called `response.json()` once. If parsing failed, the query
remained in its error state and the selected log panel was empty or unavailable.
Selecting a different test and returning to the original test triggered a new
request after generation had completed, so the same log then appeared normally.

## Why the failure is intermittent

The result depends on timing:

- already-generated logs are served normally;
- small logs may finish before another request reaches the public filename;
- large logs have a wider partial-write window;
- concurrent requests make it more likely that one client reads during that
  window.

This explains why the problem is more common for some tests and difficult to
reproduce in a development environment with cached JSON files.

## Fix

The JSON fetch helper now makes at most three attempts:

1. the initial request;
2. a retry after 250 ms;
3. a retry after 1,000 ms.

Retries stop immediately when the request is aborted. Stable 4xx responses such
as HTTP 400 and non-transport exceptions are not retried. If all parse attempts
fail, the caller receives a clear `Log is not ready` error instead of a raw
`SyntaxError`.
